### PR TITLE
Add forgot password UI

### DIFF
--- a/libs/components/package.json
+++ b/libs/components/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts theme/index.ts --dts --format=esm,cjs --clean --dts",
-    "build:watch": "tsup src/index.ts theme/index.ts --watch --format=esm,cjs --sourcemap",
+    "build:watch": "tsup src/index.ts theme/index.ts --watch --format=esm,cjs --sourcemap inline --dts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/libs/components/src/auth/AuthLogin.tsx
+++ b/libs/components/src/auth/AuthLogin.tsx
@@ -59,7 +59,7 @@ type AuthLoginProps = {
     password: string,
     callbackUrl: string
   ) => Promise<any>;
-  onForgotPassword?: () => void;
+  onForgotPassword?: () => Promise<any>;
   renderLogo?: React.ReactElement;
 };
 

--- a/libs/components/src/auth/AuthLogin.tsx
+++ b/libs/components/src/auth/AuthLogin.tsx
@@ -59,7 +59,7 @@ type AuthLoginProps = {
     password: string,
     callbackUrl: string
   ) => Promise<any>;
-  onForgotPassword?: () => Promise<any>;
+  onForgotPassword?: () => void;
   renderLogo?: React.ReactElement;
 };
 

--- a/libs/components/src/auth/AuthResetPassword.tsx
+++ b/libs/components/src/auth/AuthResetPassword.tsx
@@ -1,50 +1,117 @@
 import { useFormik } from 'formik';
+import { useState } from 'react';
 import * as yup from 'yup';
 
-import { Button, Link } from '@mui/material';
+import { MailOutline } from '@mui/icons-material';
+import { Alert, Box, Button, Link } from '@mui/material';
 
 import { TextInput } from '../inputs/TextInput';
 import { AuthTemplate } from './AuthTemplate';
 
 interface AuthResetPasswordProps {
   onGoBack: () => void;
-  onContinue: (value: string) => void;
+  onContinue: (value: string) => Promise<void>;
 }
 
 const AuthResetPassword = ({
   onGoBack,
   onContinue
 }: AuthResetPasswordProps): JSX.Element => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [showConfirmation, setShowConfirmation] = useState(false);
+
   const formik = useFormik({
     initialValues: {
       email: ''
     },
     validationSchema: yup.object({
-      email: yup.string().required()
+      email: yup.string().email().required()
     }),
-    onSubmit: async () => undefined
+    onSubmit: async ({ email }) => {
+      setLoading(true);
+
+      try {
+        await onContinue(email);
+        setShowConfirmation(true);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error.message);
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    validateOnBlur: true,
+    validateOnChange: false
   });
 
   return (
-    <AuthTemplate title="Enter your email address and we will send you instructions to reset your password.">
-      <TextInput
-        id="email"
-        placeholder="Email adress"
-        size="medium"
-        value={formik.values.email}
-        hasError={!!formik.errors.email}
-        description={formik.errors.email}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          formik.setFieldValue('email', e.target.value)
-        }
-      />
-      <Button
-        variant="contained"
-        sx={{ marginTop: 1 }}
-        onClick={() => onContinue(formik.values.email)}
-      >
-        Continue
-      </Button>
+    <AuthTemplate
+      renderLogo={
+        showConfirmation ? (
+          <Box
+            sx={{
+              border: 3,
+              borderColor: 'success.main',
+              borderRadius: 50,
+              width: 60,
+              height: 60,
+              display: 'grid',
+              placeItems: 'center'
+            }}
+          >
+            <MailOutline color="success" fontSize="large" />
+          </Box>
+        ) : undefined
+      }
+      title={
+        showConfirmation
+          ? `Please check the email address ${formik.values.email} for instructions to reset your password.`
+          : 'Enter your email address and we will send you instructions to reset your password.'
+      }
+    >
+      {error ? (
+        <Alert sx={{ my: 1 }} severity="error">
+          {error}
+        </Alert>
+      ) : null}
+
+      {showConfirmation ? (
+        <Button
+          onClick={() => formik.handleSubmit()}
+          color="success"
+          variant="outlined"
+          sx={{ marginTop: 1 }}
+        >
+          Resend email
+        </Button>
+      ) : (
+        <form onSubmit={formik.handleSubmit}>
+          <TextInput
+            id="email"
+            placeholder="Email adress"
+            size="medium"
+            value={formik.values.email}
+            hasError={!!formik.errors.email}
+            description={formik.errors.email}
+            onBlur={formik.handleBlur}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              formik.setFieldValue('email', e.target.value)
+            }
+          />
+
+          <Button
+            type="submit"
+            disabled={loading}
+            variant="contained"
+            sx={{ marginTop: 1, width: '100%' }}
+          >
+            Continue
+          </Button>
+        </form>
+      )}
+
       <Link component="button" marginTop={1} onClick={onGoBack}>
         Go Back
       </Link>


### PR DESCRIPTION
## Changes

- Fix: generate type definition in dev mode 
- Flesh out the `AuthResetPassword` to properly use the cloud
  - 💡 I took inspiration from the existing Auth0 forgot password form, for now I think the UI is servicable.

## How to test?

- ⚠️ explanation in the incoming cloud PR