### PR TITLE
Proof of Concept - Settings in drawer synchronized with backend

### DIFF
--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -34,6 +34,13 @@ from chainlit.element import (
     TaskStatus,
     Text,
     Video,
+    Checkbox,
+    Radio,
+    Slider,
+    SelectBox,
+    TextInput,
+    NumberInput,
+    Container,
 )
 from chainlit.message import Message, ErrorMessage, AskUserMessage, AskFileMessage
 from chainlit.user_session import user_session
@@ -160,6 +167,14 @@ __all__ = [
     "TaskList",
     "TaskStatus",
     "Video",
+    "File",
+    "Container",
+    "Checkbox",
+    "Radio",
+    "Slider",
+    "SelectBox",
+    "TextInput",
+    "NumberInput",
     "Message",
     "ErrorMessage",
     "AskUserMessage",

--- a/src/chainlit/db/prisma/schema.prisma
+++ b/src/chainlit/db/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Element {
   url            String
   name           String
   display        String
+  drawerWidth    Int
   size           String?
   language       String?
   forIds         String?

--- a/src/chainlit/emitter.py
+++ b/src/chainlit/emitter.py
@@ -130,3 +130,9 @@ class ChainlitEmitter:
         return self.emit(
             "stream_token", {"id": id, "token": token, "isSequence": is_sequence}
         )
+
+    def set_setting(self, key: str or int, value: any):
+        if "settings" not in self.session:
+            self.session["settings"] = {}
+
+        self.session["settings"][key] = value

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -9,7 +9,7 @@
     "test": "jest",
     "preview": "vite preview",
     "lint": "eslint ./src --ext .ts,.tsx",
-    "format": "prettier --config .prettierrc 'src/**/*.{ts,tsx}' --write"
+    "format": "prettier --config .prettierrc src/**/*.{ts,tsx} --write"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.0.1",

--- a/src/chainlit/frontend/src/api/index.ts
+++ b/src/chainlit/frontend/src/api/index.ts
@@ -2,7 +2,7 @@ import { IPageInfo, IPagination } from 'components/dataset/table';
 
 import { IChat, ILLMSettings } from 'state/chat';
 import { IDatasetFilters } from 'state/dataset';
-import { IElement } from 'state/element';
+import { IDisplayElement } from 'state/element';
 import { IMember, Role } from 'state/user';
 
 const devServer = 'http://127.0.0.1:8000';
@@ -134,7 +134,7 @@ export class ChainlitClient {
   getElement = async (
     conversationId: number | string,
     elementId: number | string
-  ): Promise<IElement> => {
+  ): Promise<IDisplayElement> => {
     const res = await fetch(
       `${httpEndpoint}/project/conversation/${conversationId}/element/${elementId}`,
       {

--- a/src/chainlit/frontend/src/components/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/chat/index.tsx
@@ -19,7 +19,7 @@ import {
   messagesState,
   sessionState
 } from 'state/chat';
-import { ITasklistElement, elementState } from 'state/element';
+import { elementState, tasklistState } from 'state/element';
 import { projectSettingsState } from 'state/project';
 
 import InputBox from './inputBox';
@@ -31,6 +31,7 @@ const Chat = () => {
   const askUser = useRecoilValue(askUserState);
   const [messages, setMessages] = useRecoilState(messagesState);
   const elements = useRecoilValue(elementState);
+  const tasklists = useRecoilValue(tasklistState);
   const actions = useRecoilValue(actionState);
   const pSettings = useRecoilValue(projectSettingsState);
   const { persistChatLocally } = useLocalChatHistory();
@@ -80,9 +81,7 @@ const Chat = () => {
     [askUser, user]
   );
 
-  const tasklist = elements.findLast((e) => e.type === 'tasklist') as
-    | ITasklistElement
-    | undefined;
+  const tasklist = tasklists.slice(-1)[0];
 
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>

--- a/src/chainlit/frontend/src/components/chat/message/author.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/author.tsx
@@ -6,7 +6,7 @@ import { Box, Tooltip, Typography } from '@mui/material';
 import AvatarElement from 'components/element/avatar';
 
 import { IMessage } from 'state/chat';
-import { IAvatarElement, elementState } from 'state/element';
+import { avatarState } from 'state/element';
 
 import MessageTime from './time';
 
@@ -19,15 +19,11 @@ export const authorBoxWidth = 70;
 
 export default function Author({ message, show }: Props) {
   const getColorForName = useColorForName();
-  const elements = useRecoilValue(elementState);
-  const avatars = elements.filter((e) => e.type === 'avatar');
+  const avatars = useRecoilValue(avatarState);
   const avatarEl = avatars.find((e) => e.name === message.author);
 
   const avatar = show && avatarEl && (
-    <AvatarElement
-      element={avatarEl as IAvatarElement}
-      author={message.author}
-    />
+    <AvatarElement element={avatarEl} author={message.author} />
   );
 
   const name = show && (

--- a/src/chainlit/frontend/src/components/chat/message/container.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/container.tsx
@@ -4,13 +4,13 @@ import { Box } from '@mui/material';
 
 import { IAction } from 'state/action';
 import { IMessage, INestedMessage } from 'state/chat';
-import { IElements } from 'state/element';
+import { IDisplayElement } from 'state/element';
 
 import Messages from './messages';
 
 interface Props {
   messages: IMessage[];
-  elements: IElements;
+  elements: IDisplayElement[];
   actions: IAction[];
   autoScroll?: boolean;
   setAutoSroll?: (autoScroll: boolean) => void;

--- a/src/chainlit/frontend/src/components/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/content.tsx
@@ -8,14 +8,14 @@ import Code from 'components/Code';
 import ElementRef from 'components/element/ref';
 
 import { IAction } from 'state/action';
-import { IElements } from 'state/element';
+import { IDisplayElement } from 'state/element';
 
 import InlinedElements from './inlined';
 
 interface Props {
   id?: string;
   content?: string;
-  elements: IElements;
+  elements: IDisplayElement[];
   actions: IAction[];
   language?: string;
   authorIsUser?: boolean;
@@ -37,9 +37,7 @@ const isGlobalMatch = (forIds: string[] | undefined) => {
 };
 
 function prepareContent({ id, elements, actions, content, language }: Props) {
-  const elementNames = elements
-    .filter((e) => e.type !== 'avatar')
-    .map((e) => e.name);
+  const elementNames = elements.map((e) => e.name);
 
   // Sort by descending length to avoid matching substrings
   elementNames.sort((a, b) => b.length - a.length);
@@ -56,10 +54,10 @@ function prepareContent({ id, elements, actions, content, language }: Props) {
   });
 
   let preparedContent = content ? content.trim() : '';
-  const inlinedElements: IElements = elements.filter(
+  const inlinedElements = elements.filter(
     (e) => isForIdMatch(id, e?.forIds) && e.display === 'inline'
   );
-  const refElements: IElements = [];
+  const refElements: IDisplayElement[] = [];
 
   if (elementRegexp) {
     preparedContent = preparedContent.replaceAll(elementRegexp, (match) => {

--- a/src/chainlit/frontend/src/components/chat/message/inlined.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/inlined.tsx
@@ -9,10 +9,10 @@ import InlinedTextList from 'components/element/inlined/texts';
 import InlinedVideoList from 'components/element/inlined/videos';
 
 import { IAction } from 'state/action';
-import { AllElements, ElementType, IElements } from 'state/element';
+import { ElementTypes, IDisplayElement } from 'state/element';
 
 interface Props {
-  elements: IElements;
+  elements: IDisplayElement[];
   actions: IAction[];
 }
 
@@ -27,19 +27,19 @@ export default function InlinedElements({ elements, actions }: Props) {
    * and get an array of IImageElement.
    */
   const elementsByType = elements.reduce(
-    (acc, el: AllElements) => {
+    (acc, el: IDisplayElement) => {
       if (!acc[el.type]) {
         acc[el.type] = [];
       }
       const array = acc[el.type] as Extract<
-        AllElements,
+        IDisplayElement,
         { type: typeof el.type }
       >[];
       array.push(el);
       return acc;
     },
     {} as {
-      [K in ElementType]: Extract<AllElements, { type: K }>[];
+      [K in ElementTypes]: Extract<IDisplayElement, { type: K }>[];
     }
   );
 

--- a/src/chainlit/frontend/src/components/chat/message/message.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/message.tsx
@@ -8,7 +8,7 @@ import DetailsButton from 'components/chat/message/detailsButton';
 
 import { IAction } from 'state/action';
 import { INestedMessage, highlightMessage } from 'state/chat';
-import { IElements } from 'state/element';
+import { IDisplayElement } from 'state/element';
 import { settingsState } from 'state/settings';
 
 import Author, { authorBoxWidth } from './author';
@@ -19,7 +19,7 @@ import UploadButton from './uploadButton';
 
 interface Props {
   message: INestedMessage;
-  elements: IElements;
+  elements: IDisplayElement[];
   actions: IAction[];
   indent: number;
   showAvatar?: boolean;

--- a/src/chainlit/frontend/src/components/chat/message/messages.tsx
+++ b/src/chainlit/frontend/src/components/chat/message/messages.tsx
@@ -2,13 +2,13 @@ import { useRecoilValue } from 'recoil';
 
 import { IAction } from 'state/action';
 import { INestedMessage, loadingState } from 'state/chat';
-import { IElements } from 'state/element';
+import { IDisplayElement } from 'state/element';
 
 import Message from './message';
 
 interface Props {
   messages: INestedMessage[];
-  elements: IElements;
+  elements: IDisplayElement[];
   actions: IAction[];
   indent: number;
   isRunning?: boolean;

--- a/src/chainlit/frontend/src/components/element/container.tsx
+++ b/src/chainlit/frontend/src/components/element/container.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material';
+
+import { IContainerElement, IElementContainer } from 'state/element';
+
+import Checkbox from './inputWidget/checkbox';
+import NumberInput from './inputWidget/numberInput';
+import Radio from './inputWidget/radio';
+import SelectBox from './inputWidget/selectBox';
+import Slider from './inputWidget/slider';
+import TextInput from './inputWidget/textInput';
+import { renderElement } from './view';
+
+interface Props {
+  element: IElementContainer;
+}
+
+export default function Container({ element }: Props) {
+  const renderContainerElement = (
+    element: IContainerElement
+  ): JSX.Element | null => {
+    switch (element.type) {
+      case 'checkbox':
+        return <Checkbox element={element} />;
+      case 'radio':
+        return <Radio element={element} />;
+      case 'slider':
+        return <Slider element={element} />;
+      case 'selectbox':
+        return <SelectBox element={element} />;
+      case 'numberinput':
+        return <NumberInput element={element} />;
+      case 'textinput':
+        return <TextInput element={element} />;
+      default:
+        return renderElement(element);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {element.content?.map(renderContainerElement)}
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/checkbox.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/checkbox.tsx
@@ -1,0 +1,40 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { FormControlLabel, Checkbox as MuiCheckbox } from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { ICheckboxElement } from 'state/element';
+
+interface Props {
+  element: ICheckboxElement;
+}
+
+export default function Checkbox({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.initial, setValue] = useRecoilState<boolean>(
+    sessionSettingsFamilyState(element.key)
+  );
+
+  const onCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.checked);
+
+    const setting = {
+      key: event.target.name,
+      value: event.target.checked
+    };
+    session?.socket.emit('settings_change', setting);
+  };
+
+  return (
+    <FormControlLabel
+      control={
+        <MuiCheckbox
+          name={element.key}
+          checked={value}
+          onChange={onCheckboxChange}
+        />
+      }
+      label={element.label}
+    />
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/numberInput.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/numberInput.tsx
@@ -1,0 +1,53 @@
+import { ChangeEvent } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { TextField } from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { INumberInputElement } from 'state/element';
+
+interface Props {
+  element: INumberInputElement;
+}
+
+export default function NumberInput({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.initial, setValue] = useRecoilState<string>(
+    sessionSettingsFamilyState(element.key)
+  );
+  const regex = element.decimal
+    ? /^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$/
+    : /^[0-9]+$/;
+
+  function onNumberInputChanged(
+    event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ): void {
+    if (event.target.value === '' || regex.test(event.target.value)) {
+      setValue(event.target.value);
+
+      const setting = {
+        key: event.target.name,
+        value: parseFloat(event.target.value) ?? ''
+      };
+      session?.socket.emit('settings_change', setting);
+    } else {
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <TextField
+      sx={{ mt: 2, mb: 1 }}
+      name={element.key}
+      label={element.label}
+      value={value}
+      type="text"
+      onChange={onNumberInputChanged}
+      placeholder={element.placeholder}
+      inputProps={{
+        inputMode: 'numeric',
+        pattern: '[0-9]'
+      }}
+    />
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/radio.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/radio.tsx
@@ -1,0 +1,48 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import {
+  Box,
+  FormControlLabel,
+  FormLabel,
+  Radio as MuiRadio,
+  RadioGroup
+} from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { IRadioElement } from 'state/element';
+
+interface Props {
+  element: IRadioElement;
+}
+
+export default function Checkbox({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.options[element.initial_index], setValue] =
+    useRecoilState<string>(sessionSettingsFamilyState(element.key));
+
+  const handleRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+
+    const setting = {
+      key: event.target.name,
+      value: event.target.value
+    };
+    session?.socket.emit('settings_change', setting);
+  };
+
+  return (
+    <Box sx={{ my: 1 }}>
+      <FormLabel>{element.label}</FormLabel>
+      <RadioGroup value={value} name={element.key} onChange={handleRadioChange}>
+        {element.options.map((option, i) => (
+          <FormControlLabel
+            key={i}
+            value={option}
+            control={<MuiRadio />}
+            label={option}
+          />
+        ))}
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/selectBox.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/selectBox.tsx
@@ -1,0 +1,54 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent
+} from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { ISelectBoxElement } from 'state/element';
+
+interface Props {
+  element: ISelectBoxElement;
+}
+
+export default function SelectBox({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.options[element.initial_index], setValue] =
+    useRecoilState<string>(sessionSettingsFamilyState(element.key));
+
+  const handleSelectBoxChange = (event: SelectChangeEvent) => {
+    setValue(event.target.value);
+
+    const setting = {
+      key: event.target.name,
+      value: event.target.value
+    };
+    session?.socket.emit('settings_change', setting);
+  };
+
+  return (
+    <Box sx={{ mt: 2, mb: 1 }}>
+      <FormControl fullWidth>
+        <InputLabel id={element.key + '-label'}>{element.label}</InputLabel>
+        <Select
+          labelId={element.key + '-label'}
+          name={element.key}
+          value={value}
+          label={element.label}
+          onChange={handleSelectBoxChange}
+        >
+          {element.options.map((option, i) => (
+            <MenuItem key={i} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/slider.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/slider.tsx
@@ -1,0 +1,52 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { Box, Slider as MuiSlider, Typography } from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { ISliderElement } from 'state/element';
+
+interface Props {
+  element: ISliderElement;
+}
+
+export default function Slider({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.initial, setValue] = useRecoilState<number>(
+    sessionSettingsFamilyState(element.key)
+  );
+
+  const handleSliderChange = (event: any) => {
+    event = event as Event & { target: { name: string } };
+
+    setValue(event.target.value);
+  };
+
+  const handleSliderChangeCommitted = (
+    event: any,
+    newValue: number | number[]
+  ) => {
+    event = event as Event & { target: { name: string } };
+
+    const setting = {
+      key: event.target.firstElementChild.name,
+      value: newValue
+    };
+    session?.socket.emit('settings_change', setting);
+  };
+
+  return (
+    <Box sx={{ my: 1 }}>
+      <Typography gutterBottom>{element.label}</Typography>
+      <MuiSlider
+        name={element.key}
+        value={value}
+        onChange={handleSliderChange}
+        onChangeCommitted={handleSliderChangeCommitted}
+        min={element.min}
+        max={element.max}
+        step={element.step}
+        valueLabelDisplay="auto"
+      />
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/element/inputWidget/textInput.tsx
+++ b/src/chainlit/frontend/src/components/element/inputWidget/textInput.tsx
@@ -1,0 +1,42 @@
+import { ChangeEvent } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { TextField } from '@mui/material';
+
+import { sessionSettingsFamilyState, sessionState } from 'state/chat';
+import { ITextInputElement } from 'state/element';
+
+interface Props {
+  element: ITextInputElement;
+}
+
+export default function TextInput({ element }: Props) {
+  const session = useRecoilValue(sessionState);
+  const [value = element.initial, setValue] = useRecoilState<string>(
+    sessionSettingsFamilyState(element.key)
+  );
+
+  function onTextInputChanged(
+    event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ): void {
+    setValue(event.target.value);
+
+    const setting = {
+      key: event.target.name,
+      value: event.target.value
+    };
+    session?.socket.emit('settings_change', setting);
+  }
+
+  return (
+    <TextField
+      sx={{ mt: 2, mb: 1 }}
+      name={element.key}
+      label={element.label}
+      value={value}
+      type="input"
+      onChange={onTextInputChanged}
+      placeholder={element.placeholder}
+    />
+  );
+}

--- a/src/chainlit/frontend/src/components/element/ref.tsx
+++ b/src/chainlit/frontend/src/components/element/ref.tsx
@@ -3,10 +3,10 @@ import { useSetRecoilState } from 'recoil';
 
 import { Link } from '@mui/material';
 
-import { IElement, sideViewState } from 'state/element';
+import { IDisplayElement, sideViewState } from 'state/element';
 
 interface Props {
-  element: IElement;
+  element: IDisplayElement;
 }
 
 export default function ElementRef({ element }: Props) {

--- a/src/chainlit/frontend/src/components/element/sideView.tsx
+++ b/src/chainlit/frontend/src/components/element/sideView.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 import { Resizable } from 'react-resizable';
 import { useRecoilState } from 'recoil';
 
@@ -7,6 +7,8 @@ import { Box, BoxProps, IconButton, Stack, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import { renderElement } from 'components/element/view';
+
+import { useWidthCalc } from 'hooks/window';
 
 import { sideViewState } from 'state/element';
 
@@ -79,10 +81,25 @@ const SideView = () => {
   const [sideViewElement, setSideViewElement] = useRecoilState(sideViewState);
   const [resizeInProgress, setResizeInProgress] = useState(false);
   const [drawerWidth, setDrawerWidth] = useState<number>(400);
+  const windowWidth = useWidthCalc();
 
   const handleResize = (event: any, data: { size: { width: number } }) => {
     setDrawerWidth(data.size.width);
   };
+
+  const minWidth = 100;
+  const maxWidth = useMemo(() => {
+    const halfScreenWidth = Math.floor(windowWidth / 2);
+    return halfScreenWidth > minWidth ? halfScreenWidth : minWidth;
+  }, [windowWidth]);
+
+  // Set initial drawerWidth of element when given
+  useEffect(() => {
+    if (!sideViewElement?.drawerWidth) return;
+    setDrawerWidth(
+      Math.min(Math.max(sideViewElement.drawerWidth, minWidth), maxWidth)
+    );
+  }, [windowWidth, sideViewElement]);
 
   const element = useMemo(() => {
     if (sideViewElement) {
@@ -101,8 +118,8 @@ const SideView = () => {
       resizeHandles={['w']}
       handle={<Handle />}
       axis="x"
-      minConstraints={[100, 0]} // Minimum width of 100px and no limit on height.
-      maxConstraints={[1000, 0]} // Maximum width of 1000px and no limit on height.
+      minConstraints={[minWidth, 0]} // Minimum width of 100px and no limit on height.
+      maxConstraints={[maxWidth, 0]} // Maximum width of windowWidth / 2 and no limit on height.
     >
       <Drawer open={!!sideViewElement} width={drawerWidth}>
         <Stack direction="row" alignItems="center">

--- a/src/chainlit/frontend/src/components/element/view.tsx
+++ b/src/chainlit/frontend/src/components/element/view.tsx
@@ -7,38 +7,32 @@ import { Box, Typography } from '@mui/material';
 import { useQuery } from 'hooks/query';
 
 import { clientState } from 'state/client';
-import {
-  IAudioElement,
-  IElement,
-  IFileElement,
-  IImageElement,
-  IPdfElement,
-  ITextElement,
-  IVideoElement,
-  elementState
-} from 'state/element';
+import { IDisplayElement, elementState } from 'state/element';
 
 import AudioElement from './audio';
+import Container from './container';
 import FileElement from './file';
 import ImageElement from './image';
 import PDFElement from './pdf';
 import TextElement from './text';
 import VideoElement from './video';
 
-export const renderElement = (element: IElement): JSX.Element | null => {
+export const renderElement = (element: IDisplayElement): JSX.Element | null => {
   switch (element.type) {
     case 'file':
-      return <FileElement element={element as IFileElement} />;
+      return <FileElement element={element} />;
     case 'image':
-      return <ImageElement element={element as IImageElement} />;
+      return <ImageElement element={element} />;
     case 'text':
-      return <TextElement element={element as ITextElement} />;
+      return <TextElement element={element} />;
     case 'pdf':
-      return <PDFElement element={element as IPdfElement} />;
+      return <PDFElement element={element} />;
     case 'audio':
-      return <AudioElement element={element as IAudioElement} />;
+      return <AudioElement element={element} />;
     case 'video':
-      return <VideoElement element={element as IVideoElement} />;
+      return <VideoElement element={element} />;
+    case 'container':
+      return <Container element={element} />;
     default:
       return null;
   }
@@ -49,7 +43,7 @@ const ElementView = () => {
   const query = useQuery();
   const elements = useRecoilValue(elementState);
   const client = useRecoilValue(clientState);
-  const [element, setElement] = useState<IElement | null>(null);
+  const [element, setElement] = useState<IDisplayElement | null>(null);
   const [error, setError] = useState<string | undefined>();
 
   const conversationId = query.get('conversation');

--- a/src/chainlit/frontend/src/components/socket.tsx
+++ b/src/chainlit/frontend/src/components/socket.tsx
@@ -16,7 +16,12 @@ import {
   sessionState,
   tokenCountState
 } from 'state/chat';
-import { IElement, elementState } from 'state/element';
+import {
+  IElement,
+  avatarState,
+  elementState,
+  tasklistState
+} from 'state/element';
 import { projectSettingsState } from 'state/project';
 import { userEnvState } from 'state/user';
 
@@ -36,6 +41,8 @@ export default memo(function Socket() {
   const setTokenCount = useSetRecoilState(tokenCountState);
   const setAskUser = useSetRecoilState(askUserState);
   const setElements = useSetRecoilState(elementState);
+  const setAvatars = useSetRecoilState(avatarState);
+  const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
 
   useEffect(() => {
@@ -167,7 +174,13 @@ export default memo(function Socket() {
     });
 
     socket.on('element', (element: IElement) => {
-      setElements((old) => [...old, element]);
+      if (element.type === 'avatar') {
+        setAvatars((old) => [...old, element]);
+      } else if (element.type === 'tasklist') {
+        setTasklists((old) => [...old, element]);
+      } else {
+        setElements((old) => [...old, element]);
+      }
     });
 
     socket.on(

--- a/src/chainlit/frontend/src/hooks/clearChat.ts
+++ b/src/chainlit/frontend/src/hooks/clearChat.ts
@@ -2,11 +2,18 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { actionState } from 'state/action';
 import { messagesState, sessionState, tokenCountState } from 'state/chat';
-import { elementState, sideViewState } from 'state/element';
+import {
+  avatarState,
+  elementState,
+  sideViewState,
+  tasklistState
+} from 'state/element';
 
 export default function useClearChat() {
   const setMessages = useSetRecoilState(messagesState);
   const setElements = useSetRecoilState(elementState);
+  const setAvatars = useSetRecoilState(avatarState);
+  const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
   const setSideView = useSetRecoilState(sideViewState);
   const setTokenCount = useSetRecoilState(tokenCountState);
@@ -17,8 +24,12 @@ export default function useClearChat() {
     session?.socket.connect();
     setMessages([]);
     setElements([]);
+    setAvatars([]);
+    setTasklists([]);
     setActions([]);
     setSideView(undefined);
     setTokenCount(0);
+
+    // TODO: How do we reset settings? How do we handle this since we used atomFamily()?
   };
 }

--- a/src/chainlit/frontend/src/hooks/window.ts
+++ b/src/chainlit/frontend/src/hooks/window.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react';
+
+export const useWidthCalc = () => {
+  const width = useSyncExternalStore(
+    (listener) => {
+      window.addEventListener('resize', listener);
+
+      return () => {
+        window.removeEventListener('resize', listener);
+      };
+    },
+    () => window.innerWidth
+  );
+
+  return width;
+};

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -1,7 +1,7 @@
-import { atom } from 'recoil';
+import { SerializableParam, atom, atomFamily } from 'recoil';
 import { Socket } from 'socket.io-client';
 
-import { IElement } from './element';
+import { IDisplayElement } from './element';
 import { IMember } from './user';
 
 export interface ILLMSettings {
@@ -19,7 +19,7 @@ export interface IChat {
   createdAt: number | string;
   author?: IMember;
   messages: IMessage[];
-  elements: IElement[];
+  elements: IDisplayElement[];
 }
 
 export interface IMessage {
@@ -114,4 +114,9 @@ export const highlightMessage = atom<
 >({
   key: 'HighlightMessage',
   default: null
+});
+
+export const sessionSettingsFamilyState = atomFamily<any, SerializableParam>({
+  key: 'SessionSettings',
+  default: undefined
 });

--- a/src/chainlit/frontend/src/state/element.ts
+++ b/src/chainlit/frontend/src/state/element.ts
@@ -1,16 +1,6 @@
 import { atom } from 'recoil';
 
-export type ElementType =
-  | 'image'
-  | 'text'
-  | 'pdf'
-  | 'avatar'
-  | 'tasklist'
-  | 'audio'
-  | 'video'
-  | 'file';
-
-export type AllElements =
+export type IElement =
   | IImageElement
   | ITextElement
   | IPdfElement
@@ -18,71 +8,159 @@ export type AllElements =
   | ITasklistElement
   | IAudioElement
   | IVideoElement
-  | IFileElement;
+  | IFileElement
+  | IElementContainer;
+
+export type IDisplayElement =
+  | IImageElement
+  | ITextElement
+  | IPdfElement
+  | IAudioElement
+  | IVideoElement
+  | IFileElement
+  | IElementContainer;
+
+export type IContainerElement =
+  | IDisplayElement
+  | ICheckboxElement
+  | IRadioElement
+  | ISelectBoxElement
+  | ISliderElement
+  | ITextInputElement
+  | INumberInputElement;
+
+export type ElementTypes = IElement['type'];
 
 export type IElementSize = 'small' | 'medium' | 'large';
 
-export interface IElement {
+interface IElementBase<T> {
+  type: T;
+}
+
+interface IContentElementBase<T> extends IElementBase<T> {
   id?: number;
   conversationId?: number;
   tempId?: string;
-  url?: string;
-  type: ElementType;
   name: string;
-  display: 'inline' | 'side' | 'page';
   forIds?: string[];
 }
 
-export interface IImageElement extends IElement {
-  type: 'image';
+interface IDisplayContentElementBase<T> extends IContentElementBase<T> {
+  display: 'inline' | 'side' | 'page';
+  drawerWidth: number;
+}
+
+export interface IImageElement extends IDisplayContentElementBase<'image'> {
+  url?: string;
   content?: ArrayBuffer;
   size?: IElementSize;
 }
 
-export interface IAvatarElement extends IElement {
-  type: 'avatar';
+export interface IAvatarElement extends IContentElementBase<'avatar'> {
+  url?: string;
   content?: ArrayBuffer;
 }
 
-export interface ITextElement extends IElement {
-  type: 'text';
+export interface ITextElement extends IDisplayContentElementBase<'text'> {
+  url?: string;
   content?: string;
   language?: string;
-}
-export interface IPdfElement extends IElement {
-  type: 'pdf';
-  content?: string;
+  drawerWidth: number;
 }
 
-export interface IAudioElement extends IElement {
-  type: 'audio';
+export interface IPdfElement extends IDisplayContentElementBase<'pdf'> {
+  url?: string;
+  content?: string;
+  drawerWidth: number;
+}
+
+export interface IAudioElement extends IDisplayContentElementBase<'audio'> {
+  url?: string;
   content?: ArrayBuffer;
 }
 
-export interface IVideoElement extends IElement {
-  type: 'video';
+export interface IVideoElement extends IDisplayContentElementBase<'video'> {
+  url?: string;
   content?: ArrayBuffer;
   size?: IElementSize;
 }
 
-export interface IFileElement extends IElement {
-  type: 'file';
+export interface IFileElement extends IDisplayContentElementBase<'file'> {
+  url?: string;
   content?: ArrayBuffer;
 }
 
-export interface ITasklistElement extends IElement {
-  type: 'tasklist';
+export interface ITasklistElement extends IContentElementBase<'tasklist'> {
   content?: string;
 }
 
-export type IElements = IElement[];
+export interface IElementContainer
+  extends IDisplayContentElementBase<'container'> {
+  content?: IContainerElement[];
+  drawerWidth: number;
+}
 
-export const elementState = atom<IElements>({
+export interface ICheckboxElement extends IElementBase<'checkbox'> {
+  key: string;
+  label: string;
+  initial: boolean;
+}
+
+export interface IRadioElement extends IElementBase<'radio'> {
+  key: string;
+  label: string;
+  options: string[];
+  initial_index: number;
+}
+
+export interface ISelectBoxElement extends IElementBase<'selectbox'> {
+  key: string;
+  label: string;
+  options: string[];
+  initial_index: number;
+}
+
+export interface ISliderElement extends IElementBase<'slider'> {
+  key: string;
+  label: string;
+  initial: number;
+  min: number;
+  max: number;
+  step: number;
+}
+
+export interface ITextInputElement extends IElementBase<'textinput'> {
+  key: string;
+  label: string;
+  initial: string;
+  placeholder: string;
+  max_chars: string;
+}
+
+export interface INumberInputElement extends IElementBase<'numberinput'> {
+  key: string;
+  label: string;
+  initial: number;
+  placeholder: string;
+  decimal: boolean;
+}
+
+export const elementState = atom<IDisplayElement[]>({
   key: 'Elements',
   default: []
 });
 
-export const sideViewState = atom<IElement | undefined>({
+export const avatarState = atom<IAvatarElement[]>({
+  key: 'AvatarElements',
+  default: []
+});
+
+export const tasklistState = atom<ITasklistElement[]>({
+  key: 'TasklistElements',
+  default: []
+});
+
+export const sideViewState = atom<IDisplayElement | undefined>({
   key: 'SideView',
   default: undefined
 });

--- a/src/chainlit/hello.py
+++ b/src/chainlit/hello.py
@@ -1,12 +1,57 @@
 # This is a simple example of a chainlit app.
 
-from chainlit import AskUserMessage, Message, on_chat_start
+import chainlit as cl
 
 
-@on_chat_start
+@cl.on_chat_start
 async def main():
-    res = await AskUserMessage(content="What is your name?", timeout=30).send()
+    elements = [
+        cl.Container(
+            content=[
+                cl.TextInput(key="FirstName", label="First Name"),
+                cl.TextInput(key="LastName", label="Last Name"),
+                cl.NumberInput(key="Age", label="Age"),
+                cl.Radio(
+                    key="Gender",
+                    label="Gender",
+                    options=["Male", "Female", "Other"],
+                    initial_index=0,
+                ),
+                cl.SelectBox(
+                    key="Country",
+                    label="Country",
+                    options=["US", "UK", "France", "Belgium", "Other"],
+                    initial_index=2,
+                ),
+                cl.TextInput(key="Feedback", label="Feedback"),
+                cl.Checkbox(key="Love", label="Are you loving chainlit?"),
+                cl.Slider(
+                    key="Score", label="How much?", initial=5, min=0, max=10, step=1
+                ),
+            ],
+            name="feedback",
+            display="side",
+        ),
+    ]
+
+    res = await cl.Message(
+        content="How are you liking chainlit? feedback", elements=elements
+    ).send()
+    res = await cl.AskUserMessage(
+        content="Send something after filling in the feedback?", timeout=30
+    ).send()
+
     if res:
-        await Message(
-            content=f"Your name is: {res['content']}.\nChainlit installation is working!\nYou can now start building your own chainlit apps!",
+        settings = cl.user_session.get("settings")
+        await cl.Message(
+            content=f"Thank you for providing feedback {settings['FirstName']} {settings['LastName']}"
         ).send()
+        await cl.Message(
+            content=f"Your information:\nAge: {settings['FirstName']}, Gender: {settings['Gender']}, Country: {settings['Country']}"
+        ).send()
+        await cl.Message(
+            content=f"Feedback: {settings['Feedback']}\nScore: {settings['Score']}"
+        ).send()
+
+        if settings["Love"]:
+            await cl.Message(content=f"I'm glad that you are enjoying chainlit!").send()

--- a/src/chainlit/server.py
+++ b/src/chainlit/server.py
@@ -547,3 +547,21 @@ async def call_action(sid, action):
     action = Action(**action)
 
     await process_action(action)
+
+
+@socket.on("settings_change")
+async def change_settings(sid, setting):
+    """Handle an action call from the UI."""
+    session = need_session(sid)
+
+    print(setting)
+
+    key = setting["key"]
+    value = setting["value"]
+
+    if "settings" not in session:
+        session["settings"] = {}
+
+    session["settings"][key] = value
+
+    print(session["settings"])

--- a/src/chainlit/types.py
+++ b/src/chainlit/types.py
@@ -4,7 +4,21 @@ from pydantic.dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
 ElementType = Literal[
-    "image", "avatar", "text", "pdf", "tasklist", "audio", "video", "file"
+    "image",
+    "avatar",
+    "text",
+    "pdf",
+    "tasklist",
+    "audio",
+    "video",
+    "file",
+    "settings",
+    "checkbox",
+    "radio",
+    "slider",
+    "selectbox",
+    "textinput",
+    "numberinput",
 ]
 ElementDisplay = Literal["inline", "side", "page"]
 ElementSize = Literal["small", "medium", "large"]

--- a/src/chainlit/user_session.py
+++ b/src/chainlit/user_session.py
@@ -27,6 +27,8 @@ class UserSession:
         user_session["user_infos"] = emitter.session["auth_client"].user_infos
         if "agent" in emitter.session:
             user_session["agent"] = emitter.session["agent"]
+        if "settings" in emitter.session:
+            user_session["settings"] = emitter.session["settings"]
 
         return user_session.get(key)
 


### PR DESCRIPTION
I really like chainlit and it's simplicity to create LLM applications. However I've found it a bit lacking when you want to have more control as a user. The AskUser method makes it a bit difficult to put constraints on what the user can input and may be confusing.

That's why I've tried to create a new element that can contain other elements, right now I've implemented Checkbox, Radio Buttons, SelectBox, Slider, TextInput and NumberInput. This makes it possible to do stuff like this (See hello.py in the PR):

![image](https://github.com/Chainlit/chainlit/assets/10130747/baf057e3-8b2b-4224-9ee8-87215e92e899)

Right now you need to use scoped elements to open the drawer but you could add extra functionality where the Agent is able to open the settings drawer and wait for user input. You would also be able to expose LLM settings like 'temperature', 'frequency_penalty', what model you are using, etc.

At first I wasn't planning on creating a PR since I was just tinkering in the code base so I haven't implemented any tests and I'm sure there are still some bugs that need to be fixed (also my first time really programming in python, any feedback welcome). Depending on your feedback and help I'm willing to create smaller PR's so that Chainlit can natively support this.

Let me know what you think!

Kind Regards,
Mathias