### PR TITLE
Avoid deadlock in event start

### DIFF
--- a/cypress/e2e/llama_index_cb/main.py
+++ b/cypress/e2e/llama_index_cb/main.py
@@ -11,8 +11,6 @@ async def start():
 
     cb = cl.LlamaIndexCallbackHandler()
 
-    cb.start_trace()
-
     cb.on_event_start(CBEventType.RETRIEVE, payload={})
 
     cb.on_event_end(

--- a/src/chainlit/llama_index/callbacks.py
+++ b/src/chainlit/llama_index/callbacks.py
@@ -52,16 +52,25 @@ class LlamaIndexCallbackHandler(BaseCallbackHandler):
             return root_message.id
         return None
 
-    def start_trace(self, trace_id: Optional[str] = None) -> None:
+    def on_event_start(
+        self,
+        event_type: CBEventType,
+        payload: Optional[Dict[str, Any]] = None,
+        event_id: str = "",
+        **kwargs: Any,
+    ) -> str:
         """Run when an event starts and return id of event."""
         self._restore_context()
         run_sync(
             Message(
-                author=trace_id or "llama_index",
-                parent_id=self._get_parent_id(),
                 content="",
-            ).send()
+                author=event_type,
+                parent_id=self._get_parent_id(),
+            ).send(),
+            force_new_loop=True,
         )
+
+        return event_id
 
     def on_event_end(
         self,
@@ -135,5 +144,5 @@ class LlamaIndexCallbackHandler(BaseCallbackHandler):
     def _noop(self, *args, **kwargs):
         pass
 
-    on_event_start = _noop
+    start_trace = _noop
     end_trace = _noop

--- a/src/chainlit/sync.py
+++ b/src/chainlit/sync.py
@@ -21,9 +21,19 @@ T_ParamSpec = ParamSpec("T_ParamSpec")
 T = TypeVar("T")
 
 
-def run_sync(co: Coroutine[Any, Any, T_Retval]) -> T_Retval:
+def run_sync(co: Coroutine[Any, Any, T_Retval], force_new_loop=False) -> T_Retval:
+    """Run the coroutine synchronously. If force_new_loop is True,
+    the coroutine is executed in a new event loop, otherwise it is
+    executed in the main event loop."""
+
+    # Execute in a new event loop
+    if force_new_loop:
+        loop = asyncio.new_event_loop()
+        return loop.run_until_complete(co)
+
+    # Execute from the main thread in the main event loop
     if threading.current_thread() == threading.main_thread():
         return sync(co)
-    else:
+    else:  # Execute from a thread in the main event loop
         result = asyncio.run_coroutine_threadsafe(co, loop=context.loop)
         return result.result()


### PR DESCRIPTION
When using streaming, the main event loop is blocked to await tokens, if we try to execute a function (`Message.send()` here) in the same event loop, it leads to a deadlock.

Adding a `new_loop` parameter to the `run_sync` function allows to create a new event loop in the current Thread and allows to send a Message during a stream.