### PR TITLE
perf: disable video on cypress tests by default

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   e2e: {
     supportFile: false,
     defaultCommandTimeout: 10000,
+    video: false,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },


### PR DESCRIPTION
This speeds up the CI (no video recording + no video compression), we can still enable the e2e video recording by reverting the flag locally.

Here is the comparison between [this PR run](https://github.com/Chainlit/chainlit/actions/runs/5145900989) and the [previous successful build](https://github.com/Chainlit/chainlit/actions/runs/5143544662) for the "Run tests" task:

- Ubuntu: from 7m 26s to 5m 47s (**1m 49s saved**)
- Windows: from 10m 49s to 9m 7s (**1m 42s saved**)

It's not a big win, but this changes removes some work from the CI so it's still a good thing.