### PR TITLE
fix: mui warning on Tooltip component wrap a disabled Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv
 
 .DS_Store
 
+.chainlit
 chainlit.md
 
 cypress/screenshots

--- a/src/chainlit/frontend/src/components/atoms/action/ref.tsx
+++ b/src/chainlit/frontend/src/components/atoms/action/ref.tsx
@@ -33,9 +33,11 @@ export default function ActionRef({ action }: Props) {
   const formattedName = action.name.trim().toLowerCase().replaceAll(' ', '-');
   const className = `action-${formattedName}`;
   const button = (
-    <LoadingButton className={className} onClick={call} disabled={loading}>
-      {action.label || action.name}
-    </LoadingButton>
+    <span>
+      <LoadingButton className={className} onClick={call} disabled={loading}>
+        {action.label || action.name}
+      </LoadingButton>
+    </span>
   );
   if (action.description) {
     return (


### PR DESCRIPTION
When a disabled `Button` was provided to the `Tooltip` component, a mui warning will occur:

```txt
Tooltip.js:276 MUI: You are providing a disabled `button` child to the Tooltip component.
A disabled element does not fire events.
Tooltip needs to listen to the child element's events to display the title.

Add a simple wrapper element, such as a `span`.
```

Noted: This warning text display on development, not on production.