### PR TITLE
perf: disable video on cypress tests by default

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   },
 
   e2e: {
+    video: false,
     supportFile: false,
     defaultCommandTimeout: 10000,
     setupNodeEvents(on, config) {


### PR DESCRIPTION
This speeds up the CI (no video recording + no video compression), we can still enable the video by reverting the flag locally.