### PR TITLE
Resolve FastAPI CVE

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,7 @@ httpx = ">=0.23.0,<0.25.0"
 literalai = "0.0.103"
 dataclasses_json = "^0.5.7"
 # FastAPI 0.109.0 breaks socketio (alway 404)
-fastapi = ">=0.100,<0.109.0"
+fastapi = ">=0.100,<0.109.1"
 uvicorn = "^0.25.0"
 fastapi-socketio = "^0.0.10"
 aiofiles = "^23.1.0"


### PR DESCRIPTION
Chainlit lacks a GitHub security policy, or any kind of security scanning mechanism that I can see. My project uses Chainlit as a third party dependency and utilizes a GitHub security policy.

I recently added the [Trivy Security Scanner](https://github.com/tylertitsworth/multi-mediawiki-rag/blob/main/.github/workflows/build.yaml#L44-L51) to my project, so I can scan the containers I build for deploying my project. This is the CVE returned from my Trivy scan:

```
Package: fastapi
Installed Version: 0.108.0
Vulnerability CVE-2024-24762
Severity: HIGH
Fixed Version: 0.109.1
Link: https://avd.aquasec.com/nvd/cve-2024-24762
```

FastAPI has fixed it in a patch release v0.109.1, however, chainlit flags this as a dependency conflict when I attempt to install the newer version to resolve the HIGH Severity CVE.

```
The conflict is caused by:
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
    The user requested fastapi>=0.109.1
    chainlit 1.0.200 depends on fastapi<0.109.0 and >=0.100
```

The change I have introduced is a short-term fix for the problem, however, I would highly suggest integrating [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) to prevent issues like this from cropping up in your python 3rd-party dependencies list.

If you would like some suggestions on the kinds of configuration files that should be added to this repository to improve and automate your security practice, please let me know and I'll add them to this PR.