### PR TITLE
Parse custom theme json before injecting it to front

### DIFF
--- a/src/chainlit/server.py
+++ b/src/chainlit/server.py
@@ -1,3 +1,4 @@
+import json
 import mimetypes
 
 mimetypes.add_type("application/javascript", ".js")
@@ -172,7 +173,7 @@ def get_html_template():
 
     js = None
     if config.ui.theme:
-        js = f"""<script>window.theme = {config.ui.theme.to_dict()}</script>"""
+        js = f"""<script>window.theme = {json.dumps(config.ui.theme.to_dict())}</script>"""
 
     index_html_file_path = os.path.join(build_dir, "index.html")
 


### PR DESCRIPTION
`None` is not supported by JavaScript. We should replace it by `undefined` or the front won't set custom theme if there is one `None` value <img width="810" alt="Capture d’écran 2023-07-25 à 10 03 37" src="https://github.com/Chainlit/chainlit/assets/18298759/d17f15c2-a11d-4eba-aea5-993a0637241b">
