### PR TITLE
fix: format command failed on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ venv
 
 .DS_Store
 
+.chainlit
 chainlit.md
 
 cypress/screenshots

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "preview": "vite preview",
     "lint": "eslint ./src --ext .ts,.tsx && tsc --noemit",
-    "format": "prettier --config .prettierrc 'src/**/*.{ts,tsx}' --write --loglevel error"
+    "format": "prettier --config .prettierrc src/**/*.{ts,tsx} --write --loglevel error"
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.0.1",


### PR DESCRIPTION
The logs of the error:

```sh
$ cd src/chainlit/frontend/ && pnpm format

> chainlit-ui@0.0.1 format D:\projects\chainlit\src\chainlit\frontend
> prettier --config .prettierrc 'src/**/*.{ts,tsx}' --write --loglevel error

[error] No files matching the pattern were found: "'src/**/*.{ts,tsx}'".
 ELIFECYCLE  Command failed with exit code 2.
(venv)
```