### PR TITLE
Added mechanism to allow injecting custom CSS files for UI customization

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -162,6 +162,8 @@ class UISettings(DataClassJsonMixin):
     default_expand_messages: bool = False
     github: Optional[str] = None
     theme: Optional[Theme] = None
+    # Optional custom CSS file that allows you to customize the UI
+    custom_css: Optional[str] = None
 
 
 @dataclass()

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -196,9 +196,7 @@ def get_html_template():
 
     css = None
     if config.ui.custom_css:
-        css = (
-            f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}">"""
-        )
+        css = f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}">"""
 
     index_html_file_path = os.path.join(build_dir, "index.html")
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -177,6 +177,7 @@ socket = SocketManager(
 def get_html_template():
     PLACEHOLDER = "<!-- TAG INJECTION PLACEHOLDER -->"
     JS_PLACEHOLDER = "<!-- JS INJECTION PLACEHOLDER -->"
+    CSS_PLACEHOLDER = "<!-- CSS INJECTION PLACEHOLDER -->"
 
     default_url = "https://github.com/Chainlit/chainlit"
     url = config.ui.github or default_url
@@ -193,6 +194,12 @@ def get_html_template():
     if config.ui.theme:
         js = f"""<script>window.theme = {json.dumps(config.ui.theme.to_dict())}</script>"""
 
+    css = None
+    if config.ui.custom_css:
+        css = (
+            f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}">"""
+        )
+
     index_html_file_path = os.path.join(build_dir, "index.html")
 
     with open(index_html_file_path, "r", encoding="utf-8") as f:
@@ -200,6 +207,8 @@ def get_html_template():
         content = content.replace(PLACEHOLDER, tags)
         if js:
             content = content.replace(JS_PLACEHOLDER, js)
+        if css:
+            content = content.replace(CSS_PLACEHOLDER, css)
         return content
 
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
       rel="stylesheet"
     />
     <!-- JS INJECTION PLACEHOLDER -->
+    <!-- CSS INJECTION PLACEHOLDER -->
     <script>
       const global = globalThis;
     </script>


### PR DESCRIPTION
This pull request adds another parameter to the configuration file `config.toml`. It allows to add a custom CSS file so that you can customize the CSS of the UI. This CSS file will be then injected into the index.html of the frontend React project.

Here is how you inject the custom CSS file by editing `config.toml`:

```
[UI]
# Name of the app and chatbot.
name = "Chatbot"

...

# Custom CSS file that can be used to customize the UI.
custom_css = '/assets/test.css'
```