### PR TITLE
avoid premature form submission when using IME

### DIFF
--- a/src/chainlit/frontend/src/components/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/chat/inputBox/input.tsx
@@ -32,6 +32,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
   const askUser = useRecoilValue(askUserState);
   const session = useRecoilValue(sessionState);
   const [value, setValue] = useState('');
+  const [isComposing, setIsComposing] = useState(false);
 
   const socketOk = session?.socket && !session?.error;
   const disabled = !socketOk || loading || askUser?.spec.type === 'file';
@@ -54,11 +55,21 @@ const Input = ({ onSubmit, onReply }: Props) => {
     setValue('');
   }, [value, disabled, setValue, askUser, onSubmit]);
 
+  const handleCompositionStart = () => {
+    setIsComposing(true);
+  };
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false);
+  };
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        submit();
+        if (!isComposing) {
+          e.preventDefault();
+          submit();
+        }
       } else if (e.key === 'ArrowUp') {
         const lineCount = getLineCount(e.currentTarget as HTMLDivElement);
         if (lineCount <= 1) {
@@ -66,7 +77,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
         }
       }
     },
-    [submit, hSetOpen]
+    [submit, hSetOpen, isComposing]
   );
 
   const onHistoryClick = useCallback((content: string) => {
@@ -93,6 +104,8 @@ const Input = ({ onSubmit, onReply }: Props) => {
       disabled={disabled}
       onChange={(e) => setValue(e.target.value)}
       onKeyDown={handleKeyDown}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
       value={value}
       fullWidth
       InputProps={{


### PR DESCRIPTION
### Description

When using an Japanese Input Method Editor (IME), the Enter key is used for finalizing character conversion. This conflicts with pressing the Enter key to submit form, and causes premature form submission and frustration for Japanese users who are in the middle of inputting text.

This PR ensures that the Enter key will only send the message if the user is not in the middle of an IME conversion, which should provide a more intuitive experience for users typing in Japanese.

NOTES: not sure but this might also happen in Chinese and Korean language which use IME.

### Solution

- track whether the user is in the middle of an IME conversion by using the `compositionstart` and `compositionend` events
- modify `handleKeyDown` to only send the message if the Enter key is pressed and the user is not in the middle of an IME conversion.

### Reference

- https://en.wikipedia.org/wiki/Japanese_input_method
- https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionstart_event
- https://developer.mozilla.org/en-US/docs/Web/API/Element/compositionend_event