### PR TITLE
AskFileMessage accept parameter can now take a dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-Nothing unreleased yet.
+### Added
+
+- `AskFileMessage`'s accept parameter can now can take a Dict to allow more fine grained rules. More infos here https://react-dropzone.org/#!/Accepting%20specific%20file%20types.
 
 ## [0.2.109] - 2023-05-31
 

--- a/cypress/e2e/ask_file/main.py
+++ b/cypress/e2e/ask_file/main.py
@@ -3,17 +3,22 @@ import chainlit as cl
 
 @cl.on_chat_start
 def start():
-    file = None
-
-    # Wait for the user to upload a file
-    while file == None:
-        file = cl.AskFileMessage(
-            content="Please upload a text file to begin!", accept=["text/plain"]
-        ).send()
+    txt_file = cl.AskFileMessage(
+        content="Please upload a text file to begin!", accept=["text/plain"]
+    ).send()
     # Decode the file
-    text = file.content.decode("utf-8")
+    text = txt_file.content.decode("utf-8")
 
-    # Let the user know that the system is ready
     cl.Message(
-        content=f"`{file.name}` uploaded, it contains {len(text)} characters!"
+        content=f"`Text file {txt_file.name}` uploaded, it contains {len(text)} characters!"
+    ).send()
+
+    py_file = cl.AskFileMessage(
+        content="Please upload a python file to begin!", accept={"text/plain": [".py"]}
+    ).send()
+    # Decode the file
+    text = py_file.content.decode("utf-8")
+
+    cl.Message(
+        content=f"`Python file {py_file.name}` uploaded, it contains {len(text)} characters!"
     ).send()

--- a/cypress/e2e/ask_file/spec.cy.ts
+++ b/cypress/e2e/ask_file/spec.cy.ts
@@ -7,9 +7,10 @@ describe("Upload file", () => {
     cy.wait(["@settings"]);
   });
 
-  it("should be able to receive and decode the file", () => {
+  it("should be able to receive and decode files", () => {
     cy.get("#upload-button").should("exist");
 
+    // Upload a text file
     cy.fixture("state_of_the_union.txt", "utf-8").as("txtFile");
     cy.get("input[type=file]").selectFile("@txtFile", { force: true });
 
@@ -25,6 +26,14 @@ describe("Upload file", () => {
       );
 
     cy.get("#upload-button").should("exist");
+
+    // Expecting a python file, cpp file upload should be rejected
+    cy.fixture("hello.cpp", "utf-8").as("cppFile");
+    cy.get("input[type=file]").selectFile("@cppFile", { force: true });
+
+    cy.get(".message").should("have.length", 3);
+
+    // Upload a python file
     cy.fixture("hello.py", "utf-8").as("pyFile");
     cy.get("input[type=file]").selectFile("@pyFile", { force: true });
 

--- a/cypress/e2e/ask_file/spec.cy.ts
+++ b/cypress/e2e/ask_file/spec.cy.ts
@@ -10,19 +10,29 @@ describe("Upload file", () => {
   it("should be able to receive and decode the file", () => {
     cy.get("#upload-button").should("exist");
 
-    cy.fixture("state_of_the_union.txt", "utf-8").as("file");
-    cy.get("input[type=file]").selectFile("@file", { force: true });
+    cy.fixture("state_of_the_union.txt", "utf-8").as("txtFile");
+    cy.get("input[type=file]").selectFile("@txtFile", { force: true });
 
     cy.get("#upload-button-loading").should("exist");
 
     cy.get("#upload-button-loading").should("not.exist");
-    cy.get("#upload-button").should("not.exist");
 
-    const messages = cy.get(".message");
-    messages.should("have.length", 2);
-
-    messages
+    cy.get(".message")
       .eq(1)
-      .should("contain", "state_of_the_union.txt uploaded, it contains");
+      .should(
+        "contain",
+        "Text file state_of_the_union.txt uploaded, it contains"
+      );
+
+    cy.get("#upload-button").should("exist");
+    cy.fixture("hello.py", "utf-8").as("pyFile");
+    cy.get("input[type=file]").selectFile("@pyFile", { force: true });
+
+    cy.get(".message")
+      .should("have.length", 4)
+      .eq(3)
+      .should("contain", "Python file hello.py uploaded, it contains");
+
+    cy.get("#upload-button").should("not.exist");
   });
 });

--- a/cypress/fixtures/hello.cpp
+++ b/cypress/fixtures/hello.cpp
@@ -1,0 +1,8 @@
+// Your First C++ Program
+
+#include <iostream>
+
+int main() {
+    std::cout << "Hello World!";
+    return 0;
+}

--- a/cypress/fixtures/hello.py
+++ b/cypress/fixtures/hello.py
@@ -1,0 +1,1 @@
+print("hello world")

--- a/src/chainlit/frontend/src/components/chat/message/uploadButton.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/uploadButton.tsx
@@ -58,9 +58,18 @@ function _UploadButton({ askUser }: Props) {
 
   if (!askUser.spec.accept || !askUser.spec.max_size_mb) return null;
 
-  const dzAccept: Record<string, string[]> = {};
+  let dzAccept: Record<string, string[]> = {};
   const accept = askUser.spec.accept;
-  accept.forEach((a) => (dzAccept[a] = []));
+  if (Array.isArray(accept)) {
+    accept.forEach((a) => {
+      if (typeof a === 'string') {
+        dzAccept[a] = [];
+      }
+    });
+  } else if (typeof accept === 'object') {
+    dzAccept = accept;
+  }
+
   const maxSize = askUser.spec.max_size_mb;
 
   const { getRootProps, getInputProps } = useDropzone({

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -56,7 +56,7 @@ export interface IAsk {
   spec: {
     type: 'text' | 'file';
     timeout: number;
-    accept?: string[];
+    accept?: string[] | Record<string, string[]>;
     max_size_mb?: number;
   };
 }

--- a/src/chainlit/message.py
+++ b/src/chainlit/message.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Dict, Union
 import uuid
 import time
 from abc import ABC, abstractmethod
@@ -335,7 +335,7 @@ class AskFileMessage(AskMessageBase):
 
     Args:
         content (str): Text displayed above the upload button.
-        accept (List[str]): List of mime type to accept like ["text/csv", "application/pdf"]
+        accept (Union[List[str], Dict[str, List[str]]]): List of mime type to accept like ["text/csv", "application/pdf"] or a dict like {"text/plain": [".txt", ".py"]}.
         max_size_mb (int, optional): Maximum file size in MB. Maximum value is 100.
         author (str, optional): The author of the message, this will be used in the UI. Defaults to the chatbot name (see config).
         timeout (int, optional): The number of seconds to wait for an answer before raising a TimeoutError.
@@ -345,7 +345,7 @@ class AskFileMessage(AskMessageBase):
     def __init__(
         self,
         content: str,
-        accept: List[str],
+        accept: Union[List[str], Dict[str, List[str]]],
         max_size_mb=2,
         author=config.chatbot_name,
         timeout=90,

--- a/src/chainlit/types.py
+++ b/src/chainlit/types.py
@@ -1,4 +1,4 @@
-from typing import List, TypedDict, Optional, Literal
+from typing import List, TypedDict, Optional, Literal, Dict, Union
 from pydantic.dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
@@ -21,7 +21,7 @@ class AskSpec:
 class AskFileSpec(AskSpec):
     """Specification for asking the user for a file."""
 
-    accept: List[str]
+    accept: Union[List[str], Dict[str, List[str]]]
     max_size_mb: int
 
 


### PR DESCRIPTION
Right now `AskFileMessage`'s accept parameter takes a list. For instance `["text/plain"]` will generate `{"text/plain": []}` in the UI.
The UI uses react dropzone, here is how it handles file type restrictions: https://react-dropzone.org/#!/Accepting%20specific%20file%20types

This approach is not allowing to filter on specific file types. For instance, if I only want to accept a python file, i need the following accept in react dropzone: `{"text/plain": [".py"]}`.

This PR enables `AskFileMessage`'s accept parameter to either take a list (for simplicity) or a dict for more detailed use cases.