### PR TITLE
feat: add jump to message from the tasklist

### DIFF
--- a/cypress/e2e/global_elements/spec.cy.ts
+++ b/cypress/e2e/global_elements/spec.cy.ts
@@ -14,11 +14,11 @@ describe("Global Elements", () => {
     // Inlined
     cy.get(".message").eq(0).find(".inline-image").should("have.length", 1);
     cy.get(".message").eq(0).find(".element-link").should("have.length", 2);
-    cy.get(".message")
+    cy.get(".message").eq(0).find(".element-link")
       .eq(0)
-      .find(".element-link")
+      .should("contain", "text1");
+    cy.get(".message").eq(0).find(".element-link")
       .eq(0)
-      .should("contain", "text1")
       .click();
 
     // Side

--- a/src/chainlit/frontend/src/components/chat/message/content.spec.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/content.spec.tsx
@@ -3,49 +3,54 @@ import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import MessageContent from './content';
 import { ITextElement } from 'state/element';
+import { RecoilRoot } from 'recoil';
 
 it('renders the message content', () => {
   const { getByText } = render(
-    <MessageContent
-      authorIsUser={false}
-      actions={[]}
-      elements={[]}
-      content="Hello World"
-    />
+    <RecoilRoot>
+      <MessageContent
+        authorIsUser={false}
+        actions={[]}
+        elements={[]}
+        content="Hello World"
+      />
+    </RecoilRoot>
   );
   expect(getByText('Hello World')).toBeInTheDocument();
 });
 
 it('highlights multiple sources correctly (no substring matching)', () => {
   const { getByText } = render(
-    <BrowserRouter>
-      <MessageContent
-        authorIsUser={false}
-        actions={[]}
-        elements={[
-          {
-            name: 'source_1',
-            type: 'text',
-            display: 'side',
-            content: 'source_1'
-          } as ITextElement,
-          {
-            name: 'source_12',
-            display: 'side',
-            type: 'text',
-            content: 'hi'
-          } as ITextElement,
-          {
-            name: 'source_121',
-            display: 'side',
-            type: 'text',
-            content: 'hi'
-          } as ITextElement
-        ]}
-        content={`Hello world
+    <RecoilRoot>
+      <BrowserRouter>
+        <MessageContent
+          authorIsUser={false}
+          actions={[]}
+          elements={[
+            {
+              name: 'source_1',
+              type: 'text',
+              display: 'side',
+              content: 'source_1'
+            } as ITextElement,
+            {
+              name: 'source_12',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement,
+            {
+              name: 'source_121',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement
+          ]}
+          content={`Hello world
         source_121, source_1, source_12`}
-      />
-    </BrowserRouter>
+        />
+      </BrowserRouter>
+    </RecoilRoot>
   );
   expect(getByText('source_1')).toBeInTheDocument();
   expect(getByText('source_12')).toBeInTheDocument();

--- a/src/chainlit/frontend/src/components/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/content.tsx
@@ -1,12 +1,15 @@
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Typography, Link, Stack } from '@mui/material';
+import { Typography, Link, Stack, Box } from '@mui/material';
 import { IElements } from 'state/element';
 import { memo } from 'react';
 import { IAction } from 'state/action';
 import ElementRef from 'components/element/ref';
 import Code from 'components/Code';
 import InlinedElements from './inlined';
+import { useRecoilValue } from 'recoil';
+import { highlightMessage } from 'state/chat';
+import { keyframes } from '@emotion/react';
 
 interface Props {
   id?: string;
@@ -97,7 +100,20 @@ function prepareContent({ id, elements, actions, content, language }: Props) {
   };
 }
 
-export default memo(function MessageContent({
+// Uses yellow[500] with 50% opacity
+const flash = keyframes`
+  from {
+    background-color: transparent;
+  }
+  25% {
+    background-color: rgba(255, 173, 51, 0.5);
+  }
+  to {
+    background-color: transparent;
+  }
+`;
+
+function MessageContent({
   id,
   content,
   elements,
@@ -158,4 +174,45 @@ export default memo(function MessageContent({
       <InlinedElements elements={inlinedElements} actions={scopedActions} />
     </Stack>
   );
-});
+}
+
+export default function Message({
+  id,
+  content,
+  elements,
+  actions,
+  language,
+  authorIsUser
+}: Props) {
+  const highlightedMessage = useRecoilValue(highlightMessage);
+
+  // The content of a message is memoized to avoid re-rendering Markdown
+  const Content = memo(() => (
+    <MessageContent
+      id={id}
+      content={content}
+      elements={elements}
+      actions={actions}
+      language={language}
+      authorIsUser={authorIsUser}
+    />
+  ));
+
+  if (!Content) {
+    return null;
+  }
+
+  // Change the key of the message to force re-rendering when it is highlighted
+  return (
+    <Box
+      id={`message-${id}`}
+      key={`${id}-${highlightedMessage == id}`}
+      sx={{
+        animation:
+          highlightedMessage == id ? `3s ease-in-out 0.1s ${flash}` : 'none'
+      }}
+    >
+      <Content />
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/tasklist/Task.tsx
+++ b/src/chainlit/frontend/src/components/tasklist/Task.tsx
@@ -28,7 +28,6 @@ export const Task = ({ index, task }: { index: number; task: ITask }) => {
         }}
         onClick={() => {
           if (task.forId) {
-            console.log('set', task.forId);
             setHighlightedMessage(task.forId);
             const element = document.getElementById(`message-${task.forId}`);
             if (element) {

--- a/src/chainlit/frontend/src/components/tasklist/Task.tsx
+++ b/src/chainlit/frontend/src/components/tasklist/Task.tsx
@@ -2,12 +2,16 @@ import { Box, ListItem, ListItemButton, useTheme } from '@mui/material';
 import { ITask } from './types';
 import { TaskStatusIcon } from './TaskStatusIcon';
 import { grey } from 'palette';
+import { useSetRecoilState } from 'recoil';
+import { highlightMessage } from 'state/chat';
 
 export const Task = ({ index, task }: { index: number; task: ITask }) => {
+  const setHighlightedMessage = useSetRecoilState(highlightMessage);
   const theme = useTheme();
   return (
     <ListItem disableGutters className={`task task-status-${task.status}`}>
       <ListItemButton
+        disableRipple={!task.forId}
         sx={{
           color:
             {
@@ -19,7 +23,22 @@ export const Task = ({ index, task }: { index: number; task: ITask }) => {
           fontWeight: task.status === 'running' ? '700' : '500',
           alignItems: 'flex-start',
           fontSize: '14px',
-          lineHeight: 1.36
+          lineHeight: 1.36,
+          cursor: task.forId ? 'pointer' : 'default'
+        }}
+        onClick={() => {
+          if (task.forId) {
+            console.log('set', task.forId);
+            setHighlightedMessage(task.forId);
+            const element = document.getElementById(`message-${task.forId}`);
+            if (element) {
+              element.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+                inline: 'start'
+              });
+            }
+          }
         }}
       >
         <Box

--- a/src/chainlit/frontend/src/components/tasklist/types.d.ts
+++ b/src/chainlit/frontend/src/components/tasklist/types.d.ts
@@ -1,6 +1,7 @@
 export interface ITask {
   title: string;
   status: 'ready' | 'running' | 'done' | 'failed';
+  forId?: string;
 }
 
 export interface ITaskList {

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -106,3 +106,10 @@ export const askUserState = atom<IAsk | undefined>({
   key: 'AskUser',
   default: undefined
 });
+
+export const highlightMessage = atom<
+  IMessage['id'] | IMessage['tempId'] | null
+>({
+  key: 'HighlightMessage',
+  default: null
+});

--- a/src/chainlit/server.py
+++ b/src/chainlit/server.py
@@ -123,6 +123,9 @@ async def lifespan(app: FastAPI):
             except asyncio.exceptions.CancelledError:
                 pass
 
+        # Force exit the process to avoid potential AnyIO threads still running
+        os._exit(0)
+
 
 root_dir = os.path.dirname(os.path.abspath(__file__))
 build_dir = os.path.join(root_dir, "frontend/dist")


### PR DESCRIPTION
- Tasks can now have a `forId` property that contains a message `id` or `tempId`
- the chat scrolls to the linked message when clicking on a task
- the linked message is highlighted when clicking on a task
- fixed mime type for the tasklist
- fixed exiting chainlit when using make_async