### PR TITLE
ensure telemetry is NEVER called when disabled

### DIFF
--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -58,7 +58,7 @@ export async function runTest(test: string) {
           kill(childProcess.pid, "SIGKILL", function (err) {
             if (err) {
               console.log("Error while trying to kill process");
-              reject(err);
+              resolve(true);
             } else {
               console.log("Process killed successfully");
               resolve(true);

--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -156,6 +156,7 @@ __all__ = [
     "Text",
     "Avatar",
     "Pyplot",
+    "File",
     "Task",
     "TaskList",
     "TaskStatus",

--- a/src/chainlit/element.py
+++ b/src/chainlit/element.py
@@ -1,5 +1,4 @@
 from pydantic.dataclasses import dataclass, Field
-from dataclasses_json import dataclass_json
 from typing import Dict, List, Union, Any
 import uuid
 import aiofiles

--- a/src/chainlit/telemetry.py
+++ b/src/chainlit/telemetry.py
@@ -66,7 +66,7 @@ class ChainlitTelemetry:
         uptrace.configure_opentelemetry(
             dsn="https://YPa4AbDF853uCW6UWN2oYg@api.uptrace.dev/1778",
             service_name="chainlit",
-            service_version="1.0.0",
+            service_version="1.1.0",
             deployment_environment="production",
             logging_level=logging.CRITICAL,
         )

--- a/src/chainlit/telemetry.py
+++ b/src/chainlit/telemetry.py
@@ -1,66 +1,95 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.resources import Attributes, Resource
+    from opentelemetry.trace import Tracer
+
 import uptrace
 import hashlib
 from socket import gethostname
-from opentelemetry.sdk.resources import Attributes, Resource
-from opentelemetry import trace as ot_trace
-from opentelemetry.exporter.otlp.proto.grpc.exporter import logger as exporter_logger
 from functools import wraps
 from chainlit.config import config
 from chainlit.version import __version__
 import logging
 
 
-# Patch uptrace.py to hash the hostname to avoid leaking it.
-def _build_resource(
-    resource: Resource,
-    resource_attributes: Attributes,
-    service_name: str,
-    service_version: str,
-    deployment_environment: str,
-) -> Resource:
-    if resource:
-        return resource
+class ChainlitTelemetry:
+    def __init__(self):
+        self._tracer = None
 
-    # If we are in production, use the URL as hostname
-    if config.chainlit_prod_url:
-        host_name = config.chainlit_prod_url
-    # Hash the local hostname to avoid leaking it.
-    else:
-        host_name = gethostname()
-        host_name = hashlib.sha256(host_name.encode("UTF-8")).hexdigest()
+    # Patch uptrace.py to hash the hostname to avoid leaking it.
+    @staticmethod
+    def _build_resource(
+        resource: "Resource",
+        resource_attributes: "Attributes",
+        service_name: str,
+        service_version: str,
+        deployment_environment: str,
+    ) -> "Resource":
+        from opentelemetry.sdk.resources import Resource
 
-    attrs = {"host.name": host_name}
+        if resource:
+            return resource
 
-    if resource_attributes:
-        attrs.update(resource_attributes)
-    if service_name:
-        attrs["service.name"] = service_name
-    if service_version:
-        attrs["service.version"] = service_version
-    if deployment_environment:
-        attrs["deployment.environment"] = deployment_environment
+        # If we are in production, use the URL as hostname
+        if config.chainlit_prod_url:
+            host_name = config.chainlit_prod_url
+        # Hash the local hostname to avoid leaking it.
+        else:
+            host_name = gethostname()
+            host_name = hashlib.sha256(host_name.encode("UTF-8")).hexdigest()
 
-    return Resource.create(attrs)
+        attrs = {"host.name": host_name}
+
+        if resource_attributes:
+            attrs.update(resource_attributes)
+        if service_name:
+            attrs["service.name"] = service_name
+        if service_version:
+            attrs["service.version"] = service_version
+        if deployment_environment:
+            attrs["deployment.environment"] = deployment_environment
+
+        return Resource.create(attrs)
+
+    def configure_tracer(self):
+        from opentelemetry.exporter.otlp.proto.grpc.exporter import (
+            logger as exporter_logger,
+        )
+        from opentelemetry.trace import get_tracer
+
+        if self._tracer:
+            return self._tracer
+
+        uptrace.uptrace._build_resource = self._build_resource
+
+        uptrace.configure_opentelemetry(
+            dsn="https://YPa4AbDF853uCW6UWN2oYg@api.uptrace.dev/1778",
+            service_name="chainlit",
+            service_version="1.0.0",
+            deployment_environment="production",
+            logging_level=logging.CRITICAL,
+        )
+
+        exporter_logger.setLevel(logging.CRITICAL)
+
+        tracer = get_tracer("chainlit", __version__)
+        return tracer
+
+    @property
+    def tracer(self) -> "Tracer":
+        if self._tracer is None:
+            self._tracer = self.configure_tracer()
+
+        return self._tracer
 
 
-uptrace.uptrace._build_resource = _build_resource
-
-uptrace.configure_opentelemetry(
-    dsn="https://YPa4AbDF853uCW6UWN2oYg@api.uptrace.dev/1778",
-    service_name="chainlit",
-    service_version="1.0.0",
-    deployment_environment="production",
-    logging_level=logging.CRITICAL,
-)
-
-exporter_logger.setLevel(logging.CRITICAL)
-
-tracer = ot_trace.get_tracer("chainlit", __version__)
+chainlit_telemetry = ChainlitTelemetry()
 
 
 def trace_event(event_name):
     if config.project.enable_telemetry:
-        with tracer.start_as_current_span(
+        with chainlit_telemetry.tracer.start_as_current_span(
             event_name, record_exception=False, set_status_on_exception=False
         ):
             return
@@ -69,9 +98,9 @@ def trace_event(event_name):
 def trace(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        event_name = func.__name__
         if config.project.enable_telemetry:
-            with tracer.start_as_current_span(
+            event_name = func.__name__
+            with chainlit_telemetry.tracer.start_as_current_span(
                 event_name, record_exception=False, set_status_on_exception=False
             ):
                 return func(*args, **kwargs)


### PR DESCRIPTION
It looks like just initialising the telemetry object was causing networks ops, which is causing issues for users using secured enterprise network (uptrace is not allowed there). 