### PR TITLE
fix: Display line on message with parentId

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/message/author.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/author.tsx
@@ -56,7 +56,7 @@ export default function Author({ message, show }: Props) {
         {display}
         <MessageTime timestamp={message.createdAt} />
       </Box>
-      {!!message.indent && (
+      {(!!message.indent || message.parentId) && (
         <Box
           width="2px"
           borderRadius="13px"


### PR DESCRIPTION
This PR fix the green line on indented message with parentId

<img width="810" alt="Capture d’écran 2023-08-08 à 14 42 33" src="https://github.com/Chainlit/chainlit/assets/18298759/a8574ee2-6974-4a5c-9342-1fa167059170">

