### PR TITLE
Implement chat settings

### DIFF
--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 from dotenv import load_dotenv
 
@@ -24,6 +24,7 @@ from chainlit.element import (
     Video,
 )
 from chainlit.haystack import HAYSTACK_INSTALLED
+from chainlit.input_widget import ChatSettings, SelectInput, Slider, Switch, TextInput
 from chainlit.lc import LANGCHAIN_INSTALLED
 from chainlit.llama_index import LLAMA_INDEX_INSTALLED
 from chainlit.logger import logger
@@ -132,6 +133,23 @@ def action_callback(name: str) -> Callable:
     return decorator
 
 
+def on_settings_update(
+    func: Callable[[Dict[str, Any]], Any]
+) -> Callable[[Dict[str, Any]], Any]:
+    """
+    Hook to react to the user changing any settings.
+
+    Args:
+        func (Callable[], Any]): The hook to execute after settings were changed.
+
+    Returns:
+        Callable[], Any]: The decorated hook.
+    """
+
+    config.code.on_settings_update = wrap_user_function(func, with_task=True)
+    return func
+
+
 @trace
 def client_factory(
     func: Callable[[Optional["UserDict"]], "BaseDBClient"]
@@ -171,6 +189,11 @@ __all__ = [
     "TaskList",
     "TaskStatus",
     "Video",
+    "ChatSettings",
+    "Switch",
+    "Slider",
+    "SelectInput",
+    "TextInput",
     "Message",
     "ErrorMessage",
     "AskUserMessage",
@@ -179,6 +202,7 @@ __all__ = [
     "on_stop",
     "action_callback",
     "author_rename",
+    "on_settings_update",
     "sleep",
     "LangchainCallbackHandler",
     "AsyncLangchainCallbackHandler",

--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -7,8 +7,10 @@ from dotenv import load_dotenv
 if TYPE_CHECKING:
     from chainlit.client.base import BaseDBClient, UserDict
 
+import chainlit.input_widget as input_widget
 from chainlit.action import Action
 from chainlit.cache import cache
+from chainlit.chat_settings import ChatSettings
 from chainlit.config import config
 from chainlit.element import (
     Audio,
@@ -24,7 +26,6 @@ from chainlit.element import (
     Video,
 )
 from chainlit.haystack import HAYSTACK_INSTALLED
-from chainlit.input_widget import ChatSettings, SelectInput, Slider, Switch, TextInput
 from chainlit.lc import LANGCHAIN_INSTALLED
 from chainlit.llama_index import LLAMA_INDEX_INSTALLED
 from chainlit.logger import logger
@@ -190,10 +191,7 @@ __all__ = [
     "TaskStatus",
     "Video",
     "ChatSettings",
-    "Switch",
-    "Slider",
-    "SelectInput",
-    "TextInput",
+    "input_widget",
     "Message",
     "ErrorMessage",
     "AskUserMessage",

--- a/src/chainlit/chat_settings.py
+++ b/src/chainlit/chat_settings.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from pydantic.dataclasses import Field, dataclass
+
+from chainlit.context import get_emitter
+from chainlit.input_widget import InputWidget
+
+
+@dataclass
+class ChatSettings:
+    """Useful to create chat settings that the user can change."""
+
+    inputs: List[InputWidget] = Field(default_factory=list, exclude=True)
+
+    def __init__(
+        self,
+        inputs: List[InputWidget],
+    ) -> None:
+        self.inputs = inputs
+        self.emitter = get_emitter()
+
+    def settings(self):
+        return dict(
+            [(input_widget.id, input_widget.initial) for input_widget in self.inputs]
+        )
+
+    async def send(self):
+        settings = self.settings()
+        self.emitter.set_chat_settings(settings)
+
+        inputs_content = [input_widget.to_dict() for input_widget in self.inputs]
+        await self.emitter.emit("chat_settings", inputs_content)
+
+        return settings

--- a/src/chainlit/config.py
+++ b/src/chainlit/config.py
@@ -150,6 +150,7 @@ class CodeSettings:
     on_chat_start: Optional[Callable[[], Any]] = None
     on_message: Optional[Callable[[str], Any]] = None
     author_rename: Optional[Callable[[str], str]] = None
+    on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
     client_factory: Optional[Callable[[str], "BaseDBClient"]] = None
 
     def validate(self):

--- a/src/chainlit/emitter.py
+++ b/src/chainlit/emitter.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Dict, Union, cast
+from typing import Any, Dict, Union, cast
 
 from socketio.exceptions import TimeoutError
 
@@ -145,3 +145,6 @@ class ChainlitEmitter:
         return self.emit(
             "stream_token", {"id": id, "token": token, "isSequence": is_sequence}
         )
+
+    def set_chat_settings(self, settings: Dict[str, Any]):
+        self.session.chat_settings = settings

--- a/src/chainlit/frontend/src/components/atoms/switch.tsx
+++ b/src/chainlit/frontend/src/components/atoms/switch.tsx
@@ -8,7 +8,7 @@ import InputStateHandler from 'components/organisms/inputs/inputStateHandler';
 import { IInput } from 'types/Input';
 
 export type SwitchProps = {
-  checked?: boolean;
+  checked: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   onChange: (
     event?: React.ChangeEvent<HTMLInputElement>,
@@ -38,6 +38,7 @@ export default function Switch(props: SwitchProps): JSX.Element {
       tooltip={tooltip}
     >
       <StyledSwitch
+        name={id}
         disabled={disabled}
         edge="end"
         onChange={onChange}

--- a/src/chainlit/frontend/src/components/organisms/FormInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/FormInput.tsx
@@ -2,38 +2,34 @@ import Switch, { SwitchProps } from 'components/atoms/switch';
 
 import { IInput } from 'types/Input';
 
-import SelectInput, {
-  SelectInputProps,
-  SelectItem
-} from './inputs/selectInput';
+import SelectInput, { SelectInputProps } from './inputs/selectInput';
 import TagsInput, { TagsInputProps } from './inputs/tagsInput';
 import TextInput, { TextInputProps } from './inputs/textInput';
 import Slider, { SliderProps } from './slider';
 
-interface IFormInput<T, I> extends IInput {
+export type FormInitial =
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[]
+  | undefined;
+
+export interface IFormInput<T> extends IInput {
   type: T;
-  initial: I;
 }
 
 export type TFormInput =
-  | (SwitchProps & IFormInput<'switch', boolean>)
-  | (SliderProps & IFormInput<'slider', number>)
-  | (SelectInputProps & IFormInput<'select', string>)
-  | (TextInputProps & IFormInput<'textinput', string>)
-  | (TagsInputProps & IFormInput<'tags', string[]>);
+  | (SwitchProps & IFormInput<'switch'>)
+  | (SliderProps & IFormInput<'slider'>)
+  | (SelectInputProps & IFormInput<'select'>)
+  | (TextInputProps & IFormInput<'textinput'>)
+  | (TagsInputProps & IFormInput<'tags'>);
 
 const FormInput = ({ element }: { element: TFormInput }): JSX.Element => {
   switch (element.type) {
     case 'select':
-      return (
-        <SelectInput
-          {...element}
-          items={element.items?.map((option: SelectItem) => ({
-            label: option.label,
-            value: option.value
-          }))}
-        />
-      );
+      return <SelectInput {...element} />;
     case 'slider':
       return <Slider {...element} />;
     case 'tags':

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -24,6 +24,7 @@ import { projectSettingsState } from 'state/project';
 import Playground from '../playground';
 import InputBox from './inputBox';
 import MessageContainer from './message/container';
+import ChatSettingsModal from './settings';
 import WelcomeScreen from './welcomeScreen';
 
 const Chat = () => {
@@ -87,6 +88,7 @@ const Chat = () => {
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>
       <Playground />
+      <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />
       <SideView>
         <TaskList tasklist={tasklist} isMobile={true} />

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
-import SettingsIcon from '@mui/icons-material/Settings';
 import SendIcon from '@mui/icons-material/Telegram';
+import TuneIcon from '@mui/icons-material/Tune';
 import { IconButton, TextField } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
 
@@ -100,7 +100,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
           color="inherit"
           onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
         >
-          <SettingsIcon />
+          <TuneIcon />
         </IconButton>
       )}
       <HistoryButton onClick={onHistoryClick} />

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
+import SettingsIcon from '@mui/icons-material/Settings';
 import SendIcon from '@mui/icons-material/Telegram';
 import { IconButton, TextField } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
 
 import {
   askUserState,
+  chatSettingsState,
   historyOpenedState,
   loadingState,
   sessionState
@@ -31,6 +33,7 @@ function getLineCount(el: HTMLDivElement) {
 const Input = ({ onSubmit, onReply }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
   const hSetOpen = useSetRecoilState(historyOpenedState);
+  const [chatSettings, setChatSettings] = useRecoilState(chatSettingsState);
   const loading = useRecoilValue(loadingState);
   const askUser = useRecoilValue(askUserState);
   const session = useRecoilValue(sessionState);
@@ -89,6 +92,21 @@ const Input = ({ onSubmit, onReply }: Props) => {
     }
   }, []);
 
+  const startAdornment = (
+    <>
+      {chatSettings.inputs.length > 0 && (
+        <IconButton
+          disabled={disabled}
+          color="inherit"
+          onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
+        >
+          <SettingsIcon />
+        </IconButton>
+      )}
+      <HistoryButton onClick={onHistoryClick} />
+    </>
+  );
+
   const endAdornment = (
     <IconButton disabled={disabled} color="inherit" onClick={() => submit()}>
       <SendIcon />
@@ -118,7 +136,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
             sx={{ ml: 1, color: 'text.secondary' }}
             position="start"
           >
-            <HistoryButton onClick={onHistoryClick} />
+            {startAdornment}
           </InputAdornment>
         ),
         endAdornment: (

--- a/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
@@ -1,0 +1,140 @@
+import { useFormik } from 'formik';
+import mapValues from 'lodash/mapValues';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { Box, Dialog, DialogActions, DialogContent } from '@mui/material';
+
+import AccentButton from 'components/atoms/buttons/accentButton';
+import RegularButton from 'components/atoms/buttons/button';
+
+import {
+  chatSettingsDefaultValueSelector,
+  chatSettingsState,
+  chatSettingsValueState,
+  sessionState
+} from 'state/chat';
+
+import FormInput, { FormInitial, TFormInput } from '../FormInput';
+
+export default function ChatSettingsModal() {
+  const session = useRecoilValue(sessionState);
+  const [chatSettings, setChatSettings] = useRecoilState(chatSettingsState);
+  const [chatSettingsValue, setChatSettingsValue] = useRecoilState(
+    chatSettingsValueState
+  );
+  const chatSettingsDefaultValue = useRecoilValue(
+    chatSettingsDefaultValueSelector
+  );
+
+  const formik = useFormik({
+    initialValues: chatSettingsValue,
+    enableReinitialize: true,
+    onSubmit: async () => undefined
+  });
+
+  const handleClose = () => setChatSettings((old) => ({ ...old, open: false }));
+  const handleConfirm = () => {
+    setChatSettingsValue(formik.values);
+
+    const values = mapValues(formik.values, (x: FormInitial) =>
+      x !== '' ? x : null
+    );
+    session?.socket.emit('chat_settings_change', values);
+
+    handleClose();
+  };
+  const handleReset = () => {
+    formik.setValues(chatSettingsDefaultValue);
+  };
+
+  const renderInput = (element: TFormInput): JSX.Element | undefined => {
+    switch (element.type) {
+      case 'switch':
+        return (
+          <FormInput
+            key={element.id}
+            element={{
+              ...element,
+              checked: formik.values[element.id] ?? false
+            }}
+          />
+        );
+      case 'slider':
+        return (
+          <FormInput
+            key={element.id}
+            element={{
+              ...element,
+              value: formik.values[element.id] ?? 0
+            }}
+          />
+        );
+      case 'select':
+        return (
+          <FormInput
+            key={element.id}
+            element={{
+              ...element,
+              value: formik.values[element.id] ?? ''
+            }}
+          />
+        );
+      case 'textinput':
+        return (
+          <FormInput
+            key={element.id}
+            element={{
+              ...element,
+              value: formik.values[element.id] ?? '',
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                formik.setFieldValue(element.id, e.target.value)
+            }}
+          />
+        );
+    }
+  };
+
+  return (
+    <Dialog
+      open={chatSettings.open}
+      onClose={handleClose}
+      id="chat-settings-dialog"
+      PaperProps={{
+        sx: {
+          backgroundImage: 'none'
+        }
+      }}
+    >
+      <DialogContent sx={{ scrollbarGutter: 'stable' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: '20vw',
+            maxHeight: '70vh',
+            gap: '15px'
+          }}
+        >
+          {chatSettings.inputs.map((input) =>
+            renderInput({
+              ...input,
+              onChange: formik.handleChange
+            })
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <RegularButton onClick={handleClose}>Cancel</RegularButton>
+        <RegularButton onClick={handleReset}>Reset</RegularButton>
+        <AccentButton
+          id="confirm"
+          variant="outlined"
+          onClick={handleConfirm}
+          autoFocus
+        >
+          Confirm
+        </AccentButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
@@ -2,7 +2,13 @@ import { useFormik } from 'formik';
 import mapValues from 'lodash/mapValues';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { Box, Dialog, DialogActions, DialogContent } from '@mui/material';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle
+} from '@mui/material';
 
 import AccentButton from 'components/atoms/buttons/accentButton';
 import RegularButton from 'components/atoms/buttons/button';
@@ -105,7 +111,8 @@ export default function ChatSettingsModal() {
         }
       }}
     >
-      <DialogContent sx={{ scrollbarGutter: 'stable' }}>
+      <DialogTitle id="alert-dialog-title">{'Settings panel'}</DialogTitle>
+      <DialogContent>
         <Box
           sx={{
             display: 'flex',
@@ -124,8 +131,11 @@ export default function ChatSettingsModal() {
         </Box>
       </DialogContent>
       <DialogActions sx={{ p: 2 }}>
+        <AccentButton onClick={handleReset} color="primary" variant="outlined">
+          Reset
+        </AccentButton>
+        <div style={{ flex: '1 0 0' }} />
         <RegularButton onClick={handleClose}>Cancel</RegularButton>
-        <RegularButton onClick={handleReset}>Reset</RegularButton>
         <AccentButton
           id="confirm"
           variant="outlined"

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -98,7 +98,7 @@ export default function SelectInput({
         value={value?.toString()}
         onChange={onChange}
         size={size}
-        name={name}
+        name={name || id}
         disabled={disabled}
         renderValue={() =>
           (renderLabel && renderLabel()) ||
@@ -106,9 +106,6 @@ export default function SelectInput({
         }
         sx={{
           backgroundColor: isDarkMode ? grey[900] : '',
-          color: isDarkMode ? grey[300] : grey[600],
-          fontSize: '14px',
-          fontWeight: 400,
           my: 0.5,
           boxShadow:
             '0px 10px 10px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px 0px rgba(0, 0, 0, 0.05)'

--- a/src/chainlit/frontend/src/components/organisms/inputs/tagsInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/tagsInput.tsx
@@ -28,7 +28,7 @@ export default function TagsInput({
       label={label}
       tooltip={tooltip}
     >
-      <MuiChipsInput {...rest} size={size} />
+      <MuiChipsInput {...rest} size={size} name={id} id={id} />
     </InputStateHandler>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -26,7 +26,7 @@ const _Slider = ({
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
     >
-      <StyledSlider {...sliderProps} />
+      <StyledSlider {...sliderProps} id={id} name={id} />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/components/socket.tsx
+++ b/src/chainlit/frontend/src/components/socket.tsx
@@ -1,7 +1,12 @@
 import { wsEndpoint } from 'api';
 import { deepEqual } from 'helpers/object';
 import { memo, useEffect } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  useRecoilState,
+  useRecoilValue,
+  useResetRecoilState,
+  useSetRecoilState
+} from 'recoil';
 import io from 'socket.io-client';
 
 import { useAuth } from 'hooks/auth';
@@ -12,6 +17,8 @@ import {
   IMessageUpdate,
   IToken,
   askUserState,
+  chatSettingsState,
+  chatSettingsValueState,
   loadingState,
   messagesState,
   sessionState,
@@ -25,6 +32,8 @@ import {
 } from 'state/element';
 import { projectSettingsState } from 'state/project';
 import { sessionIdState, userEnvState } from 'state/user';
+
+import { TFormInput } from './organisms/FormInput';
 
 const compareMessageIds = (a: IMessage, b: IMessage) => {
   if (a.id && b.id) return a.id === b.id;
@@ -45,6 +54,8 @@ export default memo(function Socket() {
   const setAvatars = useSetRecoilState(avatarState);
   const setTasklists = useSetRecoilState(tasklistState);
   const setActions = useSetRecoilState(actionState);
+  const setChatSettings = useSetRecoilState(chatSettingsState);
+  const resetChatSettingsValue = useResetRecoilState(chatSettingsValueState);
 
   useEffect(() => {
     if (authenticating || !pSettings) return;
@@ -176,6 +187,11 @@ export default memo(function Socket() {
 
     socket.on('clear_ask', () => {
       setAskUser(undefined);
+    });
+
+    socket.on('chat_settings', (inputs: TFormInput[]) => {
+      setChatSettings((old) => ({ ...old, inputs }));
+      resetChatSettingsValue();
     });
 
     socket.on('element', (element: IElement) => {

--- a/src/chainlit/frontend/src/hooks/clearChat.ts
+++ b/src/chainlit/frontend/src/hooks/clearChat.ts
@@ -1,7 +1,13 @@
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { actionState } from 'state/action';
-import { messagesState, sessionState, tokenCountState } from 'state/chat';
+import {
+  chatSettingsState,
+  chatSettingsValueState,
+  messagesState,
+  sessionState,
+  tokenCountState
+} from 'state/chat';
 import {
   avatarState,
   elementState,
@@ -18,6 +24,8 @@ export default function useClearChat() {
   const setActions = useSetRecoilState(actionState);
   const setSideView = useSetRecoilState(sideViewState);
   const setTokenCount = useSetRecoilState(tokenCountState);
+  const resetChatSettings = useResetRecoilState(chatSettingsState);
+  const resetChatSettingsValue = useResetRecoilState(chatSettingsValueState);
   const resetSessionId = useResetRecoilState(sessionIdState);
   const session = useRecoilValue(sessionState);
 
@@ -33,5 +41,7 @@ export default function useClearChat() {
     setActions([]);
     setSideView(undefined);
     setTokenCount(0);
+    resetChatSettings();
+    resetChatSettingsValue();
   };
 }

--- a/src/chainlit/frontend/src/pages/Design.tsx
+++ b/src/chainlit/frontend/src/pages/Design.tsx
@@ -94,7 +94,6 @@ export default function Design(): JSX.Element {
         </Typography>
         <FormInput
           element={{
-            initial: isDarkMode,
             type: 'switch',
             id: 'design-switch',
             onChange: onDarkModeChange,
@@ -110,7 +109,6 @@ export default function Design(): JSX.Element {
         <ComponentBox name="TextInput">
           <FormInput
             element={{
-              initial: 'first',
               type: 'textinput',
               label: 'my label',
               tooltip: 'Ok bro',
@@ -130,7 +128,6 @@ export default function Design(): JSX.Element {
         <ComponentBox name="Select">
           <FormInput
             element={{
-              initial: 'first',
               type: 'select',
               description: 'test',
               id: 'author-filter-select',
@@ -152,7 +149,6 @@ export default function Design(): JSX.Element {
         <ComponentBox name="Slider">
           <FormInput
             element={{
-              initial: 0,
               type: 'slider',
               id: 'design-slider',
               label: 'Temperature',
@@ -167,7 +163,6 @@ export default function Design(): JSX.Element {
         <ComponentBox name="Switch">
           <FormInput
             element={{
-              initial: false,
               type: 'switch',
               id: 'design-switch',
               onChange: onDarkModeChange,

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -1,5 +1,7 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
 import { Socket } from 'socket.io-client';
+
+import { FormInitial, TFormInput } from 'components/organisms/FormInput';
 
 import { IMessageElement } from './element';
 import { IMember } from './user';
@@ -116,4 +118,34 @@ export const askUserState = atom<IAsk | undefined>({
 export const highlightMessage = atom<IMessage['id'] | null>({
   key: 'HighlightMessage',
   default: null
+});
+
+export const chatSettingsState = atom<{
+  open: boolean;
+  inputs: TFormInput[];
+}>({
+  key: 'ChatSettings',
+  default: {
+    open: false,
+    inputs: []
+  }
+});
+
+export const chatSettingsDefaultValueSelector = selector({
+  key: 'ChatSettingsValue/Default',
+  get: ({ get }) => {
+    const chatSettings = get(chatSettingsState);
+    return chatSettings.inputs.reduce(
+      (
+        form: { [key: string]: any },
+        input: TFormInput & { initial?: FormInitial }
+      ) => ((form[input.id] = input.initial), form),
+      {}
+    );
+  }
+});
+
+export const chatSettingsValueState = atom({
+  key: 'ChatSettingsValue',
+  default: chatSettingsDefaultValueSelector
 });

--- a/src/chainlit/input_widget.py
+++ b/src/chainlit/input_widget.py
@@ -1,0 +1,226 @@
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from pydantic.dataclasses import Field, dataclass
+
+from chainlit.context import get_emitter
+from chainlit.types import InputWidgetType
+
+
+@dataclass
+class InputWidget(ABC):
+    id: str
+    label: str
+    initial: Any = None
+    tooltip: Optional[str] = None
+    description: Optional[str] = None
+
+    def __post_init__(self, tooltip, description) -> None:
+        if not self.id or not self.label:
+            raise ValueError("Must provide key and label to load InputWidget")
+
+        self.tooltip = tooltip
+        self.description = description
+
+    @abstractmethod
+    def to_dict(self) -> Dict[str, Any]:
+        pass
+
+
+@dataclass
+class ChatSettings:
+    """Useful to create chat settings that the user can change."""
+
+    widgets: List[InputWidget] = Field(default_factory=list, exclude=True)
+
+    def __init__(
+        self,
+        widgets: List[InputWidget],
+    ) -> None:
+        self.widgets = widgets
+        self.emitter = get_emitter()
+
+    def settings(self):
+        return dict(
+            [(input_widget.key, input_widget.initial) for input_widget in self.widgets]
+        )
+
+    async def send(self):
+        settings = self.settings()
+        self.emitter.set_chat_settings(settings)
+
+        widgets_content = [input_widget.to_dict() for input_widget in self.widgets]
+        await self.emitter.emit("chat_settings", widgets_content)
+
+        return settings
+
+
+@dataclass
+class Switch(InputWidget):
+    """Useful to create a switch input in the settings element."""
+
+    type: InputWidgetType = "switch"
+    initial: bool = False
+
+    def __init__(
+        self,
+        id: str,
+        label: str,
+        initial: bool,
+        tooltip: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.id = id
+        self.label = label
+        self.initial = initial
+        super().__post_init__(tooltip, description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class Slider(InputWidget):
+    """Useful to create a slider input in the settings element."""
+
+    type: InputWidgetType = "slider"
+    initial: float = 0
+    min: float = 0
+    max: float = 10
+    step: float = 1
+
+    def __init__(
+        self,
+        id: str,
+        label: str,
+        initial: float,
+        min: float = 0,
+        max: float = 10,
+        step: float = 1,
+        tooltip: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.id = id
+        self.label = label
+        self.initial = initial
+        self.min = min
+        self.max = max
+        self.step = step
+        super().__post_init__(tooltip, description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "min": self.min,
+            "max": self.max,
+            "step": self.step,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class SelectInput(InputWidget):
+    """Useful to create a select input in the settings element."""
+
+    type: InputWidgetType = "select"
+    initial: Optional[str] = None
+    initial_index: Optional[int] = None
+    initial_value: Optional[str] = None
+    values: List[str] = Field(default_factory=lambda: list)
+    items: Dict[str, str] = Field(default_factory=lambda: defaultdict(dict))
+
+    def __init__(
+        self,
+        id: str,
+        label: str,
+        values: Optional[List[str]] = None,
+        items: Optional[Dict[str, str]] = None,
+        initial_index: Optional[int] = None,
+        initial_value: Optional[str] = None,
+        tooltip: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        if values is None and items is None:
+            raise ValueError("Must provide values or items to create a Select")
+
+        if values is not None and items is not None:
+            raise ValueError(
+                "You can only provide either values or items to create a Select"
+            )
+
+        if values is None and initial_index is not None:
+            raise ValueError(
+                "Initial_index can only be used in combination with values to create a SelectInput"
+            )
+
+        self.id = id
+        self.label = label
+
+        if items is not None:
+            self.items = items
+        if values is not None:
+            self.items = {value: value for value in values}
+            self.initial = (
+                values[initial_index] if initial_index is not None else initial_value
+            )
+        super().__post_init__(tooltip, description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "items": [
+                {"label": id, "value": value} for id, value in self.items.items()
+            ],
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class TextInput(InputWidget):
+    """Useful to create a text input in the settings element."""
+
+    type: InputWidgetType = "textinput"
+    initial: Optional[str] = None
+    placeholder: Optional[str] = None
+
+    def __init__(
+        self,
+        id: str,
+        label: str,
+        initial: Optional[str] = None,
+        placeholder: Optional[str] = None,
+        tooltip: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.id = id
+        self.label = label
+        self.initial = initial
+        self.placeholder = placeholder
+        super().__post_init__(tooltip, description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
+            "placeholder": self.placeholder,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }

--- a/src/chainlit/input_widget.py
+++ b/src/chainlit/input_widget.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional
 
 from pydantic.dataclasses import Field, dataclass
 
-from chainlit.context import get_emitter
 from chainlit.types import InputWidgetType
 
 
@@ -29,36 +28,8 @@ class InputWidget(ABC):
 
 
 @dataclass
-class ChatSettings:
-    """Useful to create chat settings that the user can change."""
-
-    widgets: List[InputWidget] = Field(default_factory=list, exclude=True)
-
-    def __init__(
-        self,
-        widgets: List[InputWidget],
-    ) -> None:
-        self.widgets = widgets
-        self.emitter = get_emitter()
-
-    def settings(self):
-        return dict(
-            [(input_widget.key, input_widget.initial) for input_widget in self.widgets]
-        )
-
-    async def send(self):
-        settings = self.settings()
-        self.emitter.set_chat_settings(settings)
-
-        widgets_content = [input_widget.to_dict() for input_widget in self.widgets]
-        await self.emitter.emit("chat_settings", widgets_content)
-
-        return settings
-
-
-@dataclass
 class Switch(InputWidget):
-    """Useful to create a switch input in the settings element."""
+    """Useful to create a switch input."""
 
     type: InputWidgetType = "switch"
     initial: bool = False
@@ -89,7 +60,7 @@ class Switch(InputWidget):
 
 @dataclass
 class Slider(InputWidget):
-    """Useful to create a slider input in the settings element."""
+    """Useful to create a slider input."""
 
     type: InputWidgetType = "slider"
     initial: float = 0
@@ -131,8 +102,8 @@ class Slider(InputWidget):
 
 
 @dataclass
-class SelectInput(InputWidget):
-    """Useful to create a select input in the settings element."""
+class Select(InputWidget):
+    """Useful to create a select input."""
 
     type: InputWidgetType = "select"
     initial: Optional[str] = None
@@ -162,7 +133,7 @@ class SelectInput(InputWidget):
 
         if values is None and initial_index is not None:
             raise ValueError(
-                "Initial_index can only be used in combination with values to create a SelectInput"
+                "Initial_index can only be used in combination with values to create a Select"
             )
 
         self.id = id
@@ -193,7 +164,7 @@ class SelectInput(InputWidget):
 
 @dataclass
 class TextInput(InputWidget):
-    """Useful to create a text input in the settings element."""
+    """Useful to create a text input."""
 
     type: InputWidgetType = "textinput"
     initial: Optional[str] = None
@@ -221,6 +192,39 @@ class TextInput(InputWidget):
             "label": self.label,
             "initial": self.initial,
             "placeholder": self.placeholder,
+            "tooltip": self.tooltip,
+            "description": self.description,
+        }
+
+
+@dataclass
+class Tags(InputWidget):
+    """Useful to create an input for an array of strings."""
+
+    type: InputWidgetType = "tags"
+    initial: List[str] = Field(default_factory=lambda: list)
+    values: List[str] = Field(default_factory=lambda: list)
+
+    def __init__(
+        self,
+        id: str,
+        label: str,
+        initial: Optional[List[str]] = None,
+        tooltip: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.id = id
+        self.label = label
+        if initial is not None:
+            self.initial = initial
+        super().__post_init__(tooltip, description)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "id": self.id,
+            "label": self.label,
+            "initial": self.initial,
             "tooltip": self.tooltip,
             "description": self.description,
         }

--- a/src/chainlit/session.py
+++ b/src/chainlit/session.py
@@ -54,6 +54,7 @@ class Session:
         self.should_stop = False
         self.restored = False
         self.id = id
+        self.chat_settings: Dict[str, Any] = {}
 
         sessions_id[self.id] = self
         sessions_sid[socket_id] = self

--- a/src/chainlit/socket.py
+++ b/src/chainlit/socket.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from typing import Any, Dict
 
 from chainlit.action import Action
 from chainlit.client.base import MessageDict
@@ -204,3 +205,17 @@ async def call_action(sid, action):
     action = Action(**action)
 
     await process_action(action)
+
+
+@socket.on("chat_settings_change")
+async def change_settings(sid, settings: Dict[str, Any]):
+    """Handle change settings submit from the UI."""
+    session = Session.require(sid)
+    emitter_var.set(ChainlitEmitter(session))
+    loop_var.set(asyncio.get_event_loop())
+
+    for key, value in settings.items():
+        session.chat_settings[key] = value
+
+    if config.code.on_settings_update:
+        await config.code.on_settings_update(settings)

--- a/src/chainlit/types.py
+++ b/src/chainlit/types.py
@@ -4,6 +4,7 @@ from dataclasses_json import DataClassJsonMixin
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
+InputWidgetType = Literal["switch", "slider", "selectinput", "textinput"]
 ElementType = Literal[
     "image", "avatar", "text", "pdf", "tasklist", "audio", "video", "file"
 ]

--- a/src/chainlit/types.py
+++ b/src/chainlit/types.py
@@ -4,7 +4,7 @@ from dataclasses_json import DataClassJsonMixin
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
-InputWidgetType = Literal["switch", "slider", "selectinput", "textinput"]
+InputWidgetType = Literal["switch", "slider", "select", "textinput", "tags"]
 ElementType = Literal[
     "image", "avatar", "text", "pdf", "tasklist", "audio", "video", "file"
 ]

--- a/src/chainlit/user_session.py
+++ b/src/chainlit/user_session.py
@@ -26,6 +26,7 @@ class UserSession:
         user_session["id"] = emitter.session.id
         user_session["env"] = emitter.session.user_env
         user_session["user_infos"] = emitter.session.auth_client.user_infos
+        user_session["chat_settings"] = emitter.session.chat_settings
         if emitter.session.root_message:
             user_session["root_message"] = emitter.session.root_message
 


### PR DESCRIPTION
I've implemented a way to change chat settings so that a user is able to tweak LLM, Agent and other tool settings to their liking. To demonstrate, I used the image-gen cookbook example and adapted it to give the user more options to generate beautiful images (Looking forward to your feedback!):

<details>
<summary>Show Image 1 (512x512)</summary>

  ![Screenshot 2023-07-25 213916](https://github.com/Chainlit/chainlit/assets/10130747/4e44956f-d444-4258-988c-022c57f5e5db)
  ![Screenshot 2023-07-25 213945](https://github.com/Chainlit/chainlit/assets/10130747/e2a28812-8bfd-485d-b2f8-b90f5e727131)

</details>

<details>
<summary>Show Image 2 (256x256)</summary>

![Screenshot 2023-07-25 213823](https://github.com/Chainlit/chainlit/assets/10130747/0873f11e-bc8a-4a87-a23a-b39fd9b7913c)
![Screenshot 2023-07-25 213852](https://github.com/Chainlit/chainlit/assets/10130747/0c41ed48-d1b2-4fc2-a36c-0534f3d3eba9)

</details>

<details>
<summary>Show Code app.py</summary>

```python
from langchain.agents import AgentExecutor, AgentType, initialize_agent
from langchain.agents.structured_chat.prompt import SUFFIX
from langchain.chat_models import ChatOpenAI
from langchain.memory import ConversationBufferMemory
from utils.tools import edit_image_tool, generate_image_tool

import chainlit as cl
from chainlit.action import Action


@cl.action_callback("Create variation")
async def create_variant(action: Action):
    agent_input = f"Create a variation of {action.value}"
    await cl.Message(content=f"Creating a variation of `{action.value}`.").send()
    await main(agent_input)


@cl.author_rename
def rename(orig_author):
    mapping = {
        "LLMChain": "Assistant",
    }
    return mapping.get(orig_author, orig_author)


@cl.cache
def get_memory():
    return ConversationBufferMemory(memory_key="chat_history")


@cl.on_chat_start
async def start():
    settings = await cl.ChatSettings(
        [
            cl.SelectInput(
                key="Model",
                label="OpenAI - Model",
                values=["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "gpt-4-32k"],
                initial_index=0
            ),
            cl.Switch(key="Streaming", label="OpenAI - Stream Tokens", initial=True),
            cl.Slider(key="Temperature", label="OpenAI - Temperature", initial=1, min=0, max=2, step=0.1),
            cl.Slider(key="SAI_Steps", label="Stability AI - Steps", initial=30, min=10, max=150, step=1, description="Amount of inference steps performed on image generation."),
            cl.Slider(key="SAI_Cfg_Scale", label="Stability AI - Cfg_Scale", initial=7, min=1, max=35, step=0.1, description="Influences how strongly your generation is guided to match your prompt."),
            cl.Slider(key="SAI_Width", label="Stability AI - Image Width", initial=512, min=256, max=2048, step=64, tooltip="Measured in pixels"),
            cl.Slider(key="SAI_Height", label="Stability AI - Image Height", initial=512, min=256, max=2048, step=64, tooltip="Measured in pixels"),
        ]
    ).send()
    print("on_chat_start", settings)
    print(cl.user_session.get("chat_settings"))
    await setup_agent(settings)


@cl.on_settings_update
async def setup_agent(settings):
    print("on_settings_update", settings)

    llm = ChatOpenAI(temperature=settings['Temperature'], streaming=settings['Streaming'], model=settings['Model'])
    memory = get_memory()
    _SUFFIX = "Chat history:\n{chat_history}\n\n" + SUFFIX

    agent = initialize_agent(
        llm=llm,
        tools=[generate_image_tool, edit_image_tool],
        agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
        memory=memory,
        agent_kwargs={
            "suffix": _SUFFIX,
            "input_variables": ["input", "agent_scratchpad", "chat_history"],
        },
    )
    cl.user_session.set("agent", agent)


@cl.on_message
async def main(message):
    agent = cl.user_session.get("agent")  # type: AgentExecutor
    cl.user_session.set("generated_image", None)

    # No async implementation in the Stability AI client, fallback to sync
    res = await cl.make_async(agent.run)(
        input=message, callbacks=[cl.LangchainCallbackHandler()]
    )

    elements = []
    actions = []

    generated_image_name = cl.user_session.get("generated_image")
    generated_image = cl.user_session.get(generated_image_name)
    if generated_image:
        elements = [
            cl.Image(
                content=generated_image,
                name=generated_image_name,
                display="inline",
            )
        ]
        actions = [cl.Action(name="Create variation", value=generated_image_name)]

    await cl.Message(content=res, elements=elements, actions=actions).send()
```

</details>

<details>
<summary>Show Code tools.py</summary>

```python
import io
import os

import stability_sdk.interfaces.gooseai.generation.generation_pb2 as generation
from langchain.tools import StructuredTool, Tool
from PIL import Image
from stability_sdk import client

import chainlit as cl

os.environ["STABILITY_HOST"] = "grpc.stability.ai:443"


def get_image_name():
    image_count = cl.user_session.get("image_count")
    if image_count is None:
        image_count = 0
    else:
        image_count += 1

    cl.user_session.set("image_count", image_count)

    return f"image-{image_count}"


def _generate_image(prompt: str, init_image=None):
    # Set up our connection to the API.
    stability_api = client.StabilityInference(
        key=os.environ["STABILITY_KEY"],  # API Key reference.
        verbose=True,  # Print debug messages.
        engine="stable-diffusion-xl-beta-v2-2-2",  # Set the engine to use for generation.
        # Available engines: stable-diffusion-v1 stable-diffusion-v1-5 stable-diffusion-512-v2-0 stable-diffusion-768-v2-0
        # stable-diffusion-512-v2-1 stable-diffusion-768-v2-1 stable-diffusion-xl-beta-v2-2-2 stable-inpainting-v1-0 stable-inpainting-512-v2-0
    )

    start_schedule = 0.8 if init_image else 1

    cl_chat_settings = cl.user_session.get("chat_settings")
    print(cl_chat_settings)

    # Set up our initial generation parameters.
    answers = stability_api.generate(
        prompt=prompt,
        init_image=init_image,
        start_schedule=start_schedule,
        seed=992446758,  # If a seed is provided, the resulting generated image will be deterministic.
        # What this means is that as long as all generation parameters remain the same, you can always recall the same image simply by generating it again.
        # Note: This isn't quite the case for CLIP Guided generations, which we tackle in the CLIP Guidance documentation.
        steps=int(cl_chat_settings["SAI_Steps"]),  # Amount of inference steps performed on image generation. Defaults to 30.
        cfg_scale=cl_chat_settings["SAI_Cfg_Scale"],  # Influences how strongly your generation is guided to match your prompt.
        # Setting this value higher increases the strength in which it tries to match your prompt.
        # Defaults to 7.0 if not specified.
        width=int(cl_chat_settings["SAI_Width"]),  # Generation width, defaults to 512 if not included.
        height=int(cl_chat_settings["SAI_Height"]),  # Generation height, defaults to 512 if not included.
        samples=1,  # Number of images to generate, defaults to 1 if not included.
        sampler=generation.SAMPLER_K_EULER  # Choose which sampler we want to denoise our generation with.
        # Defaults to k_dpmpp_2m if not specified. Clip Guidance only supports ancestral samplers.
        # (Available Samplers: ddim, plms, k_euler, k_euler_ancestral, k_heun, k_dpm_2, k_dpm_2_ancestral, k_dpmpp_2s_ancestral, k_lms, k_dpmpp_2m, k_dpmpp_sde)
    )

    # Set up our warning to print to the console if the adult content classifier is tripped.
    # If adult content classifier is not tripped, save generated images.
    for resp in answers:
        for artifact in resp.artifacts:
            if artifact.finish_reason == generation.FILTER:
                raise ValueError(
                    "Your request activated the API's safety filters and could not be processed."
                    "Please modify the prompt and try again."
                )
            if artifact.type == generation.ARTIFACT_IMAGE:
                name = get_image_name()
                cl.user_session.set(name, artifact.binary)
                cl.user_session.set("generated_image", name)
                return name
            else:
                raise ValueError(
                    f"Your request did not generate an image. Please modify the prompt and try again. Finish reason: {artifact.finish_reason}"
                )


def generate_image(prompt: str):
    image_name = _generate_image(prompt)
    return f"Here is {image_name}."


def edit_image(init_image_name: str, prompt: str):
    init_image_bytes = cl.user_session.get(init_image_name)
    if init_image_bytes is None:
        raise ValueError(f"Could not find image `{init_image_name}`.")

    init_image = Image.open(io.BytesIO(init_image_bytes))
    image_name = _generate_image(prompt, init_image)

    return f"Here is {image_name} based on {init_image_name}."


generate_image_tool = Tool.from_function(
    func=generate_image,
    name="GenerateImage",
    description="Useful to create an image from a text prompt.",
    return_direct=True,
)

edit_image_tool = StructuredTool.from_function(
    func=edit_image,
    name="EditImage",
    description="Useful to edit an image with a prompt. Works well with commands such as 'replace', 'add', 'change', 'remove'.",
    return_direct=True,
)
```

</details>