### PR TITLE
Add disable long message collapsing option

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -65,6 +65,9 @@ name = "Chatbot"
 # Description of the app and chatbot. This is used for HTML tags.
 # description = ""
 
+# Large size content are by default collapsed for a cleaner ui
+default_collapsed_content = true
+
 # The default value for the expand messages settings.
 default_expand_messages = false
 
@@ -148,6 +151,8 @@ class UISettings(DataClassJsonMixin):
     name: str
     description: str = ""
     hide_cot: bool = False
+    # Large size content are by default collapsed for a cleaner ui
+    default_collapsed_content: bool = True
     default_expand_messages: bool = False
     github: Optional[str] = None
     theme: Optional[Theme] = None

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -66,7 +66,7 @@ name = "Chatbot"
 # description = ""
 
 # Large size content are by default collapsed for a cleaner ui
-default_collapsed_content = true
+default_collapse_content = true
 
 # The default value for the expand messages settings.
 default_expand_messages = false
@@ -152,7 +152,7 @@ class UISettings(DataClassJsonMixin):
     description: str = ""
     hide_cot: bool = False
     # Large size content are by default collapsed for a cleaner ui
-    default_collapsed_content: bool = True
+    default_collapse_content: bool = True
     default_expand_messages: bool = False
     github: Optional[str] = None
     theme: Optional[Theme] = None

--- a/frontend/setup-tests.ts
+++ b/frontend/setup-tests.ts
@@ -1,4 +1,9 @@
 import matchers from '@testing-library/jest-dom/matchers';
-import { expect } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, expect } from 'vitest';
 
 expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -23,6 +23,7 @@ export default function AppWrapper() {
     setPSettings(data);
     setAppSettings((prev) => ({
       ...prev,
+      defaultCollapsedContent: data.ui.default_collapsed_content ?? true,
       expandAll: !!data.ui.default_expand_messages,
       hideCot: !!data.ui.hide_cot
     }));

--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -23,7 +23,7 @@ export default function AppWrapper() {
     setPSettings(data);
     setAppSettings((prev) => ({
       ...prev,
-      defaultCollapsedContent: data.ui.default_collapsed_content ?? true,
+      defaultCollapseContent: data.ui.default_collapse_content ?? true,
       expandAll: !!data.ui.default_expand_messages,
       hideCot: !!data.ui.hide_cot
     }));

--- a/frontend/src/components/atoms/Collapse.tsx
+++ b/frontend/src/components/atoms/Collapse.tsx
@@ -16,10 +16,15 @@ import {
 interface CollapseProps {
   children: React.ReactNode;
   onDownload: () => void;
+  defaultExpandAll?: boolean;
 }
 
-const Collapse = ({ children, onDownload }: CollapseProps): JSX.Element => {
-  const [expandAll, toggleExpandAll] = useToggle(false);
+const Collapse = ({
+  children,
+  onDownload,
+  defaultExpandAll = false
+}: CollapseProps): JSX.Element => {
+  const [expandAll, toggleExpandAll] = useToggle(defaultExpandAll);
 
   return (
     <Box>

--- a/frontend/src/components/organisms/chat/message/content.spec.tsx
+++ b/frontend/src/components/organisms/chat/message/content.spec.tsx
@@ -92,3 +92,39 @@ it('highlights sources containing regex characters correctly', () => {
   expect(getByRole('link', { name: 'source(12)' })).toBeInTheDocument();
   expect(getByRole('link', { name: 'page{12}' })).toBeInTheDocument();
 });
+
+it('preserves the box size when collapsing', () => {
+  const { getByRole } = render(
+    <RecoilRoot>
+      <BrowserRouter>
+        <MessageContent
+          authorIsUser={false}
+          elements={[
+            {
+              name: 'source_1',
+              type: 'text',
+              display: 'side',
+              content: 'source_1'
+            } as ITextElement,
+            {
+              name: 'source_12',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement,
+            {
+              name: 'source_121',
+              display: 'side',
+              type: 'text',
+              content: 'hi'
+            } as ITextElement
+          ]}
+          content={'hello'.repeat(650)}
+          preserveSize
+        />
+      </BrowserRouter>
+    </RecoilRoot>
+  );
+
+  expect(getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+});

--- a/frontend/src/components/organisms/chat/message/content.tsx
+++ b/frontend/src/components/organisms/chat/message/content.tsx
@@ -33,6 +33,7 @@ interface Props {
   elements: IMessageElement[];
   language?: string;
   authorIsUser?: boolean;
+  preserveSize?: boolean;
 }
 
 const isForIdMatch = (
@@ -115,7 +116,8 @@ export default memo(function MessageContent({
   content,
   elements,
   language,
-  authorIsUser
+  authorIsUser,
+  preserveSize
 }: Props) {
   const { preparedContent, inlinedElements, refElements } = prepareContent({
     id,
@@ -214,7 +216,10 @@ export default memo(function MessageContent({
   return (
     <Stack width="100%">
       {collapse ? (
-        <Collapse onDownload={() => exportToFile(preparedContent, `${id}.txt`)}>
+        <Collapse
+          defaultExpandAll={preserveSize}
+          onDownload={() => exportToFile(preparedContent, `${id}.txt`)}
+        >
           {renderContent()}
         </Collapse>
       ) : (

--- a/frontend/src/components/organisms/chat/message/message.spec.tsx
+++ b/frontend/src/components/organisms/chat/message/message.spec.tsx
@@ -81,13 +81,13 @@ describe('Message', () => {
     expect(getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
   });
 
-  it('preserves the content size when app settings defaultCollapsedContent is false', () => {
+  it('preserves the content size when app settings defaultCollapseContent is false', () => {
     const { getByRole } = render(
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(settingsState, {
             ...defaultSettingsState,
-            defaultCollapsedContent: false
+            defaultCollapseContent: false
           });
         }}
       >

--- a/frontend/src/components/organisms/chat/message/message.spec.tsx
+++ b/frontend/src/components/organisms/chat/message/message.spec.tsx
@@ -3,6 +3,8 @@ import { ComponentProps } from 'react';
 import { RecoilRoot } from 'recoil';
 import { describe, expect, it } from 'vitest';
 
+import { defaultSettingsState, settingsState } from 'state/settings';
+
 import Message from './message';
 
 describe('Message', () => {
@@ -71,6 +73,29 @@ describe('Message', () => {
             ...defaultProps.message,
             content: 'hello '.repeat(650),
             streaming: true
+          }}
+        />
+      </RecoilRoot>
+    );
+
+    expect(getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+  });
+
+  it('preserves the content size when app settings defaultCollapsedContent is false', () => {
+    const { getByRole } = render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(settingsState, {
+            ...defaultSettingsState,
+            defaultCollapsedContent: false
+          });
+        }}
+      >
+        <Message
+          {...defaultProps}
+          message={{
+            ...defaultProps.message,
+            content: 'hello '.repeat(650)
           }}
         />
       </RecoilRoot>

--- a/frontend/src/components/organisms/chat/message/message.spec.tsx
+++ b/frontend/src/components/organisms/chat/message/message.spec.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ComponentProps } from 'react';
+import { RecoilRoot } from 'recoil';
+import { describe, expect, it } from 'vitest';
+
+import Message from './message';
+
+describe('Message', () => {
+  const defaultProps: ComponentProps<typeof Message> = {
+    message: {
+      id: '1',
+      content: 'Hello',
+      authorIsUser: true,
+      subMessages: [
+        {
+          id: '2',
+          content: 'bar',
+          author: 'bar',
+          createdAt: '12/12/2002'
+        }
+      ],
+      waitForAnswer: false,
+      author: 'foo',
+      createdAt: '12/12/2002'
+    },
+    elements: [],
+    actions: [],
+    indent: 0,
+    showAvatar: true,
+    showBorder: true,
+    isRunning: false,
+    isLast: true
+  };
+
+  it('renders message content', () => {
+    const { getByText } = render(
+      <RecoilRoot>
+        <Message {...defaultProps} />
+      </RecoilRoot>
+    );
+    const messageContent = getByText('Hello');
+
+    expect(messageContent).toBeInTheDocument();
+  });
+
+  it('toggles the detail button', () => {
+    const { getByRole } = render(
+      <RecoilRoot>
+        <Message {...defaultProps} />
+      </RecoilRoot>
+    );
+    let detailsButton = getByRole('button', { name: 'Took 1 step' });
+
+    expect(detailsButton).toBeInTheDocument();
+    fireEvent.click(detailsButton);
+    const closeButton = getByRole('button', { name: 'Took 1 step' });
+
+    expect(closeButton).toBeInTheDocument();
+    fireEvent.click(closeButton);
+    detailsButton = getByRole('button', { name: 'Took 1 step' });
+
+    expect(detailsButton).toBeInTheDocument();
+  });
+
+  it('preserves the content size when message is streamed', () => {
+    const { getByRole } = render(
+      <RecoilRoot>
+        <Message
+          {...defaultProps}
+          message={{
+            ...defaultProps.message,
+            content: 'hello '.repeat(650),
+            streaming: true
+          }}
+        />
+      </RecoilRoot>
+    );
+
+    expect(getByRole('button', { name: 'Collapse' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/organisms/chat/message/message.tsx
+++ b/frontend/src/components/organisms/chat/message/message.tsx
@@ -111,7 +111,7 @@ const Message = ({
               content={message.content}
               language={message.language}
               preserveSize={
-                !!message.streaming || !appSettings.defaultCollapsedContent
+                !!message.streaming || !appSettings.defaultCollapseContent
               }
             />
             <DetailsButton

--- a/frontend/src/components/organisms/chat/message/message.tsx
+++ b/frontend/src/components/organisms/chat/message/message.tsx
@@ -110,6 +110,7 @@ const Message = ({
               id={message.id}
               content={message.content}
               language={message.language}
+              preserveSize={!!message.streaming}
             />
             <DetailsButton
               message={message}

--- a/frontend/src/components/organisms/chat/message/message.tsx
+++ b/frontend/src/components/organisms/chat/message/message.tsx
@@ -110,7 +110,9 @@ const Message = ({
               id={message.id}
               content={message.content}
               language={message.language}
-              preserveSize={!!message.streaming}
+              preserveSize={
+                !!message.streaming || !appSettings.defaultCollapsedContent
+              }
             />
             <DetailsButton
               message={message}

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -8,6 +8,7 @@ export interface IProjectSettings {
     name: string;
     description?: string;
     hide_cot?: boolean;
+    default_collapsed_content?: boolean;
     default_expand_messages?: boolean;
     github?: string;
   };

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -8,7 +8,7 @@ export interface IProjectSettings {
     name: string;
     description?: string;
     hide_cot?: boolean;
-    default_collapsed_content?: boolean;
+    default_collapse_content?: boolean;
     default_expand_messages?: boolean;
     github?: string;
   };

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -12,7 +12,7 @@ const theme = preferredTheme ? preferredTheme : defaultTheme;
 
 export const defaultSettingsState = {
   open: false,
-  defaultCollapsedContent: true,
+  defaultCollapseContent: true,
   expandAll: false,
   hideCot: false,
   theme
@@ -20,7 +20,7 @@ export const defaultSettingsState = {
 
 export const settingsState = atom<{
   open: boolean;
-  defaultCollapsedContent: boolean;
+  defaultCollapseContent: boolean;
   expandAll: boolean;
   hideCot: boolean;
   theme: ThemeVariant;

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -10,17 +10,21 @@ const preferredTheme = localStorage.getItem(
 
 const theme = preferredTheme ? preferredTheme : defaultTheme;
 
+export const defaultSettingsState = {
+  open: false,
+  defaultCollapsedContent: true,
+  expandAll: false,
+  hideCot: false,
+  theme
+};
+
 export const settingsState = atom<{
   open: boolean;
+  defaultCollapsedContent: boolean;
   expandAll: boolean;
   hideCot: boolean;
   theme: ThemeVariant;
 }>({
   key: 'AppSettings',
-  default: {
-    open: false,
-    expandAll: false,
-    hideCot: false,
-    theme
-  }
+  default: defaultSettingsState
 });


### PR DESCRIPTION
## Changes

- Add a `default_collapse_content` options in Chainlit configuration
- Update `Collapse` atom props to set default state
- Update `Content` organism with `preserveSize` props
- Update `Message` organism to decide `preserveSize` behavior

- Update vitest setup to clean up rendered element after testing 
- Added tests to `Message` organism

## How to test?

- with `e2e/streaming`
    - reduce the sleep time
    - increase the length of the message
    - notice that the message  is no longer collapsed when reaching the limit
- with `e2e/cot`
    - update the config with `UI.default_collapse_content = false`
    - increase the response text length
    - notice that the box is expanded by default
