### PR TITLE
Allows IDE autocompletion for callback handlers

### DIFF
--- a/src/chainlit/__init__.py
+++ b/src/chainlit/__init__.py
@@ -7,7 +7,12 @@ from starlette.datastructures import Headers
 
 if TYPE_CHECKING:
     from chainlit.client.base import BaseDBClient, BaseAuthClient, UserDict
-
+    from chainlit.haystack.callbacks import HaystackAgentCallbackHandler
+    from chainlit.langchain.callbacks import (
+        LangchainCallbackHandler,
+        AsyncLangchainCallbackHandler,
+    )
+    from chainlit.llama_index.callbacks import LlamaIndexCallbackHandler
 import chainlit.input_widget as input_widget
 from chainlit.action import Action
 from chainlit.cache import cache


### PR DESCRIPTION
Only import expensive callback handlers modules for static type checkers, otherwise, these modules will be lazily imported at runtime through `__getattr__`.