### PR TITLE
refactor: Explicit import Icons

### DIFF
--- a/src/chainlit/frontend/src/components/atoms/ClipboardCopy.tsx
+++ b/src/chainlit/frontend/src/components/atoms/ClipboardCopy.tsx
@@ -1,7 +1,7 @@
 import { grey } from 'palette';
 import { useCopyToClipboard, useToggle } from 'usehooks-ts';
 
-import { CopyAll } from '@mui/icons-material';
+import CopyAll from '@mui/icons-material/CopyAll';
 import { IconButton, Tooltip } from '@mui/material';
 
 import useIsDarkMode from 'hooks/useIsDarkMode';

--- a/src/chainlit/frontend/src/components/atoms/Collapse.tsx
+++ b/src/chainlit/frontend/src/components/atoms/Collapse.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useToggle } from 'usehooks-ts';
 
-import { DownloadOutlined, ExpandLess, ExpandMore } from '@mui/icons-material';
+import DownloadOutlined from '@mui/icons-material/DownloadOutlined';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import {
   Box,
   IconButton,

--- a/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
+++ b/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
@@ -1,4 +1,4 @@
-import { Info } from '@mui/icons-material';
+import Info from '@mui/icons-material/Info';
 import { Box, InputLabel, Tooltip } from '@mui/material';
 
 import NotificationCount, {

--- a/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
@@ -4,7 +4,7 @@ import { grey } from 'palette';
 import { useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { AutoDelete } from '@mui/icons-material';
+import AutoDelete from '@mui/icons-material/AutoDelete';
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import {
   IconButton,

--- a/src/chainlit/frontend/src/components/organisms/chat/message/UploadButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/UploadButton.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 
-import { Add } from '@mui/icons-material';
+import Add from '@mui/icons-material/Add';
 import { LoadingButton } from '@mui/lab';
 import { Tooltip } from '@mui/material';
 

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -2,7 +2,7 @@ import { primary } from 'palette';
 import { grey } from 'palette';
 import React from 'react';
 
-import { KeyboardArrowDown } from '@mui/icons-material';
+import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
 import { MenuItem, SxProps } from '@mui/material';
 import MSelect, { SelectChangeEvent, SelectProps } from '@mui/material/Select';
 


### PR DESCRIPTION
Context : 
MUI Imports increasing bundle size due to tree-shaking issues https://mui.com/material-ui/guides/minimizing-bundle-size

I tried with the babel plugins, none of them fixed the issue (https://mui.com/material-ui/guides/minimizing-bundle-size/#option-two-use-a-babel-plugin) and also found https://github.com/Dschungelabenteuer/vite-plugin-entry-shaking wich looks like only for internal package and not node modules. 

Explicit import icons decrease the bundle size on first load from 20mb to 13mb, so maybe if we do this for all MUI imports, it should be better! 

Open to recommandations, I did not found any plugins or config to fix this..

Edit: Maked vite plugin work following Tamagui config (https://github.com/tamagui/tamagui/blob/878ed1e591f9f29a56b0b9ba918eccf4b8d8d949/packages/cli/src/studio.ts#L54-L57), and it launched the server but failed on client side

```js
/// <reference types="vitest" />
import react from '@vitejs/plugin-react-swc';
import { resolve } from 'path';
import { defineConfig } from 'vite';
import EntryShakingPlugin from 'vite-plugin-entry-shaking';
import tsconfigPaths from 'vite-tsconfig-paths';

// https://vitejs.dev/config/
export default defineConfig({
  test: {
    environment: 'jsdom',
    setupFiles: './setup-tests.ts',
    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)']
  },
  plugins: [
    react(),
    tsconfigPaths(),
    await EntryShakingPlugin({
      targets: [
        resolve('./node_modules/@mui/icons-material/esm/index.js'),
        resolve('./node_modules/@mui/material/index.js')
      ]
    })
  ]
});
```

<img width="897" alt="Capture d’écran 2023-08-29 à 17 40 49" src="https://github.com/Chainlit/chainlit/assets/18298759/37c94961-4379-4566-becb-a8f9755a4e59">



