### PR TITLE
Fix for element names containing regex characters

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/message/content.spec.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/content.spec.tsx
@@ -22,7 +22,7 @@ it('renders the message content', () => {
 });
 
 it('highlights multiple sources correctly (no substring matching)', () => {
-  const { getByText } = render(
+  const { getByRole } = render(
     <RecoilRoot>
       <BrowserRouter>
         <MessageContent
@@ -54,7 +54,44 @@ it('highlights multiple sources correctly (no substring matching)', () => {
       </BrowserRouter>
     </RecoilRoot>
   );
-  expect(getByText('source_1')).toBeInTheDocument();
-  expect(getByText('source_12')).toBeInTheDocument();
-  expect(getByText('source_121')).toBeInTheDocument();
+  expect(getByRole('link', { name: 'source_1' })).toBeInTheDocument();
+  expect(getByRole('link', { name: 'source_12' })).toBeInTheDocument();
+  expect(getByRole('link', { name: 'source_121' })).toBeInTheDocument();
+});
+
+it('highlights sources containing regex characters correctly', () => {
+  const { getByRole } = render(
+    <RecoilRoot>
+      <BrowserRouter>
+        <MessageContent
+          authorIsUser={false}
+          actions={[]}
+          elements={[
+            {
+              name: 'Document[1]',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement,
+            {
+              name: 'source(12)',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement,
+            {
+              name: 'page{12}',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement
+          ]}
+          content={`Hello world: Document[1], source(12), page{12}`}
+        />
+      </BrowserRouter>
+    </RecoilRoot>
+  );
+  expect(getByRole('link', { name: 'Document[1]' })).toBeInTheDocument();
+  expect(getByRole('link', { name: 'source(12)' })).toBeInTheDocument();
+  expect(getByRole('link', { name: 'page{12}' })).toBeInTheDocument();
 });

--- a/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
@@ -36,10 +36,15 @@ const isGlobalMatch = (forIds: string[] | undefined) => {
   return !forIds || !forIds.length;
 };
 
+function escapeRegExp(string: string) {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function prepareContent({ id, elements, actions, content, language }: Props) {
   const elementNames = elements
     .filter((e) => e.type !== 'avatar')
-    .map((e) => e.name);
+    .map((e) => escapeRegExp(e.name));
 
   // Sort by descending length to avoid matching substrings
   elementNames.sort((a, b) => b.length - a.length);


### PR DESCRIPTION
The following simple program containing scoped elements would not render the links correctly:

```python
import chainlit as cl

@cl.on_chat_start
async def main():
    element1 = cl.Text(name="Document[1]", content="Testing", display="side")
    element2 = cl.Text(name="Source(45)", content="Testing", display="side")

    await cl.Message(
        content=f"Testing: Document[1] or Source(45)", elements=[element1, element2]
    ).send()
```

I've added code that escapes regex characters so that the element names are matched correctly.