### PR TITLE
Add support for Azure OpenAI, Palm, Claude, Cohere, Replicate, Sagemaker (100+LLMs) - using litellm 

### DIFF
--- a/backend/chainlit/playground/providers/openai.py
+++ b/backend/chainlit/playground/providers/openai.py
@@ -93,7 +93,7 @@ class ChatOpenAIProvider(BaseProvider):
 
     async def create_completion(self, request):
         await super().create_completion(request)
-        import openai
+        import litellm
 
         env_settings = self.validate_env(request=request)
 
@@ -119,7 +119,7 @@ class ChatOpenAIProvider(BaseProvider):
         llm_settings["stream"] = True
 
         with handle_openai_error():
-            response = await openai.ChatCompletion.acreate(
+            response = await litellm.acompletion(
                 **env_settings,
                 messages=messages,
                 **llm_settings,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,7 @@ optional = true
 
 [tool.poetry.group.tests.dependencies]
 openai = "^0.27.7"
+litellm = "^0.1.500"
 langchain = "^0.0.262"
 llama-index = "^0.8.3"
 transformers = "^4.30.1"


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```