### PR TITLE
✨ add markdown table rendering support to enhance user experience when displaying tabular data in chat messages

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/content.tsx
@@ -3,7 +3,18 @@ import { memo } from 'react';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import { Link, Stack, Typography } from '@mui/material';
+import {
+  Link,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography
+} from '@mui/material';
 
 import Code from 'components/atoms/Code';
 import Collapse from 'components/atoms/Collapse';
@@ -147,6 +158,44 @@ export default memo(function MessageContent({
             },
             code({ ...props }) {
               return <Code {...props} />;
+            },
+            table({ children, ...props }) {
+              return (
+                <TableContainer
+                  sx={{
+                    width: 'fit-content',
+                    minWidth: '300px',
+                    margin: 1
+                  }}
+                  elevation={0}
+                  component={Paper}
+                >
+                  <Table {...props}>{children}</Table>
+                </TableContainer>
+              );
+            },
+            thead({ children, ...props }) {
+              return <TableHead {...props}>{children}</TableHead>;
+            },
+            tr({ children, ...props }) {
+              return <TableRow {...props}>{children}</TableRow>;
+            },
+            th({ children, ...props }) {
+              return (
+                <TableCell {...props} align="right" sx={{ padding: 1 }}>
+                  {children}
+                </TableCell>
+              );
+            },
+            td({ children, ...props }) {
+              return (
+                <TableCell {...props} align="right" sx={{ padding: 1 }}>
+                  {children}
+                </TableCell>
+              );
+            },
+            tbody({ children, ...props }) {
+              return <TableBody {...props}>{children}</TableBody>;
             }
           }}
         >


### PR DESCRIPTION
Before : 
<img width="605" alt="image" src="https://github.com/Chainlit/chainlit/assets/18298759/1aa14249-e9d6-40c2-b2b4-66bce84984c1">


Now :
<img width="517" alt="Capture d’écran 2023-08-23 à 17 09 36" src="https://github.com/Chainlit/chainlit/assets/18298759/9ef4a890-181c-4f98-b2c7-2410904fb607">


<img width="471" alt="Capture d’écran 2023-08-23 à 17 09 46" src="https://github.com/Chainlit/chainlit/assets/18298759/11bda243-8756-42f0-87b2-ab6b63d0319d">
