### PR TITLE
adding litellm integration - support for anthropic, azure, cohere, replicate

### DIFF
--- a/cypress/e2e/litellm/.chainlit/config.toml
+++ b/cypress/e2e/litellm/.chainlit/config.toml
@@ -1,0 +1,34 @@
+[project]
+# If true (default), the app will be available to anonymous users.
+# If false, users will need to authenticate and be part of the project to use the app.
+public = true
+
+# The project ID (found on https://cloud.chainlit.io).
+# If provided, all the message data will be stored in the cloud.
+# The project ID is required when public is set to false.
+#id = ""
+
+# Whether to enable telemetry (default: true). No personal data is collected.
+enable_telemetry = true
+
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+[UI]
+# Name of the app and chatbot.
+name = "Chatbot"
+
+# Description of the app and chatbot. This is used for HTML tags.
+# description = ""
+
+# The default value for the expand messages settings.
+default_expand_messages = false
+
+# Hide the chain of thought details from the user in the UI.
+hide_cot = false
+
+# Link to your github repo. This will add a github button in the UI's header.
+# github = ""
+
+[meta]
+generated_by = "0.3.1"

--- a/cypress/e2e/litellm/main_async.py
+++ b/cypress/e2e/litellm/main_async.py
@@ -1,0 +1,42 @@
+import os
+
+import litellm
+from litellm import acompletion
+
+import chainlit as cl
+
+prompt = """SQL tables (and columns):
+* Customers(customer_id, signup_date)
+* Streaming(customer_id, video_id, watch_date, watch_minutes)
+
+A well-written SQL query that {input}:
+```"""
+
+model_name = "text-davinci-003"
+
+settings = {
+    "temperature": 0,
+    "max_tokens": 500,
+    "top_p": 1,
+    "frequency_penalty": 0,
+    "presence_penalty": 0,
+    "stop": ["```"],
+}
+
+
+@cl.on_message
+async def main(message: str):
+    formatted_prompt = prompt.format(input=message)
+    messages = [{"role": "user", "content": formatted_prompt}]
+    response = await acompletion(
+        model=model_name, messages=messages, **settings
+    )
+
+    content = response['choices'][0]['message']['content']
+
+    await cl.Message(
+        language="sql",
+        content=content,
+        prompt=fromatted_prompt,
+        llm_settings=cl.LLMSettings(model_name=model_name, **settings),
+    ).send()

--- a/cypress/e2e/litellm/main_sync.py
+++ b/cypress/e2e/litellm/main_sync.py
@@ -1,0 +1,43 @@
+import os
+
+import litellm
+from litellm import completion
+
+import chainlit as cl
+from chainlit.sync import make_async
+
+prompt = """SQL tables (and columns):
+* Customers(customer_id, signup_date)
+* Streaming(customer_id, video_id, watch_date, watch_minutes)
+
+A well-written SQL query that {input}:
+```"""
+
+model_name = "text-davinci-003" # replace for any model in litellm.model_list (E.g. 'claude-instant-1', 'gpt-3.5-turbo', 'command-nightly', ...)
+
+settings = {
+    "temperature": 0,
+    "max_tokens": 500,
+    "top_p": 1,
+    "frequency_penalty": 0,
+    "presence_penalty": 0,
+    "stop": ["```"],
+}
+
+
+@cl.on_message
+async def main(message: str):
+    formatted_prompt = prompt.format(input=message)
+    messages = [{"role": "user", "content": formatted_prompt}]
+    response = completion(
+        model=model_name, messages=messages, **settings
+    )
+
+    content = response['choices'][0]['message']['content']
+
+    await cl.Message(
+        language="sql",
+        content=content,
+        prompt=fromatted_prompt,
+        llm_settings=cl.LLMSettings(model_name=model_name, **settings),
+    ).send()

--- a/cypress/e2e/litellm/spec.cy.ts
+++ b/cypress/e2e/litellm/spec.cy.ts
@@ -1,0 +1,18 @@
+import { submitMessage } from "../../support/testUtils";
+
+describe("OpenAI", () => {
+  before(() => {
+    cy.intercept("/project/settings").as("settings");
+    cy.visit("http://127.0.0.1:8000");
+    cy.wait(["@settings"]);
+  });
+
+  it("should output an SQL query", () => {
+    cy.get("#welcome-screen").should("exist");
+    submitMessage("How many minutes of video were watched");
+    const messages = cy.get(".message");
+    messages.should("have.length", 2);
+    
+    messages.eq(1).should("not.be.empty");
+  });
+});


### PR DESCRIPTION
Hey @ramnes @alimtunc ,

Chainlit is pretty cool. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

Added support for Claude, Cohere, Azure and Llama2 (via Replicate) by adding an additional integration file. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.

Happy to add additional tests / update documentation, if the initial PR looks good to you.