### PR TITLE
fix: changed a parent tag from p to div

### DIFF
--- a/src/chainlit/frontend/src/components/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/content.tsx
@@ -113,6 +113,7 @@ export default memo(function MessageContent({
           fontFamily: 'Inter',
           fontWeight: authorIsUser ? 500 : 300
         }}
+        component="div"
       >
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}


### PR DESCRIPTION
- Prevents warning when messages contain a p, pre or div

### UI test suite, before

<img width="586" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/ec3c1b95-f45e-4d40-a1f4-5210fe717617">

### UI test suite, after (no error anymore)

<img width="609" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/af49a33f-b310-4c74-83d3-8bdeadba35b5">
