### PR TITLE
Cloud Login UX fixes

### DIFF
--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts theme/index.ts --dts --format=esm,cjs --clean --dts",
-    "build:watch": "tsc && vite build --watch",
+    "build:watch": "tsup src/index.ts theme/index.ts --watch --format=esm,cjs --sourcemap",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/libs/components/src/auth/AuthLogin.tsx
+++ b/libs/components/src/auth/AuthLogin.tsx
@@ -202,7 +202,7 @@ const AuthLogin = ({
           )}
         </Stack>
       ) : null}
-      {providers?.length ? (
+      {providers.length ? (
         <>
           <Typography
             sx={{

--- a/libs/components/src/auth/AuthLogin.tsx
+++ b/libs/components/src/auth/AuthLogin.tsx
@@ -94,7 +94,8 @@ const AuthLogin = ({
       email: yup.string().required(),
       password: yup.string().required()
     }),
-    onSubmit: async () => undefined
+    onSubmit: async () => undefined,
+    validateOnBlur: true
   });
 
   const handleSubmit = async (event: FormEvent) => {
@@ -137,7 +138,8 @@ const AuthLogin = ({
           size="medium"
           value={formik.values.email}
           hasError={!!formik.errors.email}
-          description={formik.errors.email}
+          description={formik.touched.email ? formik.errors.email : undefined}
+          onBlur={formik.handleBlur}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             formik.setFieldValue('email', e.target.value)
           }
@@ -147,7 +149,10 @@ const AuthLogin = ({
           placeholder="Password"
           value={formik.values.password}
           hasError={!!formik.errors.password}
-          description={formik.errors.password}
+          description={
+            formik.touched.password ? formik.errors.password : undefined
+          }
+          onBlur={formik.handleBlur}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             formik.setFieldValue('password', e.target.value)
           }

--- a/libs/components/src/auth/AuthLogin.tsx
+++ b/libs/components/src/auth/AuthLogin.tsx
@@ -197,7 +197,7 @@ const AuthLogin = ({
           )}
         </Stack>
       ) : null}
-      {providers ? (
+      {providers?.length ? (
         <>
           <Typography
             sx={{


### PR DESCRIPTION


https://github.com/Chainlit/chainlit/assets/10745953/3d1663be-1025-4cd2-9717-283236f7ea0f



## Changes

- update `build:watch` script to improve dx
- oauth providers separator is only displayed when we receive at least a provider
- input validation error only appears when the field is touched (⚠️ not perfect yet, but I think we can postpone a more complete refactor, currently the UX is good enough)
- pressing enter will now send the signin form

## How to test?

- make sure to have no providers env keys
- notice that we no longer see the `OR` separator
- type a password, notice that the email is empty error is not displayed
- type an email, and empty the field, the error is properly displayed
- press `enter` to send the form, notice that it's being sent