### PR TITLE
Move model settings to drawer

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/playground/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/playground/index.tsx
@@ -9,12 +9,22 @@ import { OrderedSet } from 'immutable';
 import { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useToggle } from 'usehooks-ts';
 
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 import HelpIcon from '@mui/icons-material/HelpOutline';
 import RestoreIcon from '@mui/icons-material/Restore';
+import SettingsIcon from '@mui/icons-material/Settings';
 import LoadingButton from '@mui/lab/LoadingButton';
-import { Box, IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import {
+  Box,
+  Drawer,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography
+} from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -41,8 +51,10 @@ export default function Playground() {
   const settings = useRecoilValue(playgroundSettingsState);
   const userEnv = useRecoilValue(userEnvState);
   const setPlaygroundSettings = useSetRecoilState(playgroundSettingsState);
+
   const [state, setState] = useState(EditorState.createEmpty());
   const [loading, setLoading] = useState(false);
+  const [isDrawerOpen, toggleDrawer] = useToggle(false);
 
   useEffect(() => {
     if (playground?.prompt) {
@@ -134,21 +146,22 @@ export default function Playground() {
             <HelpIcon />
           </Tooltip>
         </IconButton>
-        <IconButton
-          edge="end"
-          id="close-playground"
-          sx={{ ml: 'auto' }}
-          onClick={handleClose}
-        >
-          <CloseIcon />
-        </IconButton>
+        <Box sx={{ ml: 'auto' }}>
+          <IconButton
+            aria-label="open drawer"
+            edge="end"
+            onClick={toggleDrawer}
+            sx={{ mr: '4px' }}
+          >
+            <SettingsIcon />
+          </IconButton>
+          <IconButton edge="end" id="close-playground" onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </Box>
       </DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column' }}>
-        <Stack
-          direction="row"
-          spacing={2}
-          sx={{ overflowY: 'auto', overflowX: 'hidden', flexGrow: 1 }}
-        >
+      <DialogContent>
+        <Stack direction="row" alignItems="flex-start">
           <Box
             sx={{
               fontFamily: 'Inter',
@@ -160,7 +173,8 @@ export default function Playground() {
               overflowY: 'auto',
               width: '100%',
               flexGrow: 1,
-              caretColor: (theme) => theme.palette.text.primary
+              caretColor: (theme) => theme.palette.text.primary,
+              height: '80vh'
             }}
           >
             <Editor
@@ -169,7 +183,32 @@ export default function Playground() {
               onChange={setState}
             />
           </Box>
-          <ModelSettings />
+          <Drawer
+            sx={{
+              '& .MuiDrawer-paper': {
+                alignItems: 'center',
+                width: '300px'
+              }
+            }}
+            variant="persistent"
+            anchor="right"
+            open={isDrawerOpen}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                width: '100%',
+                paddingRight: '30px',
+                paddingTop: '10px'
+              }}
+            >
+              <IconButton onClick={toggleDrawer}>
+                <ChevronRightIcon />
+              </IconButton>
+            </Box>
+            <ModelSettings />
+          </Drawer>
         </Stack>
         <Stack direction="row" alignItems="center" mt={1} spacing={2}>
           <LoadingButton

--- a/src/chainlit/frontend/src/components/organisms/playground/modelSettings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/playground/modelSettings.tsx
@@ -130,7 +130,7 @@ const ModelSettings = () => {
   );
 
   return (
-    <Stack spacing={2} sx={{ width: '250px' }}>
+    <Stack spacing={2} sx={{ maxWidth: '250px' }}>
       {modelSelect}
       {temperature}
       {stopSequences}


### PR DESCRIPTION
Purpose of this PR is to place the model settings container into a drawer. Since it's useless to have it fixed, it will help to be more responsive. I have also reduced the text area height to fit to the user screen and show the submit button on first render.

https://github.com/Chainlit/chainlit/assets/18298759/4ff92d2a-71c5-4e3d-b501-c60add1db64d

