### PR TITLE
fix commands order to start UI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -93,8 +93,8 @@ Don't forget to revert that change before pushing.
 ### Start the UI
 
 ```sh
-cd src/chainlit/frontend
 npm run buildUi
+cd src/chainlit/frontend
 npm run dev -- --port 5174
 ```
 


### PR DESCRIPTION
There is no `buildUi` script in `/src/chainlit/frontend/package.json` so the commands to start UI in CONTRIBUTING.md will not work. Should run `buildUi` at repo root then cd into frontend folder.