### PR TITLE
Added API reference docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please see [here](https://docs.chainlit.io) for full documentation on:
 
 - Getting started (installation, simple examples)
 - Examples
-- Reference (full API docs)
+- Reference ([full API docs](https://docs.chainlit.io/api-reference/on-chat-start))
 
 ## 🚀 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,23 @@ import chainlit as cl
 
 @cl.on_message  # this function will be called every time a user inputs a message in the UI
 async def main(message: str):
-    # this is an intermediate step
-    await cl.Message(author="Tool 1", content=f"Response from tool1", indent=1).send()
+    """
+    This function is called every time a user inputs a message in the UI.
+    It sends back an intermediate response from Tool 1, followed by the final answer.
 
-    # send back the final answer
+    Args:
+        message: The user's message.
+
+    Returns:
+        None.
+    """
+
+    # Send an intermediate response from Tool 1.
+    await cl.Message(
+        author="Tool 1", content=f"Response from tool1", indent=1
+    ).send()
+
+    # Send the final answer.
     await cl.Message(content=f"This is the final answer").send()
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ async def main(message: str):
 
     # Send an intermediate response from Tool 1.
     await cl.Message(
-        author="Tool 1", content=f"Response from tool1", indent=1
-    ).send()
+        author="Tool 1", content=f"Response from tool1", indent=1).send()
 
     # Send the final answer.
     await cl.Message(content=f"This is the final answer").send()


### PR DESCRIPTION
I have added API documentation for users who are new to Chainlit. While the official documentation is already mentioned in the README, I have provided a direct link to the API docs to save time.