### PR TITLE
Fix Message __init__

### DIFF
--- a/src/chainlit/message.py
+++ b/src/chainlit/message.py
@@ -146,8 +146,8 @@ class Message(MessageBase):
         language: str = None,
         parent_id: str = None,
         indent: int = 0,
-        actions: List[Action] = [],
-        elements: List[Element] = [],
+        actions: List[Action] = None,
+        elements: List[Element] = None,
     ):
         self.content = content
         self.author = author
@@ -155,8 +155,8 @@ class Message(MessageBase):
         self.language = language
         self.parent_id = parent_id
         self.indent = indent
-        self.actions = actions
-        self.elements = elements
+        self.actions = actions if actions is not None else []
+        self.elements = elements if elements is not None else []
         self.llm_settings = None
 
         if llm_settings is None and prompt is not None:


### PR DESCRIPTION
Currently the __init__ method initializes with a default empty list for both actions and elements.
However in Python an empty list as a default argument is only defined once and subsequent calls will return the same exact list.
This means that if you create a new Message it will be assigned the list of the previously created Message (if the elements property is not provided).

This PR fixes this problem.

The following program showcases the bug:

```python
import chainlit as cl

@cl.on_chat_start
async def main():
    element1 = cl.Text(name="Document_1", content="Testing", display="side")
    element2 = cl.Text(name="Document_2", content="Testing", display="side")

    message1 = cl.Message(author="Agent", content="")
    message1.elements.append(element1)
    message1.elements.append(element2)
    await message1.send()

    print(message1.elements)

    message2 = cl.Message(author="Agent", content="")
    await message2.send()

    # message2 contains elements of message1
    print(message2.elements)
```