### PR TITLE
run cypress once

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,8 +13,14 @@ export default defineConfig({
     supportFile: false,
     defaultCommandTimeout: 10000,
     video: false,
+    baseUrl: "http://127.0.0.1:8000",
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      on("task", {
+        log(message) {
+          console.log(message);
+          return null;
+        }
+      });
     },
   },
 });

--- a/cypress/e2e/action/spec.cy.ts
+++ b/cypress/e2e/action/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Action", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should correctly execute and display actions", () => {    

--- a/cypress/e2e/ask_file/spec.cy.ts
+++ b/cypress/e2e/ask_file/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Upload file", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to receive and decode files", () => {

--- a/cypress/e2e/ask_multiple_files/spec.cy.ts
+++ b/cypress/e2e/ask_multiple_files/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Upload multiple files", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to receive two files", () => {

--- a/cypress/e2e/ask_user/spec.cy.ts
+++ b/cypress/e2e/ask_user/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("Ask User", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should send a new message containing the user input", () => {

--- a/cypress/e2e/audio_element/spec.cy.ts
+++ b/cypress/e2e/audio_element/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("audio", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display an audio element", () => {

--- a/cypress/e2e/auth_client_factory/spec.cy.ts
+++ b/cypress/e2e/auth_client_factory/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Auth Custom client", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should call the custom client", () => {

--- a/cypress/e2e/author_rename/spec.cy.ts
+++ b/cypress/e2e/author_rename/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("Author rename", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to rename authors", () => {

--- a/cypress/e2e/avatar/spec.cy.ts
+++ b/cypress/e2e/avatar/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Avatar", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display a nested CoT", () => {

--- a/cypress/e2e/cot/spec.cy.ts
+++ b/cypress/e2e/cot/spec.cy.ts
@@ -1,4 +1,4 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 function testPlayground(index, shouldContain: string) {
   cy.get(".playground-button").eq(index).should("exist").click();
@@ -14,9 +14,7 @@ function testPlayground(index, shouldContain: string) {
 
 describe("Chain of Thought", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display a nested CoT", () => {

--- a/cypress/e2e/custom_route/spec.cy.ts
+++ b/cypress/e2e/custom_route/spec.cy.ts
@@ -1,6 +1,9 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Custom Route", () => {
   before(() => {
-    cy.visit("http://127.0.0.1:8000/hello");
+    runTestServer()
+    cy.visit("hello");
   });
 
   it("should correctly serve the custom route", () => {

--- a/cypress/e2e/db_client_factory/spec.cy.ts
+++ b/cypress/e2e/db_client_factory/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Db Custom client", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should call the custom client", () => {

--- a/cypress/e2e/default_expand_cot/spec.cy.ts
+++ b/cypress/e2e/default_expand_cot/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("Default Expand", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to set the default_expand_messages field in the config to have the CoT expanded by default", () => {

--- a/cypress/e2e/error_handling/spec.cy.ts
+++ b/cypress/e2e/error_handling/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Error Handling", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should correctly display errors", () => {

--- a/cypress/e2e/file_element/spec.cy.ts
+++ b/cypress/e2e/file_element/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("file", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display a file element", () => {

--- a/cypress/e2e/global_elements/spec.cy.ts
+++ b/cypress/e2e/global_elements/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Global Elements", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display inlined, side and page elements", () => {

--- a/cypress/e2e/haystack_cb/spec.cy.ts
+++ b/cypress/e2e/haystack_cb/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Haystack Callback", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to send messages to the UI with prompts and elements", () => {

--- a/cypress/e2e/headers/spec.cy.ts
+++ b/cypress/e2e/headers/spec.cy.ts
@@ -1,10 +1,11 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Initial headers", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000", {
+    runTestServer()
+    cy.visit("/", {
       headers: { "test-header": "test header value" },
     });
-    cy.wait(["@settings"]);
   });
 
   it("should be able to access initial headers", () => {

--- a/cypress/e2e/langchain_cb/spec.cy.ts
+++ b/cypress/e2e/langchain_cb/spec.cy.ts
@@ -1,11 +1,11 @@
-describe("Langchain Callback", () => {
+import { describeSyncAsync, runTestServer } from "../../support/testUtils";
+
+describeSyncAsync("Langchain Callback", (mode) => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer(mode)
   });
 
-  it("should be able to send messages to the UI with prompts", () => {
+  it("it should be able to send messages to the UI with prompts", () => {
     cy.get("#welcome-screen").should("exist");
 
     cy.get(".message").should("have.length", 1);

--- a/cypress/e2e/llama_index_cb/spec.cy.ts
+++ b/cypress/e2e/llama_index_cb/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Llama Index Callback", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to send messages to the UI with prompts and elements", () => {

--- a/cypress/e2e/local_db/spec.cy.ts
+++ b/cypress/e2e/local_db/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("Local db", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to see and interact with a stored conversation", () => {
@@ -26,7 +24,7 @@ describe("Local db", () => {
       .find(".positive-feedback-on")
       .should("have.length", 1);
 
-    cy.visit("http://127.0.0.1:8000/dataset");
+    cy.visit("dataset");
     cy.get(".conversation-row").should("have.length", 1);
 
     cy.get(".open-conversation-button").click();

--- a/cypress/e2e/message_history/spec.cy.ts
+++ b/cypress/e2e/message_history/spec.cy.ts
@@ -1,14 +1,13 @@
 import {
   closeHistory,
   openHistory,
+  runTestServer,
   submitMessage,
 } from "../../support/testUtils";
 
 describe("Message History", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to show the last message in the message history", () => {

--- a/cypress/e2e/on_chat_start/spec.cy.ts
+++ b/cypress/e2e/on_chat_start/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("on_chat_start", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should correctly run on_chat_start", () => {

--- a/cypress/e2e/openai/spec.cy.ts
+++ b/cypress/e2e/openai/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { describeSyncAsync, runTestServer, submitMessage } from "../../support/testUtils";
 
-describe("OpenAI", () => {
+describeSyncAsync("OpenAI", (mode) => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer(mode)
   });
 
   it("should output an SQL query", () => {

--- a/cypress/e2e/pyplot/spec.cy.ts
+++ b/cypress/e2e/pyplot/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("pyplot", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display an inline chart", () => {

--- a/cypress/e2e/remove_elements/spec.cy.ts
+++ b/cypress/e2e/remove_elements/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("remove_elements", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to remove elements", () => {

--- a/cypress/e2e/remove_message/spec.cy.ts
+++ b/cypress/e2e/remove_message/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("Delete Message", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to delete a message", () => {

--- a/cypress/e2e/scoped_elements/spec.cy.ts
+++ b/cypress/e2e/scoped_elements/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Scoped Elements", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display inlined, side and page elements", () => {

--- a/cypress/e2e/sdk_availability/spec.cy.ts
+++ b/cypress/e2e/sdk_availability/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Emitter should be reachable from all contexts", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should find the Emitter from async, make_async and async_from_sync contexts", () => {

--- a/cypress/e2e/stop_task/spec.cy.ts
+++ b/cypress/e2e/stop_task/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { describeSyncAsync, runTestServer, submitMessage } from "../../support/testUtils";
 
-describe("Stop task", () => {
+describeSyncAsync("Stop task", (mode) => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer(mode)
   });
 
   it("should be able to stop a task", () => {

--- a/cypress/e2e/streaming/spec.cy.ts
+++ b/cypress/e2e/streaming/spec.cy.ts
@@ -1,3 +1,5 @@
+import { runTestServer } from "../../support/testUtils";
+
 function testStreamedMessage(index: number) {
   const tokenList = ["the", "quick", "brown", "fox"];
   for (const token of tokenList) {
@@ -8,9 +10,7 @@ function testStreamedMessage(index: number) {
 
 describe("Streaming", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to stream a message", () => {

--- a/cypress/e2e/tasklist/spec.cy.ts
+++ b/cypress/e2e/tasklist/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("tasklist", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should display the tasklist ", () => {

--- a/cypress/e2e/update_message/spec.cy.ts
+++ b/cypress/e2e/update_message/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("Update Message", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to update a message", () => {

--- a/cypress/e2e/user_env/spec.cy.ts
+++ b/cypress/e2e/user_env/spec.cy.ts
@@ -1,10 +1,8 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 describe("User Env", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to ask a user for required keys", () => {

--- a/cypress/e2e/user_session/spec.cy.ts
+++ b/cypress/e2e/user_session/spec.cy.ts
@@ -1,4 +1,4 @@
-import { submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from "../../support/testUtils";
 
 function newSession() {
   cy.get("#new-chat-button").should("exist").click();
@@ -12,9 +12,7 @@ function newSession() {
 
 describe("User Session", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to store data related per user session", () => {

--- a/cypress/e2e/video_element/spec.cy.ts
+++ b/cypress/e2e/video_element/spec.cy.ts
@@ -1,8 +1,8 @@
+import { runTestServer } from "../../support/testUtils";
+
 describe("video", () => {
   before(() => {
-    cy.intercept("/project/settings").as("settings");
-    cy.visit("http://127.0.0.1:8000");
-    cy.wait(["@settings"]);
+    runTestServer()
   });
 
   it("should be able to display a video element", () => {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,20 +1,15 @@
 import * as dotenv from "dotenv";
 dotenv.config();
-import { installChainlit, runTests, runTest } from "./utils";
+import { installChainlit, runTests } from "./utils";
 
 async function main() {
-  const singleTest = process.env.SINGLE_TEST;
+  const matchName = process.env.SINGLE_TEST || "*";
   const skipBuild = process.env.SKIP_BUILD;
 
   if (!skipBuild) {
     await installChainlit();
   }
-
-  if (singleTest) {
-    await runTest(singleTest);
-  } else {
-    await runTests();
-  }
+  await runTests(matchName);
 }
 
 main()

--- a/cypress/support/run.ts
+++ b/cypress/support/run.ts
@@ -1,0 +1,95 @@
+import { join } from "path";
+import { spawn } from "child_process";
+import sh from "shell-exec";
+import { existsSync, unlinkSync } from "fs";
+import * as kill from "kill-port";
+import { CHAINLIT_DIR, CHAINLIT_PORT, E2E_DIR, ExecutionMode, runCommand } from "./utils";
+
+interface CmdResult {
+  stdout: string;
+  stderr: string;
+}
+
+const killPort = async (port: number): Promise<CmdResult> => {
+  if (process.platform === 'win32') return kill(port)
+  
+  return sh(`lsof -nPi :${port}`)
+    .then(res => {
+      const { stdout } = res
+      if (!stdout) return Promise.reject(`No process running on port ${port}`)
+      return sh(
+        `lsof -nPi :${port} | grep 'LISTEN' | awk '{print $2}' | xargs kill -9`
+      )
+    })
+}
+
+function cleanLocalData(testDir: string) {
+  if (existsSync(join(testDir, ".chainlit/chat_files"))) {
+    runCommand("rm -rf .chainlit/chat_files", testDir)
+  }
+  if (existsSync(join(testDir, ".chainlit/chat.db"))) {
+    unlinkSync(join(testDir, ".chainlit/chat.db"));
+  }
+}
+
+export const runChainlitForTest =  async (testName: string, mode: ExecutionMode) => {
+  try {
+    await killPort(CHAINLIT_PORT)
+    console.log(`Process on port ${CHAINLIT_PORT} killed`)
+  } catch (error) {
+    console.log(`Could not kill process on port ${CHAINLIT_PORT}. ${error}.`)
+  }
+  return new Promise((resolve, reject) => {
+
+    const dir = join(E2E_DIR, testName);
+    let file = "main.py"
+    if (mode === ExecutionMode.Async) file = "main_async.py"
+    if (mode === ExecutionMode.Sync) file = "main_sync.py"
+
+    cleanLocalData(dir);
+
+    // Headless + CI mode
+    const options = [
+      "run",
+      "-C",
+      CHAINLIT_DIR,
+      "chainlit",
+      "run",
+      file,
+      "-h",
+      "-c",
+    ];
+
+    const server = spawn("poetry", options, {
+      cwd: dir,
+    });
+
+    server.stdout.on("data", (data) => {
+      console.log(`stdout: ${data}`);
+      if (data.toString().includes("Your app is available at")) {
+        resolve(server);
+      }
+    });
+
+    server.stderr.on("data", (data) => {
+      console.error(`stderr: ${data}`);
+    });
+
+    server.on("error", (error) => {
+      reject(error.message);
+    });
+
+    server.on("exit", function (code) {
+      reject("child process exited with code " + code);
+    });
+  });
+}
+
+runChainlitForTest(process.argv[2], process.argv[3] as ExecutionMode)
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/cypress/support/testUtils.ts
+++ b/cypress/support/testUtils.ts
@@ -1,3 +1,6 @@
+import { sep } from "path";
+import { ExecutionMode } from "./utils";
+
 export function submitMessage(message: string) {
   cy.wait(2000);
   cy.get(`#chat-input`).should("not.be.disabled");
@@ -12,4 +15,21 @@ export function openHistory() {
 
 export function closeHistory() {
   cy.get(`body`).click();
+}
+
+export function runTestServer(mode: ExecutionMode = undefined) {
+  const pathItems = Cypress.spec.absolute.split(sep);
+  const testName = pathItems[pathItems.length - 2];
+  cy.exec(`pnpm exec ts-node ./cypress/support/run.ts ${testName} ${mode}`);
+  cy.intercept("/project/settings").as("settings");
+  cy.visit("/");
+  cy.wait(["@settings"]);
+}
+
+export function describeSyncAsync(
+  title: string,
+  callback: (mode: ExecutionMode) => void
+) {
+  describe(`[sync] ${title}`, () => callback(ExecutionMode.Sync));
+  describe(`[async] ${title}`, () => callback(ExecutionMode.Async));
 }

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -1,95 +1,30 @@
-import * as kill from "tree-kill";
-import { execSync, spawn } from "child_process";
+import { execSync } from "child_process";
 import { join } from "path";
-import { readdirSync, existsSync, unlinkSync } from "fs";
 
 const ROOT = process.cwd();
-const E2E_DIR = join(ROOT, "cypress/e2e");
-const CHAINLIT_DIR = join(ROOT, "src");
+export const E2E_DIR = join(ROOT, "cypress/e2e");
+export const CHAINLIT_DIR = join(ROOT, "src");
 const FRONTEND_DIR = join(CHAINLIT_DIR, "chainlit", "frontend");
+export const CHAINLIT_PORT = 8000;
 
-const candidateFiles = ["main.py", "main_sync.py", "main_async.py"];
-
-const runLocal = [
-  "cot",
-  "global_elements",
-  "scoped_elements",
-  "update_message",
-  "remove_message",
-];
-
-function cleanLocalData(testDir: string) {
-  if (existsSync(join(testDir, ".chainlit/chat_files"))) {
-    execSync("rm -rf .chainlit/chat_files", {
-      encoding: "utf-8",
-      cwd: testDir,
-      env: process.env,
-      stdio: "inherit",
-    });
-  }
-  if (existsSync(join(testDir, ".chainlit/chat.db"))) {
-    unlinkSync(join(testDir, ".chainlit/chat.db"));
-  }
+export enum ExecutionMode {
+  Async = "async",
+  Sync = "sync",
 }
 
-export async function runTest(test: string) {
-  const testDir = join(E2E_DIR, test);
-  const variants = candidateFiles.filter((file) =>
-    existsSync(join(testDir, file))
+export async function runTests(matchName) {
+  // Cypress requires a healthcheck on the server at startup so let's run
+  // Chainlit before running tests to pass the healthcheck
+  runCommand("pnpm exec ts-node ./cypress/support/run.ts action");
+
+  // Recording the cypress run is time consuming. Disabled by default.
+  // const recordOptions = ` --record --key ${process.env.CYPRESS_RECORD_KEY} `;
+  return runCommand(
+    `pnpm exec cypress run --record false --spec "cypress/e2e/${matchName}/spec.cy.ts"`
   );
-
-  const runFiles = async (localDb = false) => {
-    for (const file of variants) {
-      let childProcess;
-
-      cleanLocalData(testDir);
-
-      console.log(`Running spec "${test}" with chainlit file "${file}"`);
-
-      if (localDb) {
-        console.log("Running with local db");
-      }
-
-      await new Promise(async (resolve, reject) => {
-        let testError: string | undefined = undefined;
-
-        try {
-          childProcess = await runChainlit(testDir, file, localDb);
-          runSpec(test);
-        } catch (err) {
-          testError = err;
-        } finally {
-          kill(childProcess.pid, "SIGKILL", function (err) {
-            if (err) {
-              console.log("Error while trying to kill process");
-            } else {
-              console.log("Process killed successfully");
-            }
-            if (testError) {
-              reject(testError);
-            } else {
-              resolve(true);
-            }
-          });
-        }
-      });
-    }
-  };
-
-  await runFiles();
-
-  if (runLocal.includes(test)) {
-    await runFiles(true);
-  }
 }
 
-export async function runTests() {
-  for (const test of readdirSync(E2E_DIR)) {
-    await runTest(test);
-  }
-}
-
-function runCommand(command: string, cwd = ROOT) {
+export function runCommand(command: string, cwd = ROOT) {
   return execSync(command, {
     encoding: "utf-8",
     cwd,
@@ -101,56 +36,4 @@ function runCommand(command: string, cwd = ROOT) {
 export function installChainlit() {
   runCommand("pnpm run build", FRONTEND_DIR);
   runCommand(`poetry install -C ${CHAINLIT_DIR} --with tests`);
-}
-
-export function runSpec(test: string) {
-  // Recording the cypress run is time consuming. Disabled by default.
-  // const recordOptions = ` --record --key ${process.env.CYPRESS_RECORD_KEY} `;
-  return runCommand(
-    `pnpm exec cypress run --record false --spec cypress/e2e/${test}/spec.cy.ts`
-  );
-}
-
-export async function runChainlit(dir: string, file: string, localDb = false) {
-  return new Promise((resolve, reject) => {
-    // Headless + CI mode
-    const options = [
-      "run",
-      "-C",
-      CHAINLIT_DIR,
-      "chainlit",
-      "run",
-      file,
-      "-h",
-      "-c",
-    ];
-
-    if (localDb) {
-      options.push("--db");
-      options.push("local");
-    }
-
-    const server = spawn("poetry", options, {
-      cwd: dir,
-    });
-
-    server.stdout.on("data", (data) => {
-      console.log(`stdout: ${data}`);
-      if (data.toString().includes("Your app is available at")) {
-        resolve(server);
-      }
-    });
-
-    server.stderr.on("data", (data) => {
-      console.error(`stderr: ${data}`);
-    });
-
-    server.on("error", (error) => {
-      reject(error.message);
-    });
-
-    server.on("exit", function (code) {
-      reject("child process exited with code " + code);
-    });
-  });
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "dotenv": "^16.0.3",
     "eslint": "^8.40.0",
     "husky": "^8.0.0",
+    "kill-port": "^2.0.1",
     "lint-staged": "^13.2.3",
     "prettier": "^2.8.8",
+    "shell-exec": "^1.1.2",
     "tree-kill": "^1.2.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,18 +23,24 @@ devDependencies:
   husky:
     specifier: ^8.0.0
     version: 8.0.0
+  kill-port:
+    specifier: ^2.0.1
+    version: 2.0.1
   lint-staged:
     specifier: ^13.2.3
     version: 13.2.3
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
+  shell-exec:
+    specifier: ^1.1.2
+    version: 1.1.2
   tree-kill:
     specifier: ^1.2.2
     version: 1.2.2
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@14.18.53)(typescript@5.0.4)
+    version: 10.9.1(@types/node@14.18.53)(@types/node@14.18.53)(typescript@5.0.4)
   typescript:
     specifier: ^5.0.4
     version: 5.0.4
@@ -1334,6 +1340,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /get-them-args@1.3.2:
+    resolution: {integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==}
+    dev: true
+
   /getos@3.2.1:
     resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
     dependencies:
@@ -1640,6 +1650,14 @@ packages:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
+    dev: true
+
+  /kill-port@2.0.1:
+    resolution: {integrity: sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==}
+    hasBin: true
+    dependencies:
+      get-them-args: 1.3.2
+      shell-exec: 1.0.2
     dev: true
 
   /lazy-ass@1.6.0:
@@ -2091,6 +2109,15 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
+
+  /shell-exec@1.0.2:
+    resolution: {integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==}
+    dev: true
+
+  /shell-exec@1.1.2:
+    resolution: {integrity: sha512-v2NWVDP0ws+S7miKy2oSpJ/OuL6NKuMosPNUZLDWFBlMnBtuoZxZOwxpQJwhsFZgMb+r7frpDTT8p4OSnhkpsg==}
+    engines: {node: '>=12'}
     dev: true
 
   /side-channel@1.0.4:


### PR DESCRIPTION
This PR allows to run all Cypress specs at once instead of running them one by one.

It is based on the anti-pattern of re-starting Chainlit with `cy.exec` before running each test and thus come with some limitations which are listed here:
https://docs.cypress.io/guides/references/best-practices#Web-Servers

Unfortunately, as we can't run all tests on the same pre-started Chainlit app, this is the best solution we have for now.

![Screenshot 2023-08-09 at 15 34 06](https://github.com/Chainlit/chainlit/assets/1092138/91c78696-5b96-4987-95df-791c3993a2b6)

`SKIP_BUILD` and `SINGLE_TEST` have been preserved and `SINGLE_TEST` can even now be set as a regexp to run multiple isolated tests.

