### PR TITLE
Add query parameters

### DIFF
--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -64,6 +64,8 @@ class BaseSession:
         root_message: Optional["Message"] = None,
         # Chat profile selected before the session was created
         chat_profile: Optional[str] = None,
+        # Query Params
+        query_params: Optional[Dict[str, str]] = None,
     ):
         if thread_id:
             self.thread_id_to_resume = thread_id
@@ -75,6 +77,7 @@ class BaseSession:
         self.has_first_interaction = False
         self.user_env = user_env or {}
         self.chat_profile = chat_profile
+        self.query_params = query_params
         self.active_steps = []
 
         self.id = id
@@ -165,6 +168,8 @@ class WebsocketSession(BaseSession):
         root_message: Optional["Message"] = None,
         # Chat profile selected before the session was created
         chat_profile: Optional[str] = None,
+        # Query Params
+        query_params: Optional[Dict[str, str]] = None,
     ):
         super().__init__(
             id=id,
@@ -175,6 +180,7 @@ class WebsocketSession(BaseSession):
             client_type=client_type,
             root_message=root_message,
             chat_profile=chat_profile,
+            query_params=query_params,
         )
 
         self.socket_id = socket_id

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -146,6 +146,7 @@ async def connect(sid, environ, auth):
         user_env=user_env,
         user=user,
         token=token,
+        query_params=environ.get("HTTP_QUERY_PARAMS"),
         chat_profile=environ.get("HTTP_X_CHAINLIT_CHAT_PROFILE"),
         thread_id=environ.get("HTTP_X_CHAINLIT_THREAD_ID"),
     )
@@ -185,7 +186,9 @@ async def connection_successful(sid):
             return
 
     if config.code.on_chat_start:
-        await config.code.on_chat_start()
+        await config.code.on_chat_start({
+            "query_params": context.session.query_params,
+        })
 
 
 @socket.on("clear_session")

--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -39,7 +39,8 @@ export default function AppWrapper() {
     window.location.pathname !== '/login' &&
     window.location.pathname !== '/login/callback'
   ) {
-    window.location.href = '/login';
+  
+    window.location.href = '/login?redirect=' + encodeURIComponent(window.location.href)
   }
 
   useEffect(() => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -17,6 +17,7 @@ export default function Login() {
   const { data: config, setAccessToken, user } = useAuth();
   const [error, setError] = useState('');
   const apiClient = useRecoilValue(apiClientState);
+  const redirect = query.get('redirect') || '/';
 
   const navigate = useNavigate();
 
@@ -26,7 +27,7 @@ export default function Login() {
     try {
       const json = await apiClient.headerAuth();
       setAccessToken(json.access_token);
-      navigate('/');
+      navigate(redirect);
     } catch (error: any) {
       setError(error.message);
     }
@@ -59,13 +60,13 @@ export default function Login() {
       return;
     }
     if (!config.requireLogin) {
-      navigate('/');
+      navigate(redirect);
     }
     if (config.headerAuth) {
       handleHeaderAuth();
     }
     if (user) {
-      navigate('/');
+      navigate(redirect);
     }
   }, [config, user]);
 

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -75,6 +75,9 @@ const useChatSession = () => {
       userEnv: Record<string, string>;
       accessToken?: string;
     }) => {
+      const queryParams = new URLSearchParams(window.location.search);
+      const queryParamsObject = Object.fromEntries(queryParams.entries());      
+
       const socket = io(client.httpEndpoint, {
         path: '/ws/socket.io',
         extraHeaders: {
@@ -83,6 +86,7 @@ const useChatSession = () => {
           'X-Chainlit-Session-Id': sessionId,
           'X-Chainlit-Thread-Id': idToResume || '',
           'user-env': JSON.stringify(userEnv),
+          'query-params': JSON.stringify(queryParamsObject),
           'X-Chainlit-Chat-Profile': chatProfile || ''
         }
       });


### PR DESCRIPTION
Initial proposal for the enhancement proposed in #144 to use the browser's query parameters as part of the app (e.g. process initial query on app launch with "?q=[QUERY]").

This implementation loads the query parameter as part of the initial page data being fetched in the `useChatSession` hook, then directly into the `on_chat_start` call of the app as it may be used in the initial setup call. Open to suggestions about how else it be called.