### PR TITLE
Fix firefox notification count appearance

### DIFF
--- a/libs/components/src/NotificationCount.tsx
+++ b/libs/components/src/NotificationCount.tsx
@@ -37,7 +37,10 @@ const NotificationCount = ({
 
   const renderInput = () => {
     const getInputWidth = (hasArrow?: boolean) => {
-      const contentWidth = count.toString().length * 8 + (hasArrow ? 18 : 0);
+      const countString = count.toString();
+      let contentWidth = countString.length * 8 + (hasArrow ? 22 : 0);
+      if (countString.includes('.') || countString.includes(','))
+        contentWidth -= 6;
       return `${contentWidth}px`;
     };
 
@@ -55,11 +58,13 @@ const NotificationCount = ({
             fontSize: '12px',
             fontWeight: 600,
             color: 'text.secondary',
+            MozAppearance: 'textfield',
             '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': {
               display: 'none'
             },
             '&:focus': {
               width: getInputWidth(true),
+              MozAppearance: 'auto',
               '&::-webkit-inner-spin-button, &::-webkit-outer-spin-button': {
                 display: 'flex'
               }


### PR DESCRIPTION
The "Up & Down" number input buttons were always visible in firefox.

![image](https://github.com/Chainlit/chainlit/assets/10130747/5e10d28e-5483-4642-803d-c9e10154c554)

I also introduced some extra spacing between the number and the "Up & Down" to improve readability.