### PR TITLE
Fix Azure AD oauth

### DIFF
--- a/backend/chainlit/secret.py
+++ b/backend/chainlit/secret.py
@@ -2,7 +2,7 @@ import secrets
 import string
 
 # Using punctuation, without chars that can break in the cli (quotes, backslash, backtick...)
-chars = string.ascii_letters + string.digits + "$%*+,-./:<=>?@^_~"
+chars = string.ascii_letters + string.digits + "$%*+,-./:=>?@^_~"
 
 
 def random_secret(length: int = 64):


### PR DESCRIPTION
## Changes

- Remove unsupported character for validating authentication

## How to test?

- In `server.py#oauth_login` replace the random secret with `L+WBN^?Oqn?qw=j8K<HkMtmZwRLYJHK+` 
- Notice that the Azure authentication fails
- Remove the `<` character
- Notice that the Azure authentication succeeds