### PR TITLE
perf: move prism to dynamic import

### DIFF
--- a/cypress/e2e/on_chat_start/main.py
+++ b/cypress/e2e/on_chat_start/main.py
@@ -3,4 +3,16 @@ import chainlit as cl
 
 @cl.on_chat_start
 async def start():
-    await cl.Message(content="Hello!").send()
+    await cl.Message(
+        content="""Hello!
+
+```python
+import chainlit as cl
+
+@cl.on_chat_start
+async def main():
+    await cl.Message(
+        content="Here is a simple message",
+    ).send()
+```"""
+    ).send()

--- a/cypress/e2e/on_chat_start/spec.cy.ts
+++ b/cypress/e2e/on_chat_start/spec.cy.ts
@@ -12,5 +12,6 @@ describe("on_chat_start", () => {
     messages.should("have.length", 1);
 
     messages.eq(0).should("contain.text", "Hello!");
+    messages.eq(0).should("contain.html", "<div class=\"language-python\"");
   });
 });

--- a/src/chainlit/frontend/src/components/Code.tsx
+++ b/src/chainlit/frontend/src/components/Code.tsx
@@ -1,6 +1,6 @@
 import { Box, useTheme } from '@mui/material';
 import { CodeProps } from 'react-markdown/lib/ast-to-react';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
 export default function Code({ inline, children, ...props }: CodeProps) {


### PR DESCRIPTION
- This splits the code highlighting code into a new chunk
- Speeds up initial loading, only loads code highlighting when needed

before

<img width="610" alt="Screenshot 2023-06-15 at 17 37 51" src="https://github.com/Chainlit/chainlit/assets/494686/1fd739d2-0dde-4c0b-a31d-60983e7c8f1d">

after

<img width="609" alt="Screenshot 2023-06-15 at 17 39 13" src="https://github.com/Chainlit/chainlit/assets/494686/2ff22c53-54b8-4334-a0f9-19d2066815df">

todo

- [ ] add a test showing the code highlighting works
