### PR TITLE
fix: GraphQL "createMessage" failure, Optional "ID" should not be placed in front of a required argument.

### DIFF
--- a/src/chainlit/client/cloud.py
+++ b/src/chainlit/client/cloud.py
@@ -342,7 +342,7 @@ class CloudDBClient(BaseDBClient, GraphQLClient):
         variables["conversationId"] = c_id
 
         mutation = """
-        mutation ($id: ID, $conversationId: ID!, $author: String!, $content: String!, $language: String, $prompt: String, $llmSettings: Json, $isError: Boolean, $parentId: String, $indent: Int, $authorIsUser: Boolean, $waitForAnswer: Boolean, $createdAt: StringOrFloat) {
+        mutation ($id: ID!, $conversationId: ID!, $author: String!, $content: String!, $language: String, $prompt: String, $llmSettings: Json, $isError: Boolean, $parentId: String, $indent: Int, $authorIsUser: Boolean, $waitForAnswer: Boolean, $createdAt: StringOrFloat) {
             createMessage(id: $id, conversationId: $conversationId, author: $author, content: $content, language: $language, prompt: $prompt, llmSettings: $llmSettings, isError: $isError, parentId: $parentId, indent: $indent, authorIsUser: $authorIsUser, waitForAnswer: $waitForAnswer, createdAt: $createdAt) {
                 id
             }


### PR DESCRIPTION
How to reproduce this bugs:

1) modify the generate `.chainlit/config.toml`
```
[project]
public = false
id = "YOUR_PROJECT_ID"
database = "cloud"
...
```

2) run the app
```sh
cd src && poetry run chainlit run ../cypress/e2e/tasklist/main.py
```

3) Logs of the error:
```
2023-08-04 14:13:48 - {'message': "Variable '$id' of type 'ID' used in position expecting type 'ID!'.", 'locations': [{'line': 2, 'column': 19}, {'line': 3, 'column': 31}]}
2023-08-04 14:13:48 - Could not create message.
```