### PR TITLE
fix: only import the needed lodash submodule

### DIFF
--- a/src/chainlit/frontend/src/components/dataset/filters/SearchBar.tsx
+++ b/src/chainlit/frontend/src/components/dataset/filters/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { useRef } from 'react';
 import { useRecoilState } from 'recoil';
 


### PR DESCRIPTION
- This lowers the js asset size
- And slightly speeds up the build

Before

<img width="922" alt="Screenshot 2023-07-11 at 14 54 42" src="https://github.com/Chainlit/chainlit/assets/494686/395a2c13-cbb2-4ef7-a6b3-41f4e6d05231">

After

<img width="914" alt="Screenshot 2023-07-11 at 14 56 15" src="https://github.com/Chainlit/chainlit/assets/494686/abb64050-e014-4cec-87dd-8f9bdb50eaec">
