### PR TITLE
add a Tags input

### DIFF
--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -7,8 +7,10 @@ from dotenv import load_dotenv
 if TYPE_CHECKING:
     from chainlit.client.base import BaseDBClient, UserDict
 
+import chainlit.input_widget as input_widget
 from chainlit.action import Action
 from chainlit.cache import cache
+from chainlit.chat_settings import ChatSettings
 from chainlit.config import config
 from chainlit.element import (
     Audio,
@@ -24,7 +26,6 @@ from chainlit.element import (
     Video,
 )
 from chainlit.haystack import HAYSTACK_INSTALLED
-from chainlit.input_widget import ChatSettings, SelectInput, Slider, Switch, TextInput
 from chainlit.lc import LANGCHAIN_INSTALLED
 from chainlit.llama_index import LLAMA_INDEX_INSTALLED
 from chainlit.logger import logger
@@ -190,10 +191,7 @@ __all__ = [
     "TaskStatus",
     "Video",
     "ChatSettings",
-    "Switch",
-    "Slider",
-    "SelectInput",
-    "TextInput",
+    "input_widget",
     "Message",
     "ErrorMessage",
     "AskUserMessage",

--- a/src/chainlit/chat_settings.py
+++ b/src/chainlit/chat_settings.py
@@ -1,0 +1,34 @@
+from typing import List
+
+from pydantic.dataclasses import Field, dataclass
+
+from chainlit.context import get_emitter
+from chainlit.input_widget import InputWidget
+
+
+@dataclass
+class ChatSettings:
+    """Useful to create chat settings that the user can change."""
+
+    widgets: List[InputWidget] = Field(default_factory=list, exclude=True)
+
+    def __init__(
+        self,
+        widgets: List[InputWidget],
+    ) -> None:
+        self.widgets = widgets
+        self.emitter = get_emitter()
+
+    def settings(self):
+        return dict(
+            [(input_widget.key, input_widget.initial) for input_widget in self.widgets]
+        )
+
+    async def send(self):
+        settings = self.settings()
+        self.emitter.set_chat_settings(settings)
+
+        widgets_content = [input_widget.to_dict() for input_widget in self.widgets]
+        await self.emitter.emit("chat_settings", widgets_content)
+
+        return settings

--- a/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
@@ -96,7 +96,7 @@ export default function ChatSettingsModal() {
             <FormHelperText>{element.description}</FormHelperText>
           </Box>
         );
-      case 'selectinput':
+      case 'select':
         return (
           <SelectInput
             key={element.key}

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -107,7 +107,7 @@ export interface ISliderWidget extends TInputWidget<'slider'> {
   step: number;
 }
 
-export interface ISelectInputWidget extends TInputWidget<'selectinput'> {
+export interface ISelectInputWidget extends TInputWidget<'select'> {
   initial?: string;
   options: { label: string; value: string }[];
 }

--- a/src/chainlit/types.py
+++ b/src/chainlit/types.py
@@ -4,7 +4,7 @@ from dataclasses_json import dataclass_json
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
-InputWidgetType = Literal["switch", "slider", "selectinput", "textinput"]
+InputWidgetType = Literal["switch", "slider", "select", "textinput", "tags"]
 ElementType = Literal[
     "image", "avatar", "text", "pdf", "tasklist", "audio", "video", "file"
 ]


### PR DESCRIPTION
- One use case is for example configuring the list of stopwords for LLMs
- Also renamed "SelectInput" to "Select" as they are exposed throught "input_widget"
- Moved the ChatSettings in a separate file to enable using the input widgets outside of the chat settings