### PR TITLE
fix: text element color when `display=page`

### DIFF
--- a/src/chainlit/frontend/src/components/element/view.tsx
+++ b/src/chainlit/frontend/src/components/element/view.tsx
@@ -48,11 +48,12 @@ const ElementView = () => {
       mx="auto"
       sx={{
         width: '100%',
-        maxWidth: '60rem'
+        maxWidth: '60rem',
+        color: 'text.primary'
       }}
       id="element-view"
     >
-      <Typography color="text.primary" fontWeight={700} fontSize="25px">
+      <Typography fontWeight={700} fontSize="25px">
         {element.name}
       </Typography>
       {renderElement(element)}


### PR DESCRIPTION
- The color is always set outside of the Text element
- In the page, we've added the color definition above the Text element

Screenshot:

<img width="1123" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/a75f349b-9b86-4a5b-a53c-ea1c90065094">
