### PR TITLE
Remove `+` from secrets

### DIFF
--- a/backend/chainlit/secret.py
+++ b/backend/chainlit/secret.py
@@ -2,7 +2,7 @@ import secrets
 import string
 
 # Using punctuation, without chars that can break in the cli (quotes, backslash, backtick...)
-chars = string.ascii_letters + string.digits + "$%*+,-./:=>?@^_~"
+chars = string.ascii_letters + string.digits + "$%*,-./:=>?@^_~"
 
 
 def random_secret(length: int = 64):


### PR DESCRIPTION
Some oauth providers will replace the `+` character with a <space> which fails the auth check.

Example:
1. Backend generates random string using `random_secret()` and saves it to a cookie. This value can contain a `+` character. Ex: `zu5ETd4U^JWX0Apd2VcP>j$ioE+/-aQr`
2. The state returned on the callback replaces the `+` with a <space>
3. When `oauth_callback()` compares the cookie value with the returned value it will fail as its comparing a `+` and a <space>.

This was encountered and reproduced several times with the Cognito IDP.