### PR TITLE
Improve element type inference

### DIFF
--- a/src/chainlit/frontend/src/api/index.ts
+++ b/src/chainlit/frontend/src/api/index.ts
@@ -2,7 +2,7 @@ import { IPageInfo, IPagination } from 'components/organisms/dataset/table';
 
 import { IChat, ILLMSettings } from 'state/chat';
 import { IDatasetFilters } from 'state/dataset';
-import { IElement } from 'state/element';
+import { IMessageElement } from 'state/element';
 import { IMember, Role } from 'state/user';
 
 const devServer = 'http://127.0.0.1:8000';
@@ -112,7 +112,7 @@ export class ChainlitClient {
   getElement = async (
     conversationId: number | string,
     elementId: number | string
-  ): Promise<IElement> => {
+  ): Promise<IMessageElement> => {
     const res = await this.fetch(
       `/project/conversation/${conversationId}/element/${elementId}`,
       {

--- a/src/chainlit/frontend/src/components/atoms/element/ref.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/ref.tsx
@@ -3,10 +3,10 @@ import { useSetRecoilState } from 'recoil';
 
 import { Link } from '@mui/material';
 
-import { IElement, sideViewState } from 'state/element';
+import { IMessageElement, sideViewState } from 'state/element';
 
 interface Props {
-  element: IElement;
+  element: IMessageElement;
 }
 
 export default function ElementRef({ element }: Props) {

--- a/src/chainlit/frontend/src/components/atoms/element/view.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/view.tsx
@@ -7,16 +7,7 @@ import { Box, Typography } from '@mui/material';
 import { useQuery } from 'hooks/query';
 
 import { clientState } from 'state/client';
-import {
-  IAudioElement,
-  IElement,
-  IFileElement,
-  IImageElement,
-  IPdfElement,
-  ITextElement,
-  IVideoElement,
-  elementState
-} from 'state/element';
+import { IMessageElement, elementState } from 'state/element';
 
 import AudioElement from './audio';
 import FileElement from './file';
@@ -25,22 +16,20 @@ import PDFElement from './pdf';
 import TextElement from './text';
 import VideoElement from './video';
 
-export const renderElement = (element: IElement): JSX.Element | null => {
+export const renderElement = (element: IMessageElement): JSX.Element | null => {
   switch (element.type) {
     case 'file':
-      return <FileElement element={element as IFileElement} />;
+      return <FileElement element={element} />;
     case 'image':
-      return <ImageElement element={element as IImageElement} />;
+      return <ImageElement element={element} />;
     case 'text':
-      return <TextElement element={element as ITextElement} />;
+      return <TextElement element={element} />;
     case 'pdf':
-      return <PDFElement element={element as IPdfElement} />;
+      return <PDFElement element={element} />;
     case 'audio':
-      return <AudioElement element={element as IAudioElement} />;
+      return <AudioElement element={element} />;
     case 'video':
-      return <VideoElement element={element as IVideoElement} />;
-    default:
-      return null;
+      return <VideoElement element={element} />;
   }
 };
 
@@ -49,7 +38,7 @@ const ElementView = () => {
   const query = useQuery();
   const elements = useRecoilValue(elementState);
   const client = useRecoilValue(clientState);
-  const [element, setElement] = useState<IElement | null>(null);
+  const [element, setElement] = useState<IMessageElement | null>(null);
   const [error, setError] = useState<string | undefined>();
 
   const conversationId = query.get('conversation');

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -18,7 +18,7 @@ import {
   messagesState,
   sessionState
 } from 'state/chat';
-import { ITasklistElement, elementState } from 'state/element';
+import { elementState, tasklistState } from 'state/element';
 import { projectSettingsState } from 'state/project';
 
 import Playground from '../playground';
@@ -32,6 +32,7 @@ const Chat = () => {
   const askUser = useRecoilValue(askUserState);
   const [messages, setMessages] = useRecoilState(messagesState);
   const elements = useRecoilValue(elementState);
+  const tasklistElements = useRecoilValue(tasklistState);
   const actions = useRecoilValue(actionState);
   const pSettings = useRecoilValue(projectSettingsState);
   const { persistChatLocally } = useLocalChatHistory();
@@ -81,9 +82,7 @@ const Chat = () => {
     [askUser, user]
   );
 
-  const tasklist = elements.findLast((e) => e.type === 'tasklist') as
-    | ITasklistElement
-    | undefined;
+  const tasklist = tasklistElements.at(-1);
 
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>

--- a/src/chainlit/frontend/src/components/organisms/chat/message/author.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/author.tsx
@@ -6,7 +6,7 @@ import { Box, Tooltip, Typography } from '@mui/material';
 import AvatarElement from 'components/atoms/element/avatar';
 
 import { IMessage } from 'state/chat';
-import { IAvatarElement, elementState } from 'state/element';
+import { avatarState } from 'state/element';
 
 import MessageTime from './time';
 
@@ -19,15 +19,11 @@ export const authorBoxWidth = 70;
 
 export default function Author({ message, show }: Props) {
   const getColorForName = useColorForName();
-  const elements = useRecoilValue(elementState);
-  const avatars = elements.filter((e) => e.type === 'avatar');
+  const avatars = useRecoilValue(avatarState);
   const avatarEl = avatars.find((e) => e.name === message.author);
 
   const avatar = show && avatarEl && (
-    <AvatarElement
-      element={avatarEl as IAvatarElement}
-      author={message.author}
-    />
+    <AvatarElement element={avatarEl} author={message.author} />
   );
 
   const name = show && (

--- a/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
@@ -4,13 +4,13 @@ import { Box } from '@mui/material';
 
 import { IAction } from 'state/action';
 import { IMessage, INestedMessage } from 'state/chat';
-import { IElements } from 'state/element';
+import { IMessageElement } from 'state/element';
 
 import Messages from './messages';
 
 interface Props {
   messages: IMessage[];
-  elements: IElements;
+  elements: IMessageElement[];
   actions: IAction[];
   autoScroll?: boolean;
   setAutoSroll?: (autoScroll: boolean) => void;

--- a/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
@@ -8,14 +8,14 @@ import Code from 'components/atoms/Code';
 import ElementRef from 'components/atoms/element/ref';
 
 import { IAction } from 'state/action';
-import { IElements } from 'state/element';
+import { IMessageElement } from 'state/element';
 
 import InlinedElements from './inlined';
 
 interface Props {
   id?: string;
   content?: string;
-  elements: IElements;
+  elements: IMessageElement[];
   actions: IAction[];
   language?: string;
   authorIsUser?: boolean;
@@ -42,9 +42,7 @@ function escapeRegExp(string: string) {
 }
 
 function prepareContent({ id, elements, actions, content, language }: Props) {
-  const elementNames = elements
-    .filter((e) => e.type !== 'avatar')
-    .map((e) => escapeRegExp(e.name));
+  const elementNames = elements.map((e) => escapeRegExp(e.name));
 
   // Sort by descending length to avoid matching substrings
   elementNames.sort((a, b) => b.length - a.length);
@@ -61,10 +59,10 @@ function prepareContent({ id, elements, actions, content, language }: Props) {
   });
 
   let preparedContent = content ? content.trim() : '';
-  const inlinedElements: IElements = elements.filter(
+  const inlinedElements = elements.filter(
     (e) => isForIdMatch(id, e?.forIds) && e.display === 'inline'
   );
-  const refElements: IElements = [];
+  const refElements: IMessageElement[] = [];
 
   if (elementRegexp) {
     preparedContent = preparedContent.replaceAll(elementRegexp, (match) => {

--- a/src/chainlit/frontend/src/components/organisms/chat/message/inlined.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/inlined.tsx
@@ -9,10 +9,10 @@ import InlinedTextList from 'components/atoms/element/inlined/texts';
 import InlinedVideoList from 'components/atoms/element/inlined/videos';
 
 import { IAction } from 'state/action';
-import { AllElements, ElementType, IElements } from 'state/element';
+import { ElementType, IMessageElement } from 'state/element';
 
 interface Props {
-  elements: IElements;
+  elements: IMessageElement[];
   actions: IAction[];
 }
 
@@ -27,19 +27,19 @@ export default function InlinedElements({ elements, actions }: Props) {
    * and get an array of IImageElement.
    */
   const elementsByType = elements.reduce(
-    (acc, el: AllElements) => {
+    (acc, el: IMessageElement) => {
       if (!acc[el.type]) {
         acc[el.type] = [];
       }
       const array = acc[el.type] as Extract<
-        AllElements,
+        IMessageElement,
         { type: typeof el.type }
       >[];
       array.push(el);
       return acc;
     },
     {} as {
-      [K in ElementType]: Extract<AllElements, { type: K }>[];
+      [K in ElementType]: Extract<IMessageElement, { type: K }>[];
     }
   );
 

--- a/src/chainlit/frontend/src/components/organisms/chat/message/message.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/message.tsx
@@ -6,7 +6,7 @@ import { Box, Stack } from '@mui/material';
 
 import { IAction } from 'state/action';
 import { INestedMessage, highlightMessage } from 'state/chat';
-import { IElements } from 'state/element';
+import { IMessageElement } from 'state/element';
 import { settingsState } from 'state/settings';
 
 import Author, { authorBoxWidth } from './author';
@@ -18,7 +18,7 @@ import UploadButton from './uploadButton';
 
 interface Props {
   message: INestedMessage;
-  elements: IElements;
+  elements: IMessageElement[];
   actions: IAction[];
   indent: number;
   showAvatar?: boolean;

--- a/src/chainlit/frontend/src/components/organisms/chat/message/messages.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/messages.tsx
@@ -2,13 +2,13 @@ import { useRecoilValue } from 'recoil';
 
 import { IAction } from 'state/action';
 import { INestedMessage, loadingState } from 'state/chat';
-import { IElements } from 'state/element';
+import { IMessageElement } from 'state/element';
 
 import Message from './message';
 
 interface Props {
   messages: INestedMessage[];
-  elements: IElements;
+  elements: IMessageElement[];
   actions: IAction[];
   indent: number;
   isRunning?: boolean;

--- a/src/chainlit/frontend/src/components/socket.tsx
+++ b/src/chainlit/frontend/src/components/socket.tsx
@@ -17,7 +17,12 @@ import {
   sessionState,
   tokenCountState
 } from 'state/chat';
-import { IElement, elementState } from 'state/element';
+import {
+  IElement,
+  avatarState,
+  elementState,
+  tasklistState
+} from 'state/element';
 import { projectSettingsState } from 'state/project';
 import { sessionIdState, userEnvState } from 'state/user';
 
@@ -37,6 +42,8 @@ export default memo(function Socket() {
   const setTokenCount = useSetRecoilState(tokenCountState);
   const setAskUser = useSetRecoilState(askUserState);
   const setElements = useSetRecoilState(elementState);
+  const setAvatars = useSetRecoilState(avatarState);
+  const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
 
   useEffect(() => {
@@ -172,7 +179,13 @@ export default memo(function Socket() {
     });
 
     socket.on('element', (element: IElement) => {
-      setElements((old) => [...old, element]);
+      if (element.type === 'avatar') {
+        setAvatars((old) => [...old, element]);
+      } else if (element.type === 'tasklist') {
+        setTasklists((old) => [...old, element]);
+      } else {
+        setElements((old) => [...old, element]);
+      }
     });
 
     socket.on('update_element', (update: { id: string; forIds: string[] }) => {

--- a/src/chainlit/frontend/src/hooks/clearChat.ts
+++ b/src/chainlit/frontend/src/hooks/clearChat.ts
@@ -2,12 +2,19 @@ import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { actionState } from 'state/action';
 import { messagesState, sessionState, tokenCountState } from 'state/chat';
-import { elementState, sideViewState } from 'state/element';
+import {
+  avatarState,
+  elementState,
+  sideViewState,
+  tasklistState
+} from 'state/element';
 import { sessionIdState } from 'state/user';
 
 export default function useClearChat() {
   const setMessages = useSetRecoilState(messagesState);
   const setElements = useSetRecoilState(elementState);
+  const setAvatars = useSetRecoilState(avatarState);
+  const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
   const setSideView = useSetRecoilState(sideViewState);
   const setTokenCount = useSetRecoilState(tokenCountState);
@@ -21,6 +28,8 @@ export default function useClearChat() {
     session?.socket.connect();
     setMessages([]);
     setElements([]);
+    setAvatars([]);
+    setTasklists([]);
     setActions([]);
     setSideView(undefined);
     setTokenCount(0);

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 import { Socket } from 'socket.io-client';
 
-import { IElement } from './element';
+import { IMessageElement } from './element';
 import { IMember } from './user';
 
 export interface ILLMSettings {
@@ -19,7 +19,7 @@ export interface IChat {
   createdAt: number | string;
   author?: IMember;
   messages: IMessage[];
-  elements: IElement[];
+  elements: IMessageElement[];
 }
 
 export interface IMessage {

--- a/src/chainlit/frontend/src/state/element.ts
+++ b/src/chainlit/frontend/src/state/element.ts
@@ -1,16 +1,6 @@
 import { atom } from 'recoil';
 
-export type ElementType =
-  | 'image'
-  | 'text'
-  | 'pdf'
-  | 'avatar'
-  | 'tasklist'
-  | 'audio'
-  | 'video'
-  | 'file';
-
-export type AllElements =
+export type IElement =
   | IImageElement
   | ITextElement
   | IPdfElement
@@ -20,68 +10,83 @@ export type AllElements =
   | IVideoElement
   | IFileElement;
 
+export type IMessageElement =
+  | IImageElement
+  | ITextElement
+  | IPdfElement
+  | IAudioElement
+  | IVideoElement
+  | IFileElement;
+
+export type ElementType = IElement['type'];
 export type IElementSize = 'small' | 'medium' | 'large';
 
-export interface IElement {
+interface TElement<T> {
   id: string;
+  type: T;
   conversationId?: string;
-  url?: string;
-  type: ElementType;
-  name: string;
-  display: 'inline' | 'side' | 'page';
   forIds?: string[];
+  url?: string;
 }
 
-export interface IImageElement extends IElement {
-  type: 'image';
+interface TMessageElement<T> extends TElement<T> {
+  name: string;
+  display: 'inline' | 'side' | 'page';
+}
+
+export interface IImageElement extends TMessageElement<'image'> {
   content?: ArrayBuffer;
   size?: IElementSize;
 }
 
-export interface IAvatarElement extends IElement {
-  type: 'avatar';
+export interface IAvatarElement extends TElement<'avatar'> {
+  name: string;
   content?: ArrayBuffer;
 }
 
-export interface ITextElement extends IElement {
-  type: 'text';
+export interface ITextElement extends TMessageElement<'text'> {
   content?: string;
   language?: string;
 }
-export interface IPdfElement extends IElement {
-  type: 'pdf';
+
+export interface IPdfElement extends TMessageElement<'pdf'> {
   content?: string;
 }
 
-export interface IAudioElement extends IElement {
-  type: 'audio';
+export interface IAudioElement extends TMessageElement<'audio'> {
   content?: ArrayBuffer;
 }
 
-export interface IVideoElement extends IElement {
-  type: 'video';
+export interface IVideoElement extends TMessageElement<'video'> {
   content?: ArrayBuffer;
   size?: IElementSize;
 }
 
-export interface IFileElement extends IElement {
+export interface IFileElement extends TMessageElement<'file'> {
   type: 'file';
   content?: ArrayBuffer;
 }
 
-export interface ITasklistElement extends IElement {
-  type: 'tasklist';
+export interface ITasklistElement extends TElement<'tasklist'> {
   content?: string;
 }
 
-export type IElements = IElement[];
-
-export const elementState = atom<IElements>({
-  key: 'Elements',
+export const elementState = atom<IMessageElement[]>({
+  key: 'DisplayElements',
   default: []
 });
 
-export const sideViewState = atom<IElement | undefined>({
+export const avatarState = atom<IAvatarElement[]>({
+  key: 'AvatarElements',
+  default: []
+});
+
+export const tasklistState = atom<ITasklistElement[]>({
+  key: 'TasklistElements',
+  default: []
+});
+
+export const sideViewState = atom<IMessageElement | undefined>({
   key: 'SideView',
   default: undefined
 });


### PR DESCRIPTION
I made some changes to the `element.ts` to make typescript smarter causing less `as` casts. 
I also separated Avatar and TaskList from the other elements so that you don't need to write logic to extract them from the other elements.

Open to any feedback!
