### PR TITLE
Wd/message update

### DIFF
--- a/cypress/e2e/update_message/main.py
+++ b/cypress/e2e/update_message/main.py
@@ -6,4 +6,5 @@ async def main():
     msg = cl.Message(content="Hello!")
     await msg.send()
     await cl.sleep(2)
-    await msg.update(content="Hello again!")
+    msg.content = "Hello again!"
+    await msg.update()

--- a/src/chainlit/action.py
+++ b/src/chainlit/action.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic.dataclasses import dataclass
 from dataclasses_json import dataclass_json
 
@@ -17,7 +19,7 @@ class Action:
     # The description of the action. This is what the user will see when they hover the action.
     description: str = ""
     # This should not be set manually, only used internally.
-    forId: str = None
+    forId: Optional[str] = None
 
     def __post_init__(self) -> None:
         trace_event(f"init {self.__class__.__name__}")

--- a/src/chainlit/element.py
+++ b/src/chainlit/element.py
@@ -103,7 +103,7 @@ class Element:
 
         await self.preprocess_content()
 
-        if for_id:
+        if for_id and for_id not in self.for_ids:
             self.for_ids.append(for_id)
 
         # We have a client, persist the element

--- a/src/chainlit/message.py
+++ b/src/chainlit/message.py
@@ -204,10 +204,10 @@ class Message(MessageBase):
 
         actions_to_update = [action for action in self.actions if action.forId is None]
 
-        action_coros = [action.send(for_id=str(id)) for action in actions_to_update]
-        await asyncio.gather(*action_coros)
-
         elements_to_update = [el for el in self.elements if id not in el.for_ids]
+
+        for action in actions_to_update:
+            await action.send(for_id=str(id))
 
         for element in elements_to_update:
             await element.send(for_id=str(id))

--- a/src/chainlit/message.py
+++ b/src/chainlit/message.py
@@ -52,27 +52,11 @@ class MessageBase(ABC):
 
     async def update(
         self,
-        author: str = None,
-        content: str = None,
-        language: str = None,
-        prompt: str = None,
-        llm_settings: LLMSettings = None,
     ):
         """
         Update a message already sent to the UI.
         """
         trace_event("update_message")
-
-        if author:
-            self.author = author
-        if content:
-            self.content = content
-        if language:
-            self.language = language
-        if prompt:
-            self.prompt = prompt
-        if llm_settings:
-            self.llmSettings = llm_settings
 
         msg_dict = self.to_dict()
 
@@ -206,6 +190,28 @@ class Message(MessageBase):
         await asyncio.gather(*all_coros)
 
         return id
+
+    async def update(self):
+        """
+        Send the message to the UI and persist it in the cloud if a project ID is configured.
+        Return the ID of the message.
+        """
+        trace_event("send_message")
+        await super().update()
+
+        id = self.id or self.temp_id
+
+        actions_to_update = [action for action in self.actions if action.forId is None]
+
+        action_coros = [action.send(for_id=str(id)) for action in actions_to_update]
+        await asyncio.gather(*action_coros)
+
+        elements_to_update = [el for el in self.elements if id not in el.for_ids]
+
+        for element in elements_to_update:
+            await element.send(for_id=str(id))
+
+        return True
 
 
 class ErrorMessage(MessageBase):


### PR DESCRIPTION
the update method was badly designed, non exhaustively repeating the arguments on the Message class.

Now one can update the message instance (including actions and elements) and then  call `.update()`.