### PR TITLE
feat: add chat profiles

### DIFF
--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -41,7 +41,7 @@ from chainlit.message import AskFileMessage, AskUserMessage, ErrorMessage, Messa
 from chainlit.oauth_providers import get_configured_oauth_providers
 from chainlit.sync import make_async, run_sync
 from chainlit.telemetry import trace
-from chainlit.types import FileSpec
+from chainlit.types import ChatProfile, FileSpec
 from chainlit.user_session import user_session
 from chainlit.utils import make_module_getattr, wrap_user_function
 from chainlit.version import __version__
@@ -147,6 +147,24 @@ def on_chat_start(func: Callable) -> Callable:
     """
 
     config.code.on_chat_start = wrap_user_function(func, with_task=True)
+    return func
+
+
+@trace
+def chat_profiles(
+    func: Callable[[Optional["AppUser"]], List["ChatProfile"]]
+) -> Callable:
+    """
+    Programmatic declaration of the available chat profiles (can depend on the AppUser from the session if authentication is setup).
+
+    Args:
+        func (Callable[[Optional["AppUser"]], List["ChatProfile"]]): The function declaring the chat profiles.
+
+    Returns:
+        Callable[[Optional["AppUser"]], List["ChatProfile"]]: The decorated function.
+    """
+
+    config.code.chat_profiles = wrap_user_function(func)
     return func
 
 

--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -151,7 +151,7 @@ def on_chat_start(func: Callable) -> Callable:
 
 
 @trace
-def chat_profiles(
+def set_chat_profiles(
     func: Callable[[Optional["AppUser"]], List["ChatProfile"]]
 ) -> Callable:
     """
@@ -164,7 +164,7 @@ def chat_profiles(
         Callable[[Optional["AppUser"]], List["ChatProfile"]]: The decorated function.
     """
 
-    config.code.chat_profiles = wrap_user_function(func)
+    config.code.set_chat_profiles = wrap_user_function(func)
     return func
 
 

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import tomli
 from chainlit.logger import logger
-from chainlit.types import ChatProfile
 from chainlit.version import __version__
 from dataclasses_json import DataClassJsonMixin
 from pydantic.dataclasses import dataclass
@@ -14,6 +13,8 @@ from starlette.datastructures import Headers
 if TYPE_CHECKING:
     from chainlit.action import Action
     from chainlit.client.base import AppUser
+    from chainlit.types import ChatProfile
+
 
 BACKEND_ROOT = os.path.dirname(__file__)
 PACKAGE_ROOT = os.path.dirname(os.path.dirname(BACKEND_ROOT))

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import tomli
 from chainlit.logger import logger
+from chainlit.types import ChatProfile
 from chainlit.version import __version__
 from dataclasses_json import DataClassJsonMixin
 from pydantic.dataclasses import dataclass
@@ -171,6 +172,7 @@ class CodeSettings:
     on_file_upload: Optional[Callable[[str], Any]] = None
     author_rename: Optional[Callable[[str], str]] = None
     on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
+    chat_profiles: Optional[Callable[[Optional["AppUser"]], List["ChatProfile"]]] = None
 
 
 @dataclass()

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -172,7 +172,9 @@ class CodeSettings:
     on_file_upload: Optional[Callable[[str], Any]] = None
     author_rename: Optional[Callable[[str], str]] = None
     on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
-    chat_profiles: Optional[Callable[[Optional["AppUser"]], List["ChatProfile"]]] = None
+    set_chat_profiles: Optional[
+        Callable[[Optional["AppUser"]], List["ChatProfile"]]
+    ] = None
 
 
 @dataclass()

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -440,12 +440,18 @@ async def project_settings(
     current_user: Annotated[Union[AppUser, PersistedAppUser], Depends(get_current_user)]
 ):
     """Return project settings. This is called by the UI before the establishing the websocket connection."""
+    profiles = []
+    if config.code.chat_profiles:
+        chat_profiles = await config.code.chat_profiles(current_user)
+        if chat_profiles:
+            profiles = [dict(p) for p in chat_profiles]
     return JSONResponse(
         content={
             "ui": config.ui.to_dict(),
             "userEnv": config.project.user_env,
             "dataPersistence": config.data_persistence,
             "markdown": get_markdown_str(config.root),
+            "chatProfiles": profiles,
         }
     )
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -441,8 +441,8 @@ async def project_settings(
 ):
     """Return project settings. This is called by the UI before the establishing the websocket connection."""
     profiles = []
-    if config.code.chat_profiles:
-        chat_profiles = await config.code.chat_profiles(current_user)
+    if config.code.set_chat_profiles:
+        chat_profiles = await config.code.set_chat_profiles(current_user)
         if chat_profiles:
             profiles = [dict(p) for p in chat_profiles]
     return JSONResponse(

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -444,7 +444,7 @@ async def project_settings(
     if config.code.set_chat_profiles:
         chat_profiles = await config.code.set_chat_profiles(current_user)
         if chat_profiles:
-            profiles = [dict(p) for p in chat_profiles]
+            profiles = [p.to_dict() for p in chat_profiles]
     return JSONResponse(
         content={
             "ui": config.ui.to_dict(),

--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -20,16 +20,19 @@ class BaseSession:
         user: Optional[Union["AppUser", "PersistedAppUser"]],
         # Logged-in user token
         token: Optional[str],
+        # User specific environment variables. Empty if no user environment variables are required.
         user_env: Optional[Dict[str, str]],
         # Last message at the root of the chat
         root_message: Optional["Message"] = None,
-        # User specific environment variables. Empty if no user environment variables are required.
+        # Chat profile selected before the session was created
+        chat_profile: Optional[str] = None,
     ):
         self.user = user
         self.token = token
         self.root_message = root_message
         self.has_user_message = False
         self.user_env = user_env or {}
+        self.chat_profile = chat_profile
 
         self.id = id
         self.conversation_id: Optional[str] = None
@@ -110,9 +113,16 @@ class WebsocketSession(BaseSession):
         token: Optional[str],
         # Last message at the root of the chat
         root_message: Optional["Message"] = None,
+        # Chat profile selected before the session was created
+        chat_profile: Optional[str] = None,
     ):
         super().__init__(
-            id=id, user=user, token=token, user_env=user_env, root_message=root_message
+            id=id,
+            user=user,
+            token=token,
+            user_env=user_env,
+            root_message=root_message,
+            chat_profile=chat_profile,
         )
 
         self.socket_id = socket_id

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -47,7 +47,9 @@ def load_user_env(user_env):
 @socket.on("connect")
 async def connect(sid, environ, auth):
     if not config.code.on_chat_start and not config.code.on_message:
-        raise ConnectionRefusedError("No websocket endpoint configured")
+        raise ConnectionRefusedError(
+            "You need to configure at least an on_chat_start or an on_message callback"
+        )
 
     user = None
     token = None

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -91,6 +91,7 @@ async def connect(sid, environ, auth):
         user_env=user_env,
         user=user,
         token=token,
+        chat_profile=environ.get("HTTP_X_CHAINLIT_CHAT_PROFILE"),
     )
 
     trace_event("connection_successful")

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -76,4 +76,4 @@ class ChatProfile(BaseModel):
 
     icon: str
     name: str
-    description: str
+    markdown_description: str

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -69,3 +69,11 @@ class GetConversationsRequest(BaseModel):
 class Theme(str, Enum):
     light = "light"
     dark = "dark"
+
+
+class ChatProfile(BaseModel):
+    """Specification for a chat profile that can be chosen by the user at the conversation start."""
+
+    icon: str
+    name: str
+    description: str

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -71,9 +71,10 @@ class Theme(str, Enum):
     dark = "dark"
 
 
-class ChatProfile(BaseModel):
+@dataclass
+class ChatProfile(DataClassJsonMixin):
     """Specification for a chat profile that can be chosen by the user at the conversation start."""
 
-    icon: Optional[str]
     name: str
     markdown_description: str
+    icon: Optional[str] = None

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -74,6 +74,6 @@ class Theme(str, Enum):
 class ChatProfile(BaseModel):
     """Specification for a chat profile that can be chosen by the user at the conversation start."""
 
-    icon: str
+    icon: Optional[str]
     name: str
     markdown_description: str

--- a/backend/chainlit/user_session.py
+++ b/backend/chainlit/user_session.py
@@ -13,6 +13,7 @@ class UserSessionDict(TypedDict):
     headers: Dict[str, str]
     user: Optional[Union["AppUser", "PersistedAppUser"]]
     root_message: Optional["Message"]
+    chat_profile: Optional[str]
 
 
 user_sessions: Dict[str, UserSessionDict] = {}
@@ -39,6 +40,7 @@ class UserSession:
         user_session["env"] = context.session.user_env
         user_session["chat_settings"] = context.session.chat_settings
         user_session["user"] = context.session.user
+        user_session["chat_profile"] = context.session.chat_profile
 
         if context.session.root_message:
             user_session["root_message"] = context.session.root_message

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,26 +1,26 @@
-import { defineConfig } from "cypress";
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
-  projectId: "ij1tyk",
+  projectId: 'ij1tyk',
   component: {
     devServer: {
-      framework: "react",
-      bundler: "vite",
-    },
+      framework: 'react',
+      bundler: 'vite'
+    }
   },
 
   e2e: {
     supportFile: false,
     defaultCommandTimeout: 10000,
-    video: false,
-    baseUrl: "http://127.0.0.1:8000",
+    video: true,
+    baseUrl: 'http://127.0.0.1:8000',
     setupNodeEvents(on, config) {
-      on("task", {
+      on('task', {
         log(message) {
           console.log(message);
           return null;
-        },
+        }
       });
-    },
-  },
+    }
+  }
 });

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   e2e: {
     supportFile: false,
     defaultCommandTimeout: 10000,
-    video: true,
+    video: false,
     baseUrl: 'http://127.0.0.1:8000',
     setupNodeEvents(on, config) {
       on('task', {

--- a/cypress/e2e/ask_user/spec.cy.ts
+++ b/cypress/e2e/ask_user/spec.cy.ts
@@ -1,17 +1,16 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
-describe("Ask User", () => {
+describe('Ask User', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should send a new message containing the user input", () => {
-    cy.get("#welcome-screen").should("exist");
-    cy.get(".message").should("have.length", 1);
-    submitMessage("Jeeves");
+  it('should send a new message containing the user input', () => {
+    cy.get('.message').should('have.length', 1);
+    submitMessage('Jeeves');
     cy.wait(2000);
-    cy.get(".message").should("have.length", 3);
+    cy.get('.message').should('have.length', 3);
 
-    cy.get(".message").eq(2).should("contain", "Jeeves");
+    cy.get('.message').eq(2).should('contain', 'Jeeves');
   });
 });

--- a/cypress/e2e/audio_element/spec.cy.ts
+++ b/cypress/e2e/audio_element/spec.cy.ts
@@ -1,23 +1,21 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("audio", () => {
+describe('audio', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display an audio element", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to display an audio element', () => {
+    cy.get('.message').should('have.length', 1);
+    cy.get('.message').eq(0).find('.inline-audio').should('have.length', 1);
 
-    cy.get(".message").should("have.length", 1);
-    cy.get(".message").eq(0).find(".inline-audio").should("have.length", 1);
-
-    cy.get(".inline-audio audio")
+    cy.get('.inline-audio audio')
       .then(($el) => {
         const audioElement = $el.get(0) as HTMLAudioElement;
         return audioElement.play().then(() => {
           return audioElement.duration;
         });
       })
-      .should("be.greaterThan", 0);
+      .should('be.greaterThan', 0);
   });
 });

--- a/cypress/e2e/avatar/spec.cy.ts
+++ b/cypress/e2e/avatar/spec.cy.ts
@@ -1,19 +1,17 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("Avatar", () => {
+describe('Avatar', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display a nested CoT", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to display a nested CoT', () => {
+    cy.get('.message').should('have.length', 3);
 
-    cy.get(".message").should("have.length", 3);
+    cy.get('.message').eq(0).find('.message-avatar').should('have.length', 0);
+    cy.get('.message').eq(1).find('.message-avatar').should('have.length', 1);
+    cy.get('.message').eq(2).find('.message-avatar').should('have.length', 0);
 
-    cy.get(".message").eq(0).find(".message-avatar").should("have.length", 0);
-    cy.get(".message").eq(1).find(".message-avatar").should("have.length", 1);
-    cy.get(".message").eq(2).find(".message-avatar").should("have.length", 0);
-
-    cy.get(".element-link").should("have.length", 0);
+    cy.get('.element-link').should('have.length', 0);
   });
 });

--- a/cypress/e2e/chat_profiles/.chainlit/config.toml
+++ b/cypress/e2e/chat_profiles/.chainlit/config.toml
@@ -1,0 +1,69 @@
+[project]
+# Whether to enable telemetry (default: true). No personal data is collected.
+enable_telemetry = true
+
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+# Duration (in seconds) during which the session is saved when the connection is lost
+session_timeout = 3600
+
+# Enable third parties caching (e.g LangChain cache)
+cache = false
+
+# Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
+# follow_symlink = false
+
+[features]
+# Show the prompt playground
+prompt_playground = true
+
+[UI]
+# Name of the app and chatbot.
+name = "Chatbot"
+
+# Description of the app and chatbot. This is used for HTML tags.
+# description = ""
+
+# Large size content are by default collapsed for a cleaner ui
+default_collapse_content = true
+
+# The default value for the expand messages settings.
+default_expand_messages = false
+
+# Hide the chain of thought details from the user in the UI.
+hide_cot = false
+
+# Link to your github repo. This will add a github button in the UI's header.
+# github = ""
+
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# If the app is served behind a reverse proxy (like cloud run) we need to know the base url for oauth
+# base_url = "https://mydomain.com"
+
+# Override default MUI light theme. (Check theme.ts)
+[UI.theme.light]
+    #background = "#FAFAFA"
+    #paper = "#FFFFFF"
+
+    [UI.theme.light.primary]
+        #main = "#F80061"
+        #dark = "#980039"
+        #light = "#FFE7EB"
+
+# Override default MUI dark theme. (Check theme.ts)
+[UI.theme.dark]
+    #background = "#FAFAFA"
+    #paper = "#FFFFFF"
+
+    [UI.theme.dark.primary]
+        #main = "#F80061"
+        #dark = "#980039"
+        #light = "#FFE7EB"
+
+
+[meta]
+generated_by = "0.7.1"

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -3,7 +3,7 @@ from typing import Optional
 import chainlit as cl
 
 
-@cl.chat_profiles
+@cl.set_chat_profiles
 async def chat_profile(current_user: cl.AppUser):
     if current_user.role != "ADMIN":
         return None

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+import chainlit as cl
+
+
+@cl.chat_profiles
+async def chat_profile(current_user: cl.AppUser):
+    if current_user.role != "ADMIN":
+        return None
+
+    return [
+        cl.ChatProfile(
+            name="GPT-3.5",
+            description="The underlying LLM model is GPT-3.5, a 175B parameter model trained on 410GB of text data.",
+            icon="https://picsum.photos/200",
+        ),
+        cl.ChatProfile(
+            name="GPT-4",
+            description="The underlying LLM model is GPT-4, a 1.5T parameter model trained on 3.5TB of text data.",
+            icon="https://picsum.photos/250",
+        ),
+    ]
+
+
+@cl.password_auth_callback
+def auth_callback(username: str, password: str) -> Optional[cl.AppUser]:
+    if (username, password) == ("admin", "admin"):
+        return cl.AppUser(username="admin", role="ADMIN", provider="credentials")
+    else:
+        return None
+
+
+@cl.on_chat_start
+async def on_chat_start():
+    app_user = cl.user_session.get("user")
+    chat_profile = cl.user_session.get("chat_profile")
+    await cl.Message(
+        content=f"starting chat with {app_user.username} using the {chat_profile} chat profile"
+    ).send()

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -18,6 +18,11 @@ async def chat_profile(current_user: cl.AppUser):
             markdown_description="The underlying LLM model is **GPT-4**, a *1.5T parameter model* trained on 3.5TB of text data.",
             icon="https://picsum.photos/250",
         ),
+        cl.ChatProfile(
+            name="GPT-5",
+            markdown_description="The underlying LLM model is **GPT-5**.",
+            icon="https://picsum.photos/200",
+        ),
     ]
 
 
@@ -29,10 +34,15 @@ def auth_callback(username: str, password: str) -> Optional[cl.AppUser]:
         return None
 
 
-@cl.on_chat_start
-async def on_chat_start():
-    app_user = cl.user_session.get("user")
-    chat_profile = cl.user_session.get("chat_profile")
-    await cl.Message(
-        content=f"starting chat with {app_user.username} using the {chat_profile} chat profile"
-    ).send()
+@cl.on_message
+async def on_message(message: str):
+    await cl.Message(content=f"echo: {message}").send()
+
+
+# @cl.on_chat_start
+# async def on_chat_start():
+#     app_user = cl.user_session.get("user")
+#     chat_profile = cl.user_session.get("chat_profile")
+#     await cl.Message(
+#         content=f"starting chat with {app_user.username} using the {chat_profile} chat profile"
+#     ).send()

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -34,15 +34,15 @@ def auth_callback(username: str, password: str) -> Optional[cl.AppUser]:
         return None
 
 
-@cl.on_message
-async def on_message(message: str):
-    await cl.Message(content=f"echo: {message}").send()
+# @cl.on_message
+# async def on_message(message: str):
+#     await cl.Message(content=f"echo: {message}").send()
 
 
-# @cl.on_chat_start
-# async def on_chat_start():
-#     app_user = cl.user_session.get("user")
-#     chat_profile = cl.user_session.get("chat_profile")
-#     await cl.Message(
-#         content=f"starting chat with {app_user.username} using the {chat_profile} chat profile"
-#     ).send()
+@cl.on_chat_start
+async def on_chat_start():
+    app_user = cl.user_session.get("user")
+    chat_profile = cl.user_session.get("chat_profile")
+    await cl.Message(
+        content=f"starting chat with {app_user.username} using the {chat_profile} chat profile"
+    ).send()

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -11,12 +11,12 @@ async def chat_profile(current_user: cl.AppUser):
     return [
         cl.ChatProfile(
             name="GPT-3.5",
-            description="The underlying LLM model is **GPT-3.5**, a *175B parameter model* trained on 410GB of text data.",
+            markdown_description="The underlying LLM model is **GPT-3.5**, a *175B parameter model* trained on 410GB of text data.",
             icon="https://picsum.photos/200",
         ),
         cl.ChatProfile(
             name="GPT-4",
-            description="The underlying LLM model is **GPT-4**, a *1.5T parameter model* trained on 3.5TB of text data.",
+            markdown_description="The underlying LLM model is **GPT-4**, a *1.5T parameter model* trained on 3.5TB of text data.",
             icon="https://picsum.photos/250",
         ),
     ]

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -12,7 +12,6 @@ async def chat_profile(current_user: cl.AppUser):
         cl.ChatProfile(
             name="GPT-3.5",
             markdown_description="The underlying LLM model is **GPT-3.5**, a *175B parameter model* trained on 410GB of text data.",
-            icon="https://picsum.photos/200",
         ),
         cl.ChatProfile(
             name="GPT-4",

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -11,12 +11,12 @@ async def chat_profile(current_user: cl.AppUser):
     return [
         cl.ChatProfile(
             name="GPT-3.5",
-            description="The underlying LLM model is GPT-3.5, a 175B parameter model trained on 410GB of text data.",
+            description="The underlying LLM model is **GPT-3.5**, a *175B parameter model* trained on 410GB of text data.",
             icon="https://picsum.photos/200",
         ),
         cl.ChatProfile(
             name="GPT-4",
-            description="The underlying LLM model is GPT-4, a 1.5T parameter model trained on 3.5TB of text data.",
+            description="The underlying LLM model is **GPT-4**, a *1.5T parameter model* trained on 3.5TB of text data.",
             icon="https://picsum.photos/250",
         ),
     ]

--- a/cypress/e2e/chat_profiles/spec.cy.ts
+++ b/cypress/e2e/chat_profiles/spec.cy.ts
@@ -1,0 +1,45 @@
+import { runTestServer } from '../../support/testUtils';
+
+describe('Chat profiles', () => {
+  before(() => {
+    runTestServer();
+    cy.visit('/');
+    cy.get("input[name='email']").type('admin');
+    cy.get("input[name='password']").type('admin');
+    cy.get("button[type='submit']").click();
+    cy.get('.MuiAlert-message').should('not.exist');
+  });
+
+  it('should be able to select a chat profile', () => {
+    cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
+    cy.get('[data-test="chat-profile:GPT-4"]').should('exist');
+
+    cy.get('[data-test="chat-profile:GPT-3.5"]').click();
+
+    cy.get('.message').should(
+      'contain',
+      'starting chat with admin using the GPT-3.5 chat profile'
+    );
+
+    cy.get('[data-test="chat-profile:GPT-3.5"]').should('not.exist');
+    cy.get('[data-test="chat-profile:GPT-4"]').should('not.exist');
+
+    // New conversation
+
+    cy.get('#new-chat-button').click();
+    cy.get('#confirm').click();
+
+    cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
+    cy.get('[data-test="chat-profile:GPT-4"]').should('exist');
+
+    cy.get('[data-test="chat-profile:GPT-4"]').click();
+
+    cy.get('.message').should(
+      'contain',
+      'starting chat with admin using the GPT-4 chat profile'
+    );
+
+    cy.get('[data-test="chat-profile:GPT-3.5"]').should('not.exist');
+    cy.get('[data-test="chat-profile:GPT-4"]').should('not.exist');
+  });
+});

--- a/cypress/e2e/chat_profiles/spec.cy.ts
+++ b/cypress/e2e/chat_profiles/spec.cy.ts
@@ -13,33 +13,39 @@ describe('Chat profiles', () => {
   it('should be able to select a chat profile', () => {
     cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
     cy.get('[data-test="chat-profile:GPT-4"]').should('exist');
+    cy.get('[data-test="chat-profile:GPT-5"]').should('exist');
 
-    cy.get('[data-test="chat-profile:GPT-3.5"]').click();
+    cy.get('.message')
+      .should('have.length', 1)
+      .eq(0)
+      .should(
+        'contain',
+        'starting chat with admin using the GPT-3.5 chat profile'
+      );
 
-    cy.get('.message').should(
-      'contain',
-      'starting chat with admin using the GPT-3.5 chat profile'
-    );
+    // Change chat profile
 
-    cy.get('[data-test="chat-profile:GPT-3.5"]').should('not.exist');
-    cy.get('[data-test="chat-profile:GPT-4"]').should('not.exist');
+    cy.get('[data-test="chat-profile:GPT-4"]').click();
+    cy.get('#confirm').click();
 
+    cy.get('.message')
+      .should('have.length', 1)
+      .eq(0)
+      .should(
+        'contain',
+        'starting chat with admin using the GPT-4 chat profile'
+      );
     // New conversation
 
     cy.get('#new-chat-button').click();
     cy.get('#confirm').click();
 
-    cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
-    cy.get('[data-test="chat-profile:GPT-4"]').should('exist');
-
-    cy.get('[data-test="chat-profile:GPT-4"]').click();
-
-    cy.get('.message').should(
-      'contain',
-      'starting chat with admin using the GPT-4 chat profile'
-    );
-
-    cy.get('[data-test="chat-profile:GPT-3.5"]').should('not.exist');
-    cy.get('[data-test="chat-profile:GPT-4"]').should('not.exist');
+    cy.get('.message')
+      .should('have.length', 1)
+      .eq(0)
+      .should(
+        'contain',
+        'starting chat with admin using the GPT-4 chat profile'
+      );
   });
 });

--- a/cypress/e2e/chat_profiles/spec.cy.ts
+++ b/cypress/e2e/chat_profiles/spec.cy.ts
@@ -12,6 +12,8 @@ describe('Chat profiles', () => {
   });
 
   it('should be able to select a chat profile', () => {
+    cy.get('.message').should('exist'); // temp fix as the CI isn't finding the next elements
+
     cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
     cy.get('[data-test="chat-profile:GPT-4"]').should('exist');
     cy.get('[data-test="chat-profile:GPT-5"]').should('exist');

--- a/cypress/e2e/chat_profiles/spec.cy.ts
+++ b/cypress/e2e/chat_profiles/spec.cy.ts
@@ -3,16 +3,15 @@ import { runTestServer } from '../../support/testUtils';
 describe('Chat profiles', () => {
   before(() => {
     runTestServer();
+  });
+
+  it('should be able to select a chat profile', () => {
     cy.visit('/');
     cy.get("input[name='email']").type('admin');
     cy.get("input[name='password']").type('admin');
     cy.get("button[type='submit']").click();
     cy.get('.MuiAlert-message').should('not.exist');
     cy.get('#chat-input').should('exist');
-  });
-
-  it('should be able to select a chat profile', () => {
-    cy.get('.message').should('exist'); // temp fix as the CI isn't finding the next elements
 
     cy.get('[data-test="chat-profile:GPT-3.5"]').should('exist');
     cy.get('[data-test="chat-profile:GPT-4"]').should('exist');

--- a/cypress/e2e/chat_profiles/spec.cy.ts
+++ b/cypress/e2e/chat_profiles/spec.cy.ts
@@ -8,6 +8,7 @@ describe('Chat profiles', () => {
     cy.get("input[name='password']").type('admin');
     cy.get("button[type='submit']").click();
     cy.get('.MuiAlert-message').should('not.exist');
+    cy.get('#chat-input').should('exist');
   });
 
   it('should be able to select a chat profile', () => {

--- a/cypress/e2e/cot/spec.cy.ts
+++ b/cypress/e2e/cot/spec.cy.ts
@@ -1,23 +1,22 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
-describe("Chain of Thought", () => {
+describe('Chain of Thought', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display a nested CoT", () => {
-    cy.get("#welcome-screen").should("exist");
-    submitMessage("Hello");
+  it('should be able to display a nested CoT', () => {
+    submitMessage('Hello');
 
-    cy.get("#tool-1-loading").should("exist");
-    cy.get("#tool-1-loading").click();
+    cy.get('#tool-1-loading').should('exist');
+    cy.get('#tool-1-loading').click();
 
-    cy.get("#tool-2-loading").should("exist");
-    cy.get("#tool-2-loading").click();
+    cy.get('#tool-2-loading').should('exist');
+    cy.get('#tool-2-loading').click();
 
-    cy.get("#tool-1-done").should("exist");
-    cy.get("#tool-2-done").should("exist");
+    cy.get('#tool-1-done').should('exist');
+    cy.get('#tool-2-done').should('exist');
 
-    cy.get(".message").should("have.length", 5);
+    cy.get('.message').should('have.length', 5);
   });
 });

--- a/cypress/e2e/default_expand_cot/spec.cy.ts
+++ b/cypress/e2e/default_expand_cot/spec.cy.ts
@@ -1,14 +1,13 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
-describe("Default Expand", () => {
+describe('Default Expand', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to set the default_expand_messages field in the config to have the CoT expanded by default", () => {
-    cy.get("#welcome-screen").should("exist");
-    submitMessage("Hello");
+  it('should be able to set the default_expand_messages field in the config to have the CoT expanded by default', () => {
+    submitMessage('Hello');
 
-    cy.get(".message").should("have.length", 5);
+    cy.get('.message').should('have.length', 5);
   });
 });

--- a/cypress/e2e/file_element/spec.cy.ts
+++ b/cypress/e2e/file_element/spec.cy.ts
@@ -1,23 +1,21 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("file", () => {
+describe('file', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display a file element", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to display a file element', () => {
+    cy.get('.message').should('have.length', 1);
+    cy.get('.message').eq(0).find('.inline-file').should('have.length', 4);
 
-    cy.get(".message").should("have.length", 1);
-    cy.get(".message").eq(0).find(".inline-file").should("have.length", 4);
-
-    cy.get("a.inline-file")
+    cy.get('a.inline-file')
       .eq(0)
-      .should("have.attr", "download", "example.mp4");
-    cy.get("a.inline-file").eq(1).should("have.attr", "download", "cat.jpeg");
-    cy.get("a.inline-file").eq(2).should("have.attr", "download", "hello.py");
-    cy.get("a.inline-file")
+      .should('have.attr', 'download', 'example.mp4');
+    cy.get('a.inline-file').eq(1).should('have.attr', 'download', 'cat.jpeg');
+    cy.get('a.inline-file').eq(2).should('have.attr', 'download', 'hello.py');
+    cy.get('a.inline-file')
       .eq(3)
-      .should("have.attr", "download", "example.mp3");
+      .should('have.attr', 'download', 'example.mp3');
   });
 });

--- a/cypress/e2e/langchain_cb/spec.cy.ts
+++ b/cypress/e2e/langchain_cb/spec.cy.ts
@@ -1,33 +1,31 @@
-import { describeSyncAsync, runTestServer } from "../../support/testUtils";
+import { describeSyncAsync, runTestServer } from '../../support/testUtils';
 
-describeSyncAsync("Langchain Callback", (mode) => {
+describeSyncAsync('Langchain Callback', (mode) => {
   before(() => {
     runTestServer(mode);
   });
 
-  it("should be able to send messages to the UI with prompts", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to send messages to the UI with prompts', () => {
+    cy.get('.message').should('have.length', 1);
 
-    cy.get(".message").should("have.length", 1);
+    cy.get('#testchain1-done').should('exist').click();
 
-    cy.get("#testchain1-done").should("exist").click();
+    cy.get('.message').should('have.length', 3);
 
-    cy.get(".message").should("have.length", 3);
+    cy.get('#testtool1-done').should('exist').click();
 
-    cy.get("#testtool1-done").should("exist").click();
+    cy.get('.message').should('have.length', 4);
 
-    cy.get(".message").should("have.length", 4);
+    cy.get('.playground-button').eq(0).should('exist').click();
 
-    cy.get(".playground-button").eq(0).should("exist").click();
+    cy.get('.formatted-editor [contenteditable]')
+      .should('exist')
+      .should('contain', 'This is prompt of llm1');
 
-    cy.get(".formatted-editor [contenteditable]")
-      .should("exist")
-      .should("contain", "This is prompt of llm1");
+    cy.get('.completion-editor [contenteditable]')
+      .should('exist')
+      .should('contain', 'This is the response of llm1');
 
-    cy.get(".completion-editor [contenteditable]")
-      .should("exist")
-      .should("contain", "This is the response of llm1");
-
-    cy.get("#close-playground").should("exist").click();
+    cy.get('#close-playground').should('exist').click();
   });
 });

--- a/cypress/e2e/llama_index_cb/spec.cy.ts
+++ b/cypress/e2e/llama_index_cb/spec.cy.ts
@@ -1,35 +1,33 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("Llama Index Callback", () => {
+describe('Llama Index Callback', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to send messages to the UI with prompts and elements", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to send messages to the UI with prompts and elements', () => {
+    cy.get('.message').should('have.length', 1);
 
-    cy.get(".message").should("have.length", 1);
+    cy.get('#llm-done').should('exist').click();
 
-    cy.get("#llm-done").should("exist").click();
+    cy.get('.message').should('have.length', 3);
 
-    cy.get(".message").should("have.length", 3);
-
-    cy.get(".message")
+    cy.get('.message')
       .eq(1)
-      .find(".element-link")
+      .find('.element-link')
       .eq(0)
-      .should("contain", "Source 0");
+      .should('contain', 'Source 0');
 
-    cy.get(".playground-button").eq(0).should("exist").click();
+    cy.get('.playground-button').eq(0).should('exist').click();
 
-    cy.get(".formatted-editor [contenteditable]")
-      .should("exist")
-      .should("contain", "This is the LLM prompt");
+    cy.get('.formatted-editor [contenteditable]')
+      .should('exist')
+      .should('contain', 'This is the LLM prompt');
 
-    cy.get(".completion-editor [contenteditable]")
-      .should("exist")
-      .should("contain", "This is the LLM response");
+    cy.get('.completion-editor [contenteditable]')
+      .should('exist')
+      .should('contain', 'This is the LLM response');
 
-    cy.get("#close-playground").should("exist").click();
+    cy.get('#close-playground').should('exist').click();
   });
 });

--- a/cypress/e2e/pyplot/spec.cy.ts
+++ b/cypress/e2e/pyplot/spec.cy.ts
@@ -1,14 +1,12 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("pyplot", () => {
+describe('pyplot', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display an inline chart", () => {
-    cy.get("#welcome-screen").should("exist");
-
-    cy.get(".message").should("have.length", 1);
-    cy.get(".message").eq(0).find(".inline-image").should("have.length", 1);
+  it('should be able to display an inline chart', () => {
+    cy.get('.message').should('have.length', 1);
+    cy.get('.message').eq(0).find('.inline-image').should('have.length', 1);
   });
 });

--- a/cypress/e2e/remove_elements/spec.cy.ts
+++ b/cypress/e2e/remove_elements/spec.cy.ts
@@ -1,14 +1,12 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("remove_elements", () => {
+describe('remove_elements', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to remove elements", () => {
-    cy.get("#welcome-screen").should("exist");
-
-    cy.get(".message").should("have.length", 1);
-    cy.get(".inline-image").should("have.length", 1);
+  it('should be able to remove elements', () => {
+    cy.get('.message').should('have.length', 1);
+    cy.get('.inline-image').should('have.length', 1);
   });
 });

--- a/cypress/e2e/tasklist/spec.cy.ts
+++ b/cypress/e2e/tasklist/spec.cy.ts
@@ -1,40 +1,38 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
-describe("tasklist", () => {
+describe('tasklist', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should display the tasklist ", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should display the tasklist ', () => {
+    cy.get('.message').should('have.length', 0);
+    cy.get('.tasklist').should('have.length', 2);
+    cy.get('.tasklist.tasklist-mobile').should('not.be.visible');
+    cy.get('.tasklist.tasklist-mobile .task').should('not.be.visible');
 
-    cy.get(".message").should("have.length", 0);
-    cy.get(".tasklist").should("have.length", 2);
-    cy.get(".tasklist.tasklist-mobile").should("not.be.visible");
-    cy.get(".tasklist.tasklist-mobile .task").should("not.be.visible");
+    cy.get('.tasklist.tasklist-desktop').should('be.visible');
+    cy.get('.tasklist.tasklist-desktop .task').should('have.length', 17);
 
-    cy.get(".tasklist.tasklist-desktop").should("be.visible");
-    cy.get(".tasklist.tasklist-desktop .task").should("have.length", 17);
-
-    cy.get(".tasklist.tasklist-desktop .task.task-status-ready").should(
-      "have.length",
+    cy.get('.tasklist.tasklist-desktop .task.task-status-ready').should(
+      'have.length',
       7
     );
-    cy.get(".tasklist.tasklist-desktop .task.task-status-running").should(
-      "have.length",
+    cy.get('.tasklist.tasklist-desktop .task.task-status-running').should(
+      'have.length',
       0
     );
-    cy.get(".tasklist.tasklist-desktop .task.task-status-failed").should(
-      "have.length",
+    cy.get('.tasklist.tasklist-desktop .task.task-status-failed').should(
+      'have.length',
       1
     );
-    cy.get(".tasklist.tasklist-desktop .task.task-status-done").should(
-      "have.length",
+    cy.get('.tasklist.tasklist-desktop .task.task-status-done').should(
+      'have.length',
       9
     );
 
-    submitMessage("ok");
+    submitMessage('ok');
 
-    cy.get(".tasklist").should("not.exist");
+    cy.get('.tasklist').should('not.exist');
   });
 });

--- a/cypress/e2e/user_env/spec.cy.ts
+++ b/cypress/e2e/user_env/spec.cy.ts
@@ -1,23 +1,22 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
-describe("User Env", () => {
+describe('User Env', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to ask a user for required keys", () => {
-    const key = "TEST_KEY";
-    const keyValue = "TEST_VALUE";
+  it('should be able to ask a user for required keys', () => {
+    const key = 'TEST_KEY';
+    const keyValue = 'TEST_VALUE';
 
-    cy.get("#env").should("exist");
-    cy.get(`.${key}`).should("exist").type(keyValue);
+    cy.get('#env').should('exist');
+    cy.get(`.${key}`).should('exist').type(keyValue);
 
-    cy.get("#submit-env").should("exist").click();
-    cy.get("#welcome-screen").should("exist");
+    cy.get('#submit-env').should('exist').click();
 
-    submitMessage("Hello");
+    submitMessage('Hello');
 
-    cy.get(".message").should("have.length", 2);
-    cy.get(".message").eq(1).should("contain", keyValue);
+    cy.get('.message').should('have.length', 2);
+    cy.get('.message').eq(1).should('contain', keyValue);
   });
 });

--- a/cypress/e2e/user_session/spec.cy.ts
+++ b/cypress/e2e/user_session/spec.cy.ts
@@ -1,43 +1,39 @@
-import { runTestServer, submitMessage } from "../../support/testUtils";
+import { runTestServer, submitMessage } from '../../support/testUtils';
 
 function newSession() {
-  cy.get("#new-chat-button").should("exist").click();
-  cy.get("#new-chat-dialog").should("exist");
-  cy.get("#confirm").should("exist").click();
+  cy.get('#new-chat-button').should('exist').click();
+  cy.get('#new-chat-dialog').should('exist');
+  cy.get('#confirm').should('exist').click();
 
-  cy.get("#new-chat-dialog").should("not.exist");
-
-  cy.get("#welcome-screen").should("exist");
+  cy.get('#new-chat-dialog').should('not.exist');
 }
 
-describe("User Session", () => {
+describe('User Session', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to store data related per user session", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to store data related per user session', () => {
+    submitMessage('Hello 1');
 
-    submitMessage("Hello 1");
+    cy.get('.message').should('have.length', 2);
+    cy.get('.message').eq(1).should('contain', 'Prev message: None');
 
-    cy.get(".message").should("have.length", 2);
-    cy.get(".message").eq(1).should("contain", "Prev message: None");
+    submitMessage('Hello 2');
 
-    submitMessage("Hello 2");
-
-    cy.get(".message").should("have.length", 4);
-    cy.get(".message").eq(3).should("contain", "Prev message: Hello 1");
+    cy.get('.message').should('have.length', 4);
+    cy.get('.message').eq(3).should('contain', 'Prev message: Hello 1');
 
     newSession();
 
-    submitMessage("Hello 3");
+    submitMessage('Hello 3');
 
-    cy.get(".message").should("have.length", 2);
-    cy.get(".message").eq(1).should("contain", "Prev message: None");
+    cy.get('.message').should('have.length', 2);
+    cy.get('.message').eq(1).should('contain', 'Prev message: None');
 
-    submitMessage("Hello 4");
+    submitMessage('Hello 4');
 
-    cy.get(".message").should("have.length", 4);
-    cy.get(".message").eq(3).should("contain", "Prev message: Hello 3");
+    cy.get('.message').should('have.length', 4);
+    cy.get('.message').eq(3).should('contain', 'Prev message: Hello 3');
   });
 });

--- a/cypress/e2e/video_element/spec.cy.ts
+++ b/cypress/e2e/video_element/spec.cy.ts
@@ -1,23 +1,21 @@
-import { runTestServer } from "../../support/testUtils";
+import { runTestServer } from '../../support/testUtils';
 
-describe("video", () => {
+describe('video', () => {
   before(() => {
     runTestServer();
   });
 
-  it("should be able to display a video element", () => {
-    cy.get("#welcome-screen").should("exist");
+  it('should be able to display a video element', () => {
+    cy.get('.message').should('have.length', 1);
+    cy.get('.message').eq(0).find('.inline-video').should('have.length', 1);
 
-    cy.get(".message").should("have.length", 1);
-    cy.get(".message").eq(0).find(".inline-video").should("have.length", 1);
-
-    cy.get("video.inline-video")
+    cy.get('video.inline-video')
       .then(($el) => {
         const videoElement = $el.get(0) as HTMLVideoElement;
         return videoElement.play().then(() => {
           return videoElement.duration;
         });
       })
-      .should("be.greaterThan", 0);
+      .should('be.greaterThan', 0);
   });
 });

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -19,7 +19,7 @@ export async function runTests(matchName) {
   // Recording the cypress run is time consuming. Disabled by default.
   // const recordOptions = ` --record --key ${process.env.CYPRESS_RECORD_KEY} `;
   return runCommand(
-    `pnpm exec cypress run --record --key ${process.env.CYPRESS_RECORD_KEY} --spec "cypress/e2e/${matchName}/spec.cy.ts"`
+    `pnpm exec cypress run --record false --spec "cypress/e2e/${matchName}/spec.cy.ts"`
   );
 }
 

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -19,7 +19,7 @@ export async function runTests(matchName) {
   // Recording the cypress run is time consuming. Disabled by default.
   // const recordOptions = ` --record --key ${process.env.CYPRESS_RECORD_KEY} `;
   return runCommand(
-    `pnpm exec cypress run --record false --spec "cypress/e2e/${matchName}/spec.cy.ts"`
+    `pnpm exec cypress run --record --key ${process.env.CYPRESS_RECORD_KEY} --spec "cypress/e2e/${matchName}/spec.cy.ts"`
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import PromptPlayground from 'components/organisms/playground';
 
 import { useAuth } from 'hooks/auth';
 
+import { chatProfile, projectSettingsState } from 'state/project';
 import { settingsState } from 'state/settings';
 import { userEnvState } from 'state/user';
 
@@ -68,16 +69,34 @@ function overrideTheme(theme: Theme) {
 
 function App() {
   const { theme: themeVariant } = useRecoilValue(settingsState);
+  const pSettings = useRecoilValue(projectSettingsState);
+  const chatProfileValue = useRecoilValue(chatProfile);
   const theme = overrideTheme(makeTheme(themeVariant));
   const { isAuthenticated, accessToken } = useAuth();
   const userEnv = useRecoilValue(userEnvState);
-  const { connect } = useChat();
+  const { connect, disconnect } = useChat();
 
   useEffect(() => {
-    if (isAuthenticated) {
-      connect(wsEndpoint, userEnv, accessToken);
+    if (
+      isAuthenticated &&
+      pSettings?.chatProfiles &&
+      (pSettings.chatProfiles.length === 0 || chatProfileValue)
+    ) {
+      connect({
+        wsEndpoint,
+        userEnv,
+        accessToken,
+        chatProfiles: chatProfileValue
+      });
     }
-  }, [userEnv, accessToken, isAuthenticated, connect]);
+  }, [
+    userEnv,
+    accessToken,
+    isAuthenticated,
+    connect,
+    pSettings?.chatProfiles,
+    chatProfileValue
+  ]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,19 +74,24 @@ function App() {
   const theme = overrideTheme(makeTheme(themeVariant));
   const { isAuthenticated, accessToken } = useAuth();
   const userEnv = useRecoilValue(userEnvState);
-  const { connect, disconnect } = useChat();
+  const { connect } = useChat();
 
   useEffect(() => {
     if (
       isAuthenticated &&
       pSettings?.chatProfiles &&
-      (pSettings.chatProfiles.length === 0 || chatProfileValue)
+      (pSettings.chatProfiles.length <= 1 || chatProfileValue)
     ) {
+      // Autoselect the chat profile if there is only one
+      const chatProfile =
+        pSettings.chatProfiles.length === 1
+          ? pSettings.chatProfiles[0].name
+          : chatProfileValue;
       connect({
         wsEndpoint,
         userEnv,
         accessToken,
-        chatProfiles: chatProfileValue
+        chatProfile
       });
     }
   }, [

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -43,6 +43,9 @@ export default function ChatProfiles() {
               setAnchorEl(e.currentTarget.parentElement);
             }}
             onMouseLeave={() => setAnchorEl(null)}
+            sx={{
+              textTransform: 'none'
+            }}
           >
             <img
               src={profile.icon}

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -62,7 +62,7 @@ export default function ChatProfiles() {
   const popoverOpen = Boolean(anchorEl);
 
   return (
-    <Box p={2} alignSelf="center">
+    <Box py={2} alignSelf="center" maxWidth="min(60rem, 90vw)" overflow="auto">
       <InputStateHandler
         id={'chat-profile-selector'}
         sx={{
@@ -146,6 +146,7 @@ export default function ChatProfiles() {
                   setAnchorEl(event.currentTarget.parentElement);
                 }}
                 onMouseLeave={() => setAnchorEl(null)}
+                data-test={`chat-profile:${item.name}`}
               />
             ))}
           </Tabs>
@@ -155,9 +156,17 @@ export default function ChatProfiles() {
         id="chat-profile-description"
         anchorEl={anchorEl}
         open={popoverOpen}
+        PaperProps={{
+          sx: {
+            boxShadow: (theme) =>
+              theme.palette.mode === 'light'
+                ? '0px 2px 4px 0px #0000000D'
+                : '0px 10px 10px 0px #0000000D'
+          }
+        }}
         sx={{
           pointerEvents: 'none',
-          marginTop: 1
+          marginTop: 1.5
         }}
         anchorOrigin={{
           vertical: 'bottom',

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -39,7 +39,7 @@ export default function ChatProfiles() {
             value={profile.name}
             onClick={() => setChatProfile(profile.name)}
             onMouseEnter={(e) => {
-              setChatProfileDescription(profile.description);
+              setChatProfileDescription(profile.markdown_description);
               setAnchorEl(e.currentTarget.parentElement);
             }}
             onMouseLeave={() => setAnchorEl(null)}

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -1,0 +1,50 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { Box, Stack } from '@mui/material';
+
+import { chatProfile, projectSettingsState } from 'state/project';
+
+export default function ChatProfiles() {
+  const pSettings = useRecoilValue(projectSettingsState);
+  const [chatProfileValue, setChatProfile] = useRecoilState(chatProfile);
+
+  if (
+    typeof pSettings === 'undefined' ||
+    pSettings.chatProfiles.length === 0 ||
+    chatProfileValue
+  ) {
+    return null;
+  }
+
+  return (
+    <Box p={2} alignSelf="center">
+      <Stack direction="row" spacing={1}>
+        {pSettings.chatProfiles.map((profile) => (
+          <Box
+            key={profile.name}
+            sx={{ cursor: 'pointer' }}
+            display="flex"
+            justifyContent="center"
+            border="1px solid"
+            borderColor={'divider'}
+            p={1}
+            onClick={() => setChatProfile(profile.name)}
+            title={profile.description}
+            data-test={`chat-profile:${profile.name}`}
+          >
+            <img
+              src={profile.icon}
+              style={{
+                width: '20px',
+                height: '20px',
+                borderRadius: '50%',
+                marginRight: '4px'
+              }}
+            />
+            {profile.name}
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -114,15 +114,28 @@ export default function ChatProfiles() {
                 disableRipple
                 label={item.name}
                 value={item.name}
+                sx={{
+                  '& .chat-profile-icon': {
+                    filter:
+                      item.name !== chatProfileValue
+                        ? 'grayscale(100%)'
+                        : undefined
+                  },
+                  '&:hover': {
+                    '& .chat-profile-icon': { filter: 'grayscale(0%)' }
+                  }
+                }}
                 icon={
                   item.icon ? (
                     <img
                       src={item.icon}
+                      className="chat-profile-icon"
                       style={{
-                        width: '20px',
-                        height: '20px',
+                        width: '24px',
+                        height: '24px',
                         borderRadius: '50%',
-                        objectFit: 'cover'
+                        objectFit: 'cover',
+                        transition: 'filter 0.5s ease-in-out'
                       }}
                     />
                   ) : undefined

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -1,12 +1,17 @@
+import { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { Box, Stack } from '@mui/material';
+import { Box, Popover, ToggleButton, ToggleButtonGroup } from '@mui/material';
 
 import { chatProfile, projectSettingsState } from 'state/project';
+
+import Markdown from './markdown';
 
 export default function ChatProfiles() {
   const pSettings = useRecoilValue(projectSettingsState);
   const [chatProfileValue, setChatProfile] = useRecoilState(chatProfile);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [chatProfileDescription, setChatProfileDescription] = useState('');
 
   if (
     typeof pSettings === 'undefined' ||
@@ -16,21 +21,28 @@ export default function ChatProfiles() {
     return null;
   }
 
+  const open = Boolean(anchorEl);
+
   return (
     <Box p={2} alignSelf="center">
-      <Stack direction="row" spacing={1}>
+      <ToggleButtonGroup
+        color="primary"
+        value={''}
+        exclusive
+        aria-label="Chat profile"
+        aria-owns={open ? 'chat-profile-description' : undefined}
+        aria-haspopup="true"
+      >
         {pSettings.chatProfiles.map((profile) => (
-          <Box
+          <ToggleButton
             key={profile.name}
-            sx={{ cursor: 'pointer' }}
-            display="flex"
-            justifyContent="center"
-            border="1px solid"
-            borderColor={'divider'}
-            p={1}
+            value={profile.name}
             onClick={() => setChatProfile(profile.name)}
-            title={profile.description}
-            data-test={`chat-profile:${profile.name}`}
+            onMouseEnter={(e) => {
+              setChatProfileDescription(profile.description);
+              setAnchorEl(e.currentTarget.parentElement);
+            }}
+            onMouseLeave={() => setAnchorEl(null)}
           >
             <img
               src={profile.icon}
@@ -40,11 +52,34 @@ export default function ChatProfiles() {
                 borderRadius: '50%',
                 marginRight: '4px'
               }}
-            />
+            />{' '}
             {profile.name}
-          </Box>
+          </ToggleButton>
         ))}
-      </Stack>
+      </ToggleButtonGroup>
+      <Popover
+        id="chat-profile-description"
+        anchorEl={anchorEl}
+        open={open}
+        sx={{
+          pointerEvents: 'none',
+          marginTop: 1
+        }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center'
+        }}
+        onClose={() => setAnchorEl(null)}
+        disableRestoreFocus
+      >
+        <Box p={2} maxWidth="20rem">
+          <Markdown content={chatProfileDescription} />
+        </Box>
+      </Popover>
     </Box>
   );
 }

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -46,6 +46,7 @@ export default function ChatProfiles() {
             sx={{
               textTransform: 'none'
             }}
+            data-test={`chat-profile:${profile.name}`}
           >
             <img
               src={profile.icon}

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -10,7 +10,7 @@ export default function ChatProfiles() {
 
   if (
     typeof pSettings === 'undefined' ||
-    pSettings.chatProfiles.length === 0 ||
+    pSettings.chatProfiles.length <= 1 ||
     chatProfileValue
   ) {
     return null;

--- a/frontend/src/components/molecules/markdown.tsx
+++ b/frontend/src/components/molecules/markdown.tsx
@@ -1,0 +1,29 @@
+import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { Link } from '@mui/material';
+
+import { Code } from '@chainlit/components';
+
+type Props = {
+  content: string;
+};
+
+export default function Markdown({ content }: Props) {
+  return (
+    <ReactMarkdown
+      className="markdown-body"
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ children, ...props }) => (
+          <Link {...props} target="_blank">
+            {children}
+          </Link>
+        ),
+        code: ({ ...props }) => <Code {...props} />
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/components/molecules/newChatButton.tsx
+++ b/frontend/src/components/molecules/newChatButton.tsx
@@ -3,13 +3,10 @@ import { useNavigate } from 'react-router-dom';
 
 import AddIcon from '@mui/icons-material/Add';
 import { Box } from '@mui/material';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
 
-import { AccentButton, RegularButton, useChat } from '@chainlit/components';
+import { AccentButton, useChat } from '@chainlit/components';
+
+import NewChatDialog from './newChatDialog';
 
 export default function NewChatButton() {
   const navigate = useNavigate();
@@ -40,36 +37,11 @@ export default function NewChatButton() {
       >
         New Chat
       </AccentButton>
-      <Dialog
+      <NewChatDialog
         open={open}
-        onClose={handleClose}
-        id="new-chat-dialog"
-        PaperProps={{
-          sx: {
-            backgroundImage: 'none'
-          }
-        }}
-      >
-        <DialogTitle id="alert-dialog-title">
-          {'Create a new chat?'}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText id="alert-dialog-description">
-            This will clear the current messages and start a new chat.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions sx={{ p: 2 }}>
-          <RegularButton onClick={handleClose}>Cancel</RegularButton>
-          <AccentButton
-            id="confirm"
-            variant="outlined"
-            onClick={handleConfirm}
-            autoFocus
-          >
-            Confirm
-          </AccentButton>
-        </DialogActions>
-      </Dialog>
+        handleClose={handleClose}
+        handleConfirm={handleConfirm}
+      />
     </Box>
   );
 }

--- a/frontend/src/components/molecules/newChatButton.tsx
+++ b/frontend/src/components/molecules/newChatButton.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 
 import AddIcon from '@mui/icons-material/Add';
 import { Box } from '@mui/material';
@@ -12,13 +11,10 @@ import DialogTitle from '@mui/material/DialogTitle';
 
 import { AccentButton, RegularButton, useChat } from '@chainlit/components';
 
-import { chatProfile } from 'state/project';
-
 export default function NewChatButton() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const { clear } = useChat();
-  const setChatProfile = useSetRecoilState(chatProfile);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -29,9 +25,6 @@ export default function NewChatButton() {
   };
 
   const handleConfirm = () => {
-    // Clear profile to enable users to change it before their next chat
-    setChatProfile(undefined);
-
     clear();
     navigate('/');
     handleClose();

--- a/frontend/src/components/molecules/newChatButton.tsx
+++ b/frontend/src/components/molecules/newChatButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import AddIcon from '@mui/icons-material/Add';
 import { Box } from '@mui/material';
@@ -11,10 +12,13 @@ import DialogTitle from '@mui/material/DialogTitle';
 
 import { AccentButton, RegularButton, useChat } from '@chainlit/components';
 
+import { chatProfile } from 'state/project';
+
 export default function NewChatButton() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const { clear } = useChat();
+  const setChatProfile = useSetRecoilState(chatProfile);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -25,6 +29,9 @@ export default function NewChatButton() {
   };
 
   const handleConfirm = () => {
+    // Clear profile to enable users to change it before their next chat
+    setChatProfile(undefined);
+
     clear();
     navigate('/');
     handleClose();

--- a/frontend/src/components/molecules/newChatDialog.tsx
+++ b/frontend/src/components/molecules/newChatDialog.tsx
@@ -1,0 +1,50 @@
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+
+import { AccentButton, RegularButton } from '@chainlit/components';
+
+type Props = {
+  open: boolean;
+  handleClose: () => void;
+  handleConfirm: () => void;
+};
+
+export default function NewChatDialog({
+  open,
+  handleClose,
+  handleConfirm
+}: Props) {
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      id="new-chat-dialog"
+      PaperProps={{
+        sx: {
+          backgroundImage: 'none'
+        }
+      }}
+    >
+      <DialogTitle id="alert-dialog-title">{'Create a new chat?'}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          This will clear the current messages and start a new chat.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ p: 2 }}>
+        <RegularButton onClick={handleClose}>Cancel</RegularButton>
+        <AccentButton
+          id="confirm"
+          variant="outlined"
+          onClick={handleConfirm}
+          autoFocus
+        >
+          Confirm
+        </AccentButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Alert, Box } from '@mui/material';
@@ -14,20 +14,14 @@ import { useAuth } from 'hooks/auth';
 
 import { chatHistoryState } from 'state/chatHistory';
 import { conversationsHistoryState } from 'state/conversations';
-import {
-  chatProfile,
-  projectSettingsState,
-  sideViewState
-} from 'state/project';
+import { projectSettingsState, sideViewState } from 'state/project';
 
 import InputBox from './inputBox';
 import MessageContainer from './message/container';
-import WelcomeScreen from './welcomeScreen';
 
 const Chat = () => {
   const { user } = useAuth();
   const pSettings = useRecoilValue(projectSettingsState);
-  const [chatProfileValue, setChatProfile] = useRecoilState(chatProfile);
   const sideViewElement = useRecoilValue(sideViewState);
   const setChatHistory = useSetRecoilState(chatHistoryState);
   const setConversations = useSetRecoilState(conversationsHistoryState);
@@ -116,21 +110,18 @@ const Chat = () => {
           </Alert>
         )}
         <ErrorBoundary>
-          {!!messages.length && (
-            <MessageContainer
-              avatars={avatars}
-              loading={loading}
-              askUser={askUser}
-              actions={actions}
-              elements={elements}
-              messages={messages}
-              autoScroll={autoScroll}
-              callAction={callAction}
-              setAutoScroll={setAutoScroll}
-            />
-          )}
-          {!messages.length && <ChatProfiles />}
-          {!messages.length && <WelcomeScreen />}
+          <ChatProfiles />
+          <MessageContainer
+            avatars={avatars}
+            loading={loading}
+            askUser={askUser}
+            actions={actions}
+            elements={elements}
+            messages={messages}
+            autoScroll={autoScroll}
+            callAction={callAction}
+            setAutoScroll={setAutoScroll}
+          />
           <InputBox onReply={onReply} onSubmit={onSubmit} />
         </ErrorBoundary>
       </SideView>

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -7,6 +7,7 @@ import { Alert, Box } from '@mui/material';
 import { ErrorBoundary, IMessage, useChat } from '@chainlit/components';
 
 import SideView from 'components/atoms/element/sideView';
+import { Logo } from 'components/atoms/logo';
 import ChatProfiles from 'components/molecules/chatProfiles';
 import TaskList from 'components/molecules/tasklist';
 
@@ -123,6 +124,22 @@ const Chat = () => {
             setAutoScroll={setAutoScroll}
           />
           <InputBox onReply={onReply} onSubmit={onSubmit} />
+          <Logo
+            style={{
+              width: '200px',
+              height: '200px',
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              filter: 'grayscale(100%)',
+              opacity: messages.length > 0 ? 0 : 0.5,
+              transition:
+                messages.length > 0
+                  ? 'opacity 1s ease-in-out'
+                  : 'opacity 0.2s ease-in-out'
+            }}
+          />
         </ErrorBoundary>
       </SideView>
       {sideViewElement ? null : (

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -128,15 +128,17 @@ const Chat = () => {
             style={{
               width: '200px',
               height: '200px',
+              objectFit: 'contain',
               position: 'absolute',
-              top: '50%',
+              pointerEvents: 'none',
+              top: '45%',
               left: '50%',
               transform: 'translate(-50%, -50%)',
               filter: 'grayscale(100%)',
               opacity: messages.length > 0 ? 0 : 0.5,
               transition:
                 messages.length > 0
-                  ? 'opacity 1s ease-in-out'
+                  ? 'opacity 0.2s ease-in-out'
                   : 'opacity 0.2s ease-in-out'
             }}
           />

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -1,20 +1,25 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Alert, Box } from '@mui/material';
+import { Alert, Box, Stack } from '@mui/material';
 
 import { ErrorBoundary, IMessage } from '@chainlit/components';
 import { useChat } from '@chainlit/components';
 
 import SideView from 'components/atoms/element/sideView';
+import ChatProfiles from 'components/molecules/chatProfiles';
 import TaskList from 'components/molecules/tasklist';
 
 import { useAuth } from 'hooks/auth';
 
 import { chatHistoryState } from 'state/chatHistory';
 import { conversationsHistoryState } from 'state/conversations';
-import { projectSettingsState, sideViewState } from 'state/project';
+import {
+  chatProfile,
+  projectSettingsState,
+  sideViewState
+} from 'state/project';
 
 import InputBox from './inputBox';
 import MessageContainer from './message/container';
@@ -23,6 +28,7 @@ import WelcomeScreen from './welcomeScreen';
 const Chat = () => {
   const { user } = useAuth();
   const pSettings = useRecoilValue(projectSettingsState);
+  const [chatProfileValue, setChatProfile] = useRecoilState(chatProfile);
   const sideViewElement = useRecoilValue(sideViewState);
   const setChatHistory = useSetRecoilState(chatHistoryState);
   const setConversations = useSetRecoilState(conversationsHistoryState);
@@ -124,6 +130,7 @@ const Chat = () => {
               setAutoScroll={setAutoScroll}
             />
           )}
+          {!messages.length && <ChatProfiles />}
           {!messages.length && <WelcomeScreen />}
           <InputBox onReply={onReply} onSubmit={onSubmit} />
         </ErrorBoundary>

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -2,10 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Alert, Box, Stack } from '@mui/material';
+import { Alert, Box } from '@mui/material';
 
-import { ErrorBoundary, IMessage } from '@chainlit/components';
-import { useChat } from '@chainlit/components';
+import { ErrorBoundary, IMessage, useChat } from '@chainlit/components';
 
 import SideView from 'components/atoms/element/sideView';
 import ChatProfiles from 'components/molecules/chatProfiles';

--- a/frontend/src/components/organisms/chat/welcomeScreen.tsx
+++ b/frontend/src/components/organisms/chat/welcomeScreen.tsx
@@ -1,10 +1,8 @@
-import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { useRecoilValue } from 'recoil';
-import remarkGfm from 'remark-gfm';
 
-import { Box, Link } from '@mui/material';
+import { Box } from '@mui/material';
 
-import { Code } from '@chainlit/components';
+import Markdown from 'components/molecules/markdown';
 
 import { projectSettingsState } from 'state/project';
 
@@ -35,20 +33,7 @@ const WelcomeScreen = () => {
         }}
       >
         {pSettings?.markdown ? (
-          <ReactMarkdown
-            className="markdown-body"
-            remarkPlugins={[remarkGfm]}
-            components={{
-              a: ({ children, ...props }) => (
-                <Link {...props} target="_blank">
-                  {children}
-                </Link>
-              ),
-              code: ({ ...props }) => <Code {...props} />
-            }}
-          >
-            {pSettings?.markdown}
-          </ReactMarkdown>
+          <Markdown content={pSettings?.markdown} />
         ) : null}
       </Box>
     </Box>

--- a/frontend/src/components/organisms/conversationsHistory/sidebar/ConversationsHistoryList.tsx
+++ b/frontend/src/components/organisms/conversationsHistory/sidebar/ConversationsHistoryList.tsx
@@ -1,7 +1,6 @@
 import { capitalize, map, size } from 'lodash';
 import { useNavigate } from 'react-router-dom';
 
-import { Height } from '@mui/icons-material';
 import ChatBubbleOutline from '@mui/icons-material/ChatBubbleOutline';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -2,6 +2,12 @@ import { atom } from 'recoil';
 
 import { IMessage, IMessageElement } from '@chainlit/components';
 
+export interface ChatProfile {
+  icon: string;
+  name: string;
+  description: string;
+}
+
 export interface IProjectSettings {
   markdown?: string;
   ui: {
@@ -14,10 +20,16 @@ export interface IProjectSettings {
   };
   userEnv: string[];
   dataPersistence: boolean;
+  chatProfiles: ChatProfile[];
 }
 
 export const projectSettingsState = atom<IProjectSettings | undefined>({
   key: 'ProjectSettings',
+  default: undefined
+});
+
+export const chatProfile = atom<string | undefined>({
+  key: 'ChatProfile',
   default: undefined
 });
 

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -5,7 +5,7 @@ import { IMessage, IMessageElement } from '@chainlit/components';
 export interface ChatProfile {
   icon: string;
   name: string;
-  description: string;
+  markdown_description: string;
 }
 
 export interface IProjectSettings {

--- a/libs/components/hooks/useChat/index.ts
+++ b/libs/components/hooks/useChat/index.ts
@@ -293,7 +293,6 @@ const useChat = () => {
   }, [session]);
 
   const clear = useCallback(() => {
-    setChatProfile(undefined);
     session?.socket.emit('clear_session');
     session?.socket.disconnect();
     resetSessionId();

--- a/libs/components/hooks/useChat/index.ts
+++ b/libs/components/hooks/useChat/index.ts
@@ -75,12 +75,12 @@ const useChat = () => {
       wsEndpoint,
       userEnv,
       accessToken,
-      chatProfiles
+      chatProfile
     }: {
       wsEndpoint: string;
       userEnv: Record<string, string>;
       accessToken?: string;
-      chatProfiles?: string;
+      chatProfile?: string;
     }) => {
       const socket = io(wsEndpoint, {
         path: '/ws/socket.io',
@@ -88,7 +88,7 @@ const useChat = () => {
           Authorization: accessToken || '',
           'X-Chainlit-Session-Id': sessionId,
           'user-env': JSON.stringify(userEnv),
-          'X-Chainlit-Chat-Profile': chatProfiles || ''
+          'X-Chainlit-Chat-Profile': chatProfile || ''
         }
       });
       setSession((old) => {

--- a/libs/components/hooks/useChat/index.ts
+++ b/libs/components/hooks/useChat/index.ts
@@ -15,6 +15,7 @@ import {
   actionState,
   askUserState,
   avatarState,
+  chatProfile,
   chatSettingsDefaultValueSelector,
   chatSettingsInputsState,
   chatSettingsValueState,
@@ -69,6 +70,7 @@ const useChat = () => {
   const resetChatSettings = useResetRecoilState(chatSettingsInputsState);
   const resetSessionId = useResetRecoilState(sessionIdState);
   const setTokenCount = useSetRecoilState(tokenCountState);
+  const setChatProfile = useSetRecoilState(chatProfile);
 
   const _connect = useCallback(
     ({
@@ -291,6 +293,7 @@ const useChat = () => {
   }, [session]);
 
   const clear = useCallback(() => {
+    setChatProfile(undefined);
     session?.socket.emit('clear_session');
     session?.socket.disconnect();
     resetSessionId();

--- a/libs/components/hooks/useChat/index.ts
+++ b/libs/components/hooks/useChat/index.ts
@@ -71,17 +71,24 @@ const useChat = () => {
   const setTokenCount = useSetRecoilState(tokenCountState);
 
   const _connect = useCallback(
-    (
-      wsEndpoint: string,
-      userEnv: Record<string, string>,
-      accessToken?: string
-    ) => {
+    ({
+      wsEndpoint,
+      userEnv,
+      accessToken,
+      chatProfiles
+    }: {
+      wsEndpoint: string;
+      userEnv: Record<string, string>;
+      accessToken?: string;
+      chatProfiles?: string;
+    }) => {
       const socket = io(wsEndpoint, {
         path: '/ws/socket.io',
         extraHeaders: {
           Authorization: accessToken || '',
           'X-Chainlit-Session-Id': sessionId,
-          'user-env': JSON.stringify(userEnv)
+          'user-env': JSON.stringify(userEnv),
+          'X-Chainlit-Chat-Profile': chatProfiles || ''
         }
       });
       setSession((old) => {

--- a/libs/components/hooks/useChat/index.ts
+++ b/libs/components/hooks/useChat/index.ts
@@ -15,7 +15,6 @@ import {
   actionState,
   askUserState,
   avatarState,
-  chatProfile,
   chatSettingsDefaultValueSelector,
   chatSettingsInputsState,
   chatSettingsValueState,
@@ -70,7 +69,6 @@ const useChat = () => {
   const resetChatSettings = useResetRecoilState(chatSettingsInputsState);
   const resetSessionId = useResetRecoilState(sessionIdState);
   const setTokenCount = useSetRecoilState(tokenCountState);
-  const setChatProfile = useSetRecoilState(chatProfile);
 
   const _connect = useCallback(
     ({

--- a/libs/components/hooks/useChat/state.ts
+++ b/libs/components/hooks/useChat/state.ts
@@ -108,3 +108,8 @@ export const firstUserMessageState = atom<IMessage | undefined>({
   key: 'FirstUserMessage',
   default: undefined
 });
+
+export const chatProfile = atom<string | undefined>({
+  key: 'ChatProfile',
+  default: undefined
+});


### PR DESCRIPTION
- Chat profiles enable the end user to select a pre-configuration before starting a chat
- Chat profiles can be declared with a function decorated by `@cl.chat_profiles`
- Chat profiles are sent to the client via the `/project/settings` endpoint
- Users can select their chat profile of choice before starting a conversation (first or new conversation)
- The chat profile is sent to the backend with the websocket connect as a header
- The selected chat profile is stored in the user session as "chat_profile"

# Screenshots

Chat profile definition
<img width="1398" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/0b0366f8-9c97-4a52-b665-b0a85a02b39a">

Chat profile selection
<img width="1088" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/17c2e8a6-48a4-4df9-a83f-0f270a8a1db1">

Mouse over a chat profile button
<img width="386" alt="image" src="https://github.com/Chainlit/chainlit/assets/494686/badfc3ca-5ac4-4c4e-aadf-374bf50fc285">
