### PR TITLE
FormInput improvements

### DIFF
--- a/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
+++ b/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
@@ -20,7 +20,7 @@ export default function inputLabel({
     <Box display="flex" justifyContent="space-between" width="100%">
       <Box display="flex" gap={0.5} alignItems="center">
         <InputLabel
-          id={id}
+          htmlFor={id}
           sx={{
             fontWeight: 600,
             fontSize: '12px',

--- a/src/chainlit/frontend/src/components/organisms/FormInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/FormInput.tsx
@@ -7,46 +7,45 @@ import TagsInput, { TagsInputProps } from './inputs/tagsInput';
 import TextInput, { TextInputProps } from './inputs/textInput';
 import Slider, { SliderProps } from './slider';
 
-export type FormInitial =
-  | string
-  | number
-  | boolean
-  | string[]
-  | number[]
-  | undefined;
+export type TFormInputValue = string | number | boolean | string[] | undefined;
 
-export interface IFormInput<T> extends IInput {
+export interface IFormInput<T, V extends TFormInputValue> extends IInput {
   type: T;
+  value?: V;
+  setField?(field: string, value: V, shouldValidate?: boolean): void;
 }
 
 export type TFormInput =
-  | (SwitchProps & IFormInput<'switch'>)
-  | (SliderProps & IFormInput<'slider'>)
-  | (SelectInputProps & IFormInput<'select'>)
-  | (TextInputProps & IFormInput<'textinput'>)
-  | (TagsInputProps & IFormInput<'tags'>);
+  | (Omit<SwitchProps, 'checked'> & IFormInput<'switch', boolean>)
+  | (Omit<SliderProps, 'value'> & IFormInput<'slider', number>)
+  | (Omit<SelectInputProps, 'value'> & IFormInput<'select', string>)
+  | (Omit<TextInputProps, 'value'> & IFormInput<'textinput', string>)
+  | (Omit<TagsInputProps, 'value'> & IFormInput<'tags', string[]>);
 
 const FormInput = ({ element }: { element: TFormInput }): JSX.Element => {
   switch (element.type) {
     case 'select':
-      return <SelectInput {...element} />;
+      return <SelectInput {...element} value={element.value ?? ''} />;
     case 'slider':
-      return <Slider {...element} />;
+      return <Slider {...element} value={element.value ?? 0} />;
     case 'tags':
-      return <TagsInput {...element} />;
+      return <TagsInput {...element} value={element.value ?? []} />;
     case 'switch':
       return (
         <Switch
           {...element}
+          checked={!!element.value}
           inputProps={{
-            id: element.id || undefined,
+            id: element.id,
             name: element.id
           }}
         />
       );
     case 'textinput':
-      return <TextInput {...element} placeholder={element.placeholder} />;
+      return <TextInput {...element} value={element.value ?? ''} />;
     default:
+      // Unimplemented element type if this errors
+      element satisfies never;
       return <></>;
   }
 };

--- a/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
@@ -20,7 +20,7 @@ import {
   sessionState
 } from 'state/chat';
 
-import FormInput, { FormInitial, TFormInput } from '../FormInput';
+import FormInput, { TFormInputValue } from '../FormInput';
 
 export default function ChatSettingsModal() {
   const session = useRecoilValue(sessionState);
@@ -42,7 +42,7 @@ export default function ChatSettingsModal() {
   const handleConfirm = () => {
     setChatSettingsValue(formik.values);
 
-    const values = mapValues(formik.values, (x: FormInitial) =>
+    const values = mapValues(formik.values, (x: TFormInputValue) =>
       x !== '' ? x : null
     );
     session?.socket.emit('chat_settings_change', values);
@@ -51,53 +51,6 @@ export default function ChatSettingsModal() {
   };
   const handleReset = () => {
     formik.setValues(chatSettingsDefaultValue);
-  };
-
-  const renderInput = (element: TFormInput): JSX.Element | undefined => {
-    switch (element.type) {
-      case 'switch':
-        return (
-          <FormInput
-            key={element.id}
-            element={{
-              ...element,
-              checked: formik.values[element.id] ?? false
-            }}
-          />
-        );
-      case 'slider':
-        return (
-          <FormInput
-            key={element.id}
-            element={{
-              ...element,
-              value: formik.values[element.id] ?? 0
-            }}
-          />
-        );
-      case 'select':
-        return (
-          <FormInput
-            key={element.id}
-            element={{
-              ...element,
-              value: formik.values[element.id] ?? ''
-            }}
-          />
-        );
-      case 'textinput':
-        return (
-          <FormInput
-            key={element.id}
-            element={{
-              ...element,
-              value: formik.values[element.id] ?? '',
-              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
-                formik.setFieldValue(element.id, e.target.value)
-            }}
-          />
-        );
-    }
   };
 
   return (
@@ -122,12 +75,17 @@ export default function ChatSettingsModal() {
             gap: '15px'
           }}
         >
-          {chatSettings.inputs.map((input) =>
-            renderInput({
-              ...input,
-              onChange: formik.handleChange
-            })
-          )}
+          {chatSettings.inputs.map((input) => (
+            <FormInput
+              key={input.id}
+              element={{
+                ...input,
+                value: formik.values[input.id],
+                onChange: formik.handleChange,
+                setField: formik.setFieldValue
+              }}
+            />
+          ))}
         </Box>
       </DialogContent>
       <DialogActions sx={{ p: 2 }}>

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -98,7 +98,6 @@ export default function SelectInput({
         value={value?.toString()}
         onChange={onChange}
         size={size}
-        name={name || id}
         disabled={disabled}
         renderValue={() =>
           (renderLabel && renderLabel()) ||
@@ -111,6 +110,8 @@ export default function SelectInput({
             '0px 10px 10px 0px rgba(0, 0, 0, 0.05), 0px 2px 4px 0px rgba(0, 0, 0, 0.05)'
         }}
         inputProps={{
+          id: id,
+          name: name || id,
           sx: {
             px: '16px',
             py: size === 'small' ? '10px' : '14px'

--- a/src/chainlit/frontend/src/components/organisms/inputs/tagsInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/tagsInput.tsx
@@ -1,4 +1,4 @@
-import { MuiChipsInput, MuiChipsInputChip } from 'mui-chips-input';
+import { MuiChipsInput } from 'mui-chips-input';
 
 import { IInput } from 'types/Input';
 
@@ -7,17 +7,18 @@ import InputStateHandler from './inputStateHandler';
 export type TagsInputProps = {
   placeholder?: string;
   value?: string[];
-  onChange?: (value: MuiChipsInputChip[]) => void;
-} & IInput;
+  setField?(field: string, value: string[], shouldValidate?: boolean): void;
+} & IInput &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'color'>;
 
 export default function TagsInput({
   description,
-  disabled,
   hasError,
   id,
   label,
   size = 'small',
   tooltip,
+  setField,
   ...rest
 }: TagsInputProps): JSX.Element {
   return (
@@ -28,7 +29,15 @@ export default function TagsInput({
       label={label}
       tooltip={tooltip}
     >
-      <MuiChipsInput {...rest} size={size} name={id} id={id} />
+      <MuiChipsInput
+        {...rest}
+        size={size}
+        onChange={(value) => setField?.(id, value, false)}
+        inputProps={{
+          id: id,
+          name: id
+        }}
+      />
     </InputStateHandler>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/inputs/textInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/textInput.tsx
@@ -32,6 +32,8 @@ export default function TextInput({
         disabled={disabled}
         inputProps={{
           ...rest,
+          id: id,
+          name: id,
           sx: { height: size === 'small' ? '7px' : '15px' }
         }}
         fullWidth

--- a/src/chainlit/frontend/src/pages/Design.tsx
+++ b/src/chainlit/frontend/src/pages/Design.tsx
@@ -97,7 +97,7 @@ export default function Design(): JSX.Element {
             type: 'switch',
             id: 'design-switch',
             onChange: onDarkModeChange,
-            checked: isDarkMode,
+            value: isDarkMode,
             inputProps: {
               'aria-labelledby': 'switch-theme'
             }
@@ -166,7 +166,7 @@ export default function Design(): JSX.Element {
               type: 'switch',
               id: 'design-switch',
               onChange: onDarkModeChange,
-              checked: isDarkMode,
+              value: isDarkMode,
               inputProps: {
                 'aria-labelledby': 'switch-theme'
               }

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -1,7 +1,7 @@
 import { atom, selector } from 'recoil';
 import { Socket } from 'socket.io-client';
 
-import { FormInitial, TFormInput } from 'components/organisms/FormInput';
+import { TFormInput, TFormInputValue } from 'components/organisms/FormInput';
 
 import { IMessageElement } from './element';
 import { IMember } from './user';
@@ -138,7 +138,7 @@ export const chatSettingsDefaultValueSelector = selector({
     return chatSettings.inputs.reduce(
       (
         form: { [key: string]: any },
-        input: TFormInput & { initial?: FormInitial }
+        input: TFormInput & { initial?: TFormInputValue }
       ) => ((form[input.id] = input.initial), form),
       {}
     );

--- a/src/chainlit/frontend/tsconfig.json
+++ b/src/chainlit/frontend/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",


### PR DESCRIPTION
This PR contains several changes:

- I changed the InputLabel id={id} to htmlFor={id} to make sure that the labels are linked to the inputs. I was unable to make it work using the id attribute. (Normally MUI does this for us using the id attribute, but this didn't work for some reason)
- Changes to FormInput as discussed to make sure that it is always in a controlled state (and won't switch to uncontrolled if passed null or undefined as a value)
- Some fixes to make sure that formik.handleChange works.
- I had to use formik.setField for the tagsInput since the mui-chips-input doesn't expose an onChange event handle. Not really happy about my solution since now tagsInput 'knows' about Formik. 
- I added 'strictNullChecks' to the tsconfig.json file and added a check to make sure that the FormInput switch case throws an error if a case is not implemented.

Any feedback welcome!