### PR TITLE
Disable cache by default

### DIFF
--- a/src/chainlit/cache.py
+++ b/src/chainlit/cache.py
@@ -6,7 +6,7 @@ from chainlit.logger import logger
 
 
 def init_lc_cache():
-    use_cache = config.run.no_cache is False and config.run.ci is False
+    use_cache = config.project.cache is True and config.run.no_cache is False
 
     if use_cache:
         try:

--- a/src/chainlit/config.py
+++ b/src/chainlit/config.py
@@ -48,6 +48,9 @@ user_env = []
 # Duration (in seconds) during which the session is saved when the connection is lost
 session_timeout = 3600
 
+# Enable third parties caching (e.g LangChain cache)
+cache = false
+
 # Chainlit server address
 # chainlit_server = ""
 
@@ -198,6 +201,8 @@ class ProjectSettings(DataClassJsonMixin):
     local_fs_path: Optional[str] = None
     # Duration (in seconds) during which the session is saved when the connection is lost
     session_timeout: int = 3600
+    # Enable third parties caching (e.g LangChain cache)
+    cache: bool = False
     # Chainlit server address
     chainlit_server: Optional[str] = None
 


### PR DESCRIPTION
LangChain cache can cause some issues (for instance with Streaming), so let's disable it by default.

The cache can now be enabled with the config param `cache = true`.
It can still be overridden with the CLI param `--no-cache`, which takes precedence.