### PR TITLE
fix importing of os module in chainlit_run

### DIFF
--- a/src/chainlit/cli/__init__.py
+++ b/src/chainlit/cli/__init__.py
@@ -68,6 +68,9 @@ def run_chainlit(target: str, watch=False, headless=False, debug=False):
 @click.option("--host")
 @click.option("--port")
 def chainlit_run(target, watch, headless, debug, ci, host, port):
+
+    import os
+
     if host:
         os.environ["CHAINLIT_HOST"] = host
     if port:
@@ -77,8 +80,6 @@ def chainlit_run(target, watch, headless, debug, ci, host, port):
         config.enable_telemetry = False
 
         # Set the openai api key to a fake value
-        import os
-
         os.environ["OPENAI_API_KEY"] = "sk-FAKE-OPENAI-API-KEY"
 
         # Mock the openai api


### PR DESCRIPTION
Without this change starting the app with a specified port doesn't work.

In particular, running `chainlit run demo.py --port 9000` results in the following error:

```
    os.environ["CHAINLIT_PORT"] = port
    ^^
UnboundLocalError: cannot access local variable 'os' where it is not associated with a value
```