### PR TITLE
feat(vertexai): Add GCP Vertex AI providers with generation and chat …

### DIFF
--- a/backend/chainlit/playground/config.py
+++ b/backend/chainlit/playground/config.py
@@ -7,6 +7,8 @@ from chainlit.playground.providers import (
     AzureOpenAI,
     ChatOpenAI,
     OpenAI,
+    ChatVertexAI,
+    GenerationVertexAI,
 )
 
 providers = {
@@ -15,6 +17,8 @@ providers = {
     ChatOpenAI.id: ChatOpenAI,
     OpenAI.id: OpenAI,
     Anthropic.id: Anthropic,
+    ChatVertexAI.id: ChatVertexAI,
+    GenerationVertexAI.id: GenerationVertexAI,
 }  # type: Dict[str, BaseProvider]
 
 

--- a/backend/chainlit/playground/providers/__init__.py
+++ b/backend/chainlit/playground/providers/__init__.py
@@ -1,3 +1,12 @@
 from .anthropic import Anthropic
 from .huggingface import HFFlanT5
-from .openai import AzureChatOpenAI, AzureOpenAI, ChatOpenAI, OpenAI
+from .openai import (
+    AzureChatOpenAI,
+    AzureOpenAI,
+    ChatOpenAI,
+    OpenAI,
+)
+from .vertexai import (
+    ChatVertexAI,
+    GenerationVertexAI,
+)

--- a/backend/chainlit/playground/providers/vertexai.py
+++ b/backend/chainlit/playground/providers/vertexai.py
@@ -1,0 +1,126 @@
+import chainlit as cl
+from fastapi import HTTPException
+
+from fastapi.responses import StreamingResponse
+
+from chainlit.input_widget import Select, Slider, Tags
+from chainlit.playground.provider import BaseProvider
+
+vertexai_common_inputs = [
+    Slider(
+        id="temperature",
+        label="Temperature",
+        min=0.0,
+        max=0.99,
+        step=0.01,
+        initial=0.2,
+    ),
+    Slider(
+        id="max_output_tokens",
+        label="Max Output Tokens",
+        min=0.0,
+        max=1024,
+        step=1,
+        initial=256,
+    ),
+]
+
+
+class ChatVertexAIProvider(BaseProvider):
+    async def create_completion(self, request):
+        await super().create_completion(request)
+        from vertexai.language_models import ChatModel, CodeChatModel
+
+        self.validate_env(request=request)
+
+        llm_settings = request.prompt.settings
+        self.require_settings(llm_settings)
+
+        prompt = self.create_prompt(request)
+        model_name = llm_settings["model"]
+        if model_name.startswith("chat-"):
+            model = ChatModel.from_pretrained(model_name)
+        elif model_name.startswith("codechat-"):
+            model = CodeChatModel.from_pretrained(model_name)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"This model{model_name} is not implemented.",
+            )
+        del llm_settings["model"]
+        chat = model.start_chat()
+
+        def create_event_stream():
+            for response in cl.make_async(
+                chat.send_message_streaming(prompt[0].formatted, **llm_settings)
+            ):
+                yield response.text
+
+        return StreamingResponse(create_event_stream())
+
+
+class GenerationVertexAIProvider(BaseProvider):
+    async def create_completion(self, request):
+        await super().create_completion(request)
+        from vertexai.language_models import TextGenerationModel, CodeGenerationModel
+
+        self.validate_env(request=request)
+
+        llm_settings = request.prompt.settings
+        self.require_settings(llm_settings)
+
+        prompt = self.create_prompt(request)
+        model_name = llm_settings["model"]
+        if model_name.startswith("text-"):
+            model = TextGenerationModel.from_pretrained(model_name)
+        elif model_name.startswith("code-"):
+            model = CodeGenerationModel.from_pretrained(model_name)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"This model{model_name} is not implemented.",
+            )
+        del llm_settings["model"]
+
+        def create_event_stream():
+            for response in cl.make_async(
+                model.predict_streaming(prompt, **llm_settings)
+            ):
+                yield response.text
+
+        return StreamingResponse(create_event_stream())
+
+
+gcp_env_vars = {"google_application_credentials": "GOOGLE_APPLICATION_CREDENTIALS"}
+
+ChatVertexAI = ChatVertexAIProvider(
+    id="chat-vertexai",
+    env_vars=gcp_env_vars,
+    name="ChatVertexAI",
+    inputs=[
+        Select(
+            id="model",
+            label="Model",
+            values=["chat-bison", "codechat-bison"],
+            initial_value="chat-bison",
+        ),
+        *vertexai_common_inputs,
+    ],
+    is_chat=True,
+)
+
+GenerationVertexAI = GenerationVertexAIProvider(
+    id="generation-vertexai",
+    env_vars=gcp_env_vars,
+    name="GenerationVertexAI",
+    inputs=[
+        Select(
+            id="model",
+            label="Model",
+            values=["text-bison", "code-bison"],
+            initial_value="text-bison",
+        ),
+        *vertexai_common_inputs,
+    ],
+    is_chat=False,
+)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -80,6 +80,7 @@ module = [
     "socketio.*",
     "uptrace",
     "syncer",
+    "vertexai.language_models"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
# Description
- Add the Generation and Chat models from [GCP VertexAI](https://cloud.google.com/vertex-ai?hl=en)
- Using the `GOOGLE_APPLICATION_CREDENTIALS` environment variables, the playground is available for chat and generation LLM models of VertexAI
- Only common parameters are available: `temperature` and `max_output_tokens`