### PR TITLE
Set oauth cookie to secure=True when using same-site=none

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -318,8 +318,9 @@ async def oauth_login(provider_id: str, request: Request):
         url=f"{provider.authorize_url}?{params}",
     )
     samesite = os.environ.get("CHAINLIT_COOKIE_SAMESITE", "lax")  # type: Any
+    secure = samesite.lower() == 'none'
     response.set_cookie(
-        "oauth_state", random, httponly=True, samesite=samesite, max_age=3 * 60
+        "oauth_state", random, httponly=True, samesite=samesite, secure=secure, max_age=3 * 60
     )
     return response
 


### PR DESCRIPTION
When setting the env var `CHAINLIT_COOKIE_SAMESITE=none` the `secure` parameter in the browser cookie needs to be set to `secure=True`. By default, `secure=False` so adding a boolean conditional and explicitly passing in the `secure` variable.

[Discord Discussion](https://discord.com/channels/1088038867602526210/1179183494124019852/1184663263070388244)

![image](https://github.com/Chainlit/chainlit/assets/35790761/0d32844d-cb2d-49d9-b5db-1bb8e493c63f)
