### PR TITLE
make logo configurable

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1,6 +1,8 @@
 import glob
 import json
 import mimetypes
+from enum import Enum
+from typing import Optional
 
 mimetypes.add_type("application/javascript", ".js")
 mimetypes.add_type("text/css", ".css")
@@ -34,7 +36,7 @@ from chainlit.types import (
     GetConversationsRequest,
     UpdateFeedbackRequest,
 )
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi_socketio import SocketManager
@@ -339,6 +341,33 @@ async def get_favicon():
     media_type, _ = mimetypes.guess_type(favicon_path)
 
     return FileResponse(favicon_path, media_type=media_type)
+
+
+class Theme(str, Enum):
+    light = "light"
+    dark = "dark"
+
+
+@app.get("/logo")
+async def get_logo(theme: Optional[Theme] = Query(Theme.light)):
+    theme_value = theme.value if theme else Theme.light.value
+    logo_path = None
+
+    for path in [
+        f"logo_{theme_value}.*",
+        os.path.join("assets", f"logo_{theme_value}*.*"),
+    ]:
+        files = glob.glob(os.path.join(build_dir, path))
+
+        if files:
+            logo_path = files[0]
+            break
+
+    if not logo_path:
+        raise HTTPException(status_code=500, detail="Missing default logo")
+    media_type, _ = mimetypes.guess_type(logo_path)
+
+    return FileResponse(logo_path, media_type=media_type)
 
 
 def register_wildcard_route_handler():

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1,7 +1,6 @@
 import glob
 import json
 import mimetypes
-from enum import Enum
 from typing import Optional
 
 mimetypes.add_type("application/javascript", ".js")
@@ -34,6 +33,7 @@ from chainlit.types import (
     CompletionRequest,
     DeleteConversationRequest,
     GetConversationsRequest,
+    Theme,
     UpdateFeedbackRequest,
 )
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -343,11 +343,6 @@ async def get_favicon():
     return FileResponse(favicon_path, media_type=media_type)
 
 
-class Theme(str, Enum):
-    light = "light"
-    dark = "dark"
-
-
 @app.get("/logo")
 async def get_logo(theme: Optional[Theme] = Query(Theme.light)):
     theme_value = theme.value if theme else Theme.light.value
@@ -364,7 +359,7 @@ async def get_logo(theme: Optional[Theme] = Query(Theme.light)):
             break
 
     if not logo_path:
-        raise HTTPException(status_code=500, detail="Missing default logo")
+        raise HTTPException(status_code=404, detail="Missing default logo")
     media_type, _ = mimetypes.guess_type(logo_path)
 
     return FileResponse(logo_path, media_type=media_type)

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
 from chainlit.prompt import Prompt
@@ -77,3 +78,8 @@ class ConversationFilter(BaseModel):
 class GetConversationsRequest(BaseModel):
     pagination: Pagination
     filter: ConversationFilter
+
+
+class Theme(str, Enum):
+    light = "light"
+    dark = "dark"


### PR DESCRIPTION

https://github.com/Chainlit/chainlit/assets/10745953/e03893e6-5a0f-442a-9640-0d21d06b41ee


## Changes

- Add a new `GET /logo` endpoint accepting an optional `theme` path parameter.

## How to test?

- run chainlit
- go to `/logo`
- notice the default logo is displayed
- check with the parameter `?theme=dark`
- notice the default dark logo is displayed
- add a custom logo `logo_light` or `logo_dark` in the `public` folder
- run the `buildUi` script again
- repeat previous steps, notice that we display the custom ones
- remove every logos from `frontend/dist`
- notice that we raise an error