### PR TITLE
Fix bug in playground for Azure OpenAI

### DIFF
--- a/backend/chainlit/playground/providers/openai.py
+++ b/backend/chainlit/playground/providers/openai.py
@@ -145,8 +145,11 @@ class ChatOpenAIProvider(BaseProvider):
 
         async def create_event_stream():
             async for stream_resp in response:
-                token = stream_resp.choices[0]["delta"].get("content", "")
-                yield token
+                if 'choices' in stream_resp and len(stream_resp.choices) > 0:
+                    token = stream_resp.choices[0]["delta"].get("content", "")
+                    yield token
+                else:
+                    continue
 
         return StreamingResponse(create_event_stream())
 

--- a/backend/chainlit/playground/providers/openai.py
+++ b/backend/chainlit/playground/providers/openai.py
@@ -145,7 +145,7 @@ class ChatOpenAIProvider(BaseProvider):
 
         async def create_event_stream():
             async for stream_resp in response:
-                if 'choices' in stream_resp and len(stream_resp.choices) > 0:
+                if hasattr(stream_resp, 'choices') and len(stream_resp.choices) > 0:
                     token = stream_resp.choices[0]["delta"].get("content", "")
                     yield token
                 else:


### PR DESCRIPTION
Long time user, first time contributor. Apologies if I'm not following the right format for this PR.

When working with the Playground and AzureOpenAI, if you try to rerun your prompt for a new completion you receive the following error:

```
Error:

File "/.venv/lib/python3.11/site-packages/chainlit/playground/providers/openai.py", line 148, in create_event_stream
    token = stream_resp.choices[0]["delta"].get("content", "")
            ~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

This is because when AzureOpenAI has "moderation" turned on, the first chunk has no 'choices' and instead just has "prompt_filter_results". It looks like this:

```
{
  "id": "",
  "object": "",
  "created": 0,
  "model": "",
  "prompt_filter_results": [
    {
      "prompt_index": 0,
      "content_filter_results": {
        "hate": {
          "filtered": false,
          "severity": "safe"
        },
        "self_harm": {
          "filtered": false,
          "severity": "safe"
        },
        "sexual": {
          "filtered": false,
          "severity": "safe"
        },
        "violence": {
          "filtered": false,
          "severity": "safe"
        }
      }
    }
  ],
  "choices": [],
  "usage": null
}
```

This PR introduces a very simple fix where we check for the existence of the choices field before referencing it. If it exists, we do business as usual. If it doesn't, we simply "continue" and wait for the next chunk.

I've tested this fix locally and it fixed the problem for me. 