### PR TITLE
Support Azure AD single tenant

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -137,7 +137,16 @@ class AzureADOAuthProvider(OAuthProvider):
         "OAUTH_AZURE_AD_CLIENT_SECRET",
         "OAUTH_AZURE_AD_TENANT_ID",
     ]
-    authorize_url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    authorize_url = (
+        f"https://login.microsoftonline.com/{os.environ.get('OAUTH_AZURE_AD_TENANT_ID', '')}/oauth2/v2.0/authorize"
+        if os.environ.get("OAUTH_AZURE_AD_ENABLE_SINGLE_TENANT")
+        else "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+    )
+    token_url = (
+        f"https://login.microsoftonline.com/{os.environ.get('OAUTH_AZURE_AD_TENANT_ID', '')}/oauth2/v2.0/token"
+        if os.environ.get("OAUTH_AZURE_AD_ENABLE_SINGLE_TENANT")
+        else "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+    )
 
     def __init__(self):
         self.client_id = os.environ.get("OAUTH_AZURE_AD_CLIENT_ID")
@@ -159,7 +168,7 @@ class AzureADOAuthProvider(OAuthProvider):
         }
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.post(
-                "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+                self.token_url,
                 data=payload,
             ) as result:
                 json = await result.json()


### PR DESCRIPTION
Solving #425

## Changes

- Add an env variable to toggle `single tenant` option (pick theses over decorator parameter because it would be a leak of abstraction)

## How to test?

- Add `OAUTH_AZURE_AD_ENABLE_SINGLE_TENANT=true`
- Update credentials for a single tenant application
- Notice that you can connect to chainlit app