### PR TITLE
Compare versions with packaging.version

### DIFF
--- a/src/chainlit/cache.py
+++ b/src/chainlit/cache.py
@@ -5,17 +5,14 @@ from chainlit.config import config
 from chainlit.logger import logger
 
 
-def is_langchain_installed():
-    from chainlit.langchain import LANGCHAIN_INSTALLED
-
-    return LANGCHAIN_INSTALLED
-
-
 def init_lc_cache():
     use_cache = config.run.no_cache is False and config.run.ci is False
 
-    if use_cache and is_langchain_installed():
-        import langchain
+    if use_cache:
+        try:
+            import langchain
+        except ImportError:
+            return
         from langchain.cache import SQLiteCache
 
         if config.project.lc_cache_path is not None:

--- a/src/chainlit/haystack/__init__.py
+++ b/src/chainlit/haystack/__init__.py
@@ -1,11 +1,6 @@
-try:
-    import haystack
+from chainlit.utils import check_module_version
 
-    if haystack.__version__ < "1.18.0":
-        raise ValueError(
-            "Haystack version is too old, expected >= 1.18.0. Run `pip install farm-haystack --upgrade`"
-        )
-
-    HAYSTACK_INSTALLED = True
-except ImportError:
-    HAYSTACK_INSTALLED = False
+if not check_module_version("haystack", "1.18.0"):
+    raise ValueError(
+        "Haystack version is too old, expected >= 1.18.0. Run `pip install farm-haystack --upgrade`"
+    )

--- a/src/chainlit/haystack/__init__.py
+++ b/src/chainlit/haystack/__init__.py
@@ -2,5 +2,5 @@ from chainlit.utils import check_module_version
 
 if not check_module_version("haystack", "1.18.0"):
     raise ValueError(
-        "Haystack version is too old, expected >= 1.18.0. Run `pip install farm-haystack --upgrade`"
+        "Expected Haystack version >= 1.18.0. Run `pip install farm-haystack --upgrade`"
     )

--- a/src/chainlit/langchain/__init__.py
+++ b/src/chainlit/langchain/__init__.py
@@ -1,11 +1,6 @@
-try:
-    import langchain
+from chainlit.utils import check_module_version
 
-    if langchain.__version__ < "0.0.198":
-        raise ValueError(
-            "LangChain version is too old, expected >= 0.0.198. Run `pip install langchain --upgrade`"
-        )
-
-    LANGCHAIN_INSTALLED = True
-except ImportError:
-    LANGCHAIN_INSTALLED = False
+if not check_module_version("langchain", "0.0.198"):
+    raise ValueError(
+        "LangChain version is too old, expected >= 0.0.198. Run `pip install langchain --upgrade`"
+    )

--- a/src/chainlit/langchain/__init__.py
+++ b/src/chainlit/langchain/__init__.py
@@ -2,5 +2,5 @@ from chainlit.utils import check_module_version
 
 if not check_module_version("langchain", "0.0.198"):
     raise ValueError(
-        "LangChain version is too old, expected >= 0.0.198. Run `pip install langchain --upgrade`"
+        "Expected LangChain version >= 0.0.198. Run `pip install langchain --upgrade`"
     )

--- a/src/chainlit/langflow/__init__.py
+++ b/src/chainlit/langflow/__init__.py
@@ -2,7 +2,7 @@ from chainlit.utils import check_module_version
 
 if not check_module_version("langflow", "0.1.4"):
     raise ValueError(
-        "Langflow version is too old, expected >= 0.1.4. Run `pip install langflow --upgrade`"
+        "Expected Langflow version >= 0.1.4. Run `pip install langflow --upgrade`"
     )
 
 from typing import Dict, Optional, Union

--- a/src/chainlit/langflow/__init__.py
+++ b/src/chainlit/langflow/__init__.py
@@ -1,14 +1,9 @@
-try:
-    import langflow
+from chainlit.utils import check_module_version
 
-    if langflow.__version__ < "0.1.4":
-        raise ValueError(
-            "Langflow version is too old, expected >= 0.1.4. Run `pip install langflow --upgrade`"
-        )
-
-    LANGFLOW_INSTALLED = True
-except ImportError:
-    LANGFLOW_INSTALLED = False
+if not check_module_version("langflow", "0.1.4"):
+    raise ValueError(
+        "Langflow version is too old, expected >= 0.1.4. Run `pip install langflow --upgrade`"
+    )
 
 from typing import Dict, Optional, Union
 

--- a/src/chainlit/llama_index/__init__.py
+++ b/src/chainlit/llama_index/__init__.py
@@ -1,11 +1,6 @@
-try:
-    import llama_index
+from chainlit.utils import check_module_version
 
-    if llama_index.__version__ < "0.8.3":
-        raise ValueError(
-            "LlamaIndex version is too old, expected >= 0.8.3. Run `pip install llama_index --upgrade`"
-        )
-
-    LLAMA_INDEX_INSTALLED = True
-except ImportError:
-    LLAMA_INDEX_INSTALLED = False
+if not check_module_version("llama_index", "0.8.3"):
+    raise ValueError(
+        "LlamaIndex version is too old, expected >= 0.8.3. Run `pip install llama_index --upgrade`"
+    )

--- a/src/chainlit/llama_index/__init__.py
+++ b/src/chainlit/llama_index/__init__.py
@@ -2,5 +2,5 @@ from chainlit.utils import check_module_version
 
 if not check_module_version("llama_index", "0.8.3"):
     raise ValueError(
-        "LlamaIndex version is too old, expected >= 0.8.3. Run `pip install llama_index --upgrade`"
+        "Expected LlamaIndex version >= 0.8.3. Run `pip install llama_index --upgrade`"
     )

--- a/src/chainlit/utils.py
+++ b/src/chainlit/utils.py
@@ -2,6 +2,8 @@ import importlib
 import inspect
 from typing import Callable
 
+from packaging import version
+
 from chainlit.context import context
 from chainlit.logger import logger
 from chainlit.message import ErrorMessage
@@ -63,3 +65,22 @@ def make_module_getattr(registry):
         return getattr(module, name)
 
     return __getattr__
+
+
+def check_module_version(name, required_version):
+    """
+    Check the version of a module.
+
+    Args:
+        name (str): A module name.
+        version (str): Minimum version.
+
+    Returns:
+        (bool): Return False if the module is installed and the version
+            is lower than the minimum version required.
+    """
+    try:
+        module = importlib.import_module(name)
+    except ModuleNotFoundError:
+        return True
+    return version.parse(module.__version__) >= version.parse(required_version)

--- a/src/chainlit/utils.py
+++ b/src/chainlit/utils.py
@@ -76,11 +76,11 @@ def check_module_version(name, required_version):
         version (str): Minimum version.
 
     Returns:
-        (bool): Return False if the module is installed and the version
-            is lower than the minimum version required.
+        (bool): Return True if the module is installed and the version
+            match the minimum required version.
     """
     try:
         module = importlib.import_module(name)
     except ModuleNotFoundError:
-        return True
+        return False
     return version.parse(module.__version__) >= version.parse(required_version)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -40,6 +40,7 @@ watchfiles="^0.19.0"
 prisma="^0.9.0"
 filetype = "^1.2.0"
 lazify = "^0.4.0"
+packaging = "^23.1"
 
 [tool.poetry.group.tests]
 optional = true


### PR DESCRIPTION
Fix version comparison from string compare to PEP 440 versions.
`packaging.version` is used instead of `semver` because `semver` doesn't support version like `0.8.11.post3`