### PR TITLE
add cache decorator to be able to iterate with the file watcher more …

### DIFF
--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -17,6 +17,7 @@ from chainlit.element import Image, Text, Pdf, Avatar, Pyplot
 from chainlit.message import Message, ErrorMessage, AskUserMessage, AskFileMessage
 from chainlit.user_session import user_session
 from chainlit.sync import run_sync, make_async
+from chainlit.cache import cache
 
 if LANGCHAIN_INSTALLED:
     from chainlit.lc.callbacks import (
@@ -249,4 +250,5 @@ __all__ = [
     "AsyncChainlitCallbackHandler",
     "run_sync",
     "make_async",
+    "cache",
 ]

--- a/src/chainlit/cache.py
+++ b/src/chainlit/cache.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 from chainlit.config import config
 from chainlit.logger import logger
@@ -20,3 +21,25 @@ def init_lc_cache():
                 logger.info(
                     f"LangChain cache created at: {config.project.lc_cache_path}"
                 )
+
+
+_cache = {}
+_cache_lock = threading.Lock()
+
+
+def cache(func):
+    def wrapper(*args, **kwargs):
+        # Create a cache key based on the function name, arguments, and keyword arguments
+        cache_key = (
+            (func.__name__,) + args + tuple((k, v) for k, v in sorted(kwargs.items()))
+        )
+
+        with _cache_lock:
+            # Check if the result is already in the cache
+            if cache_key not in _cache:
+                # If not, call the function and store the result in the cache
+                _cache[cache_key] = func(*args, **kwargs)
+
+        return _cache[cache_key]
+
+    return wrapper

--- a/src/chainlit/cache.py
+++ b/src/chainlit/cache.py
@@ -13,7 +13,7 @@ def init_lc_cache():
         import langchain
         from langchain.cache import SQLiteCache
 
-        if config.project.lc_cache_path is None:
+        if config.project.lc_cache_path is not None:
             langchain.llm_cache = SQLiteCache(
                 database_path=config.project.lc_cache_path
             )


### PR DESCRIPTION
Typical use case is:

```py
import chainlit as cl


@cl.cache
def load_data():
    import time

    time.sleep(5)
    return 10


data = load_data()


@cl.on_chat_start
async def on_chat_start():
    await cl.Message(content="Hello World!").send()
```

With no cache + file watcher, every change will trigger a reload of the file and we have to wait 5s. With the cache the reload is instant