### PR TITLE
Add config.ui.meta_image

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -130,6 +130,9 @@ hide_cot = false
         #dark = "#980039"
         #light = "#FFE7EB"
 
+# Override default UI metadata
+[UI.meta]
+#image = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
 
 [meta]
 generated_by = "{__version__}"

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -207,7 +207,7 @@ def get_html_template():
     url = config.ui.github or default_url
 
     default_meta_image = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
-    meta_image = config.ui.meta_image or default_meta_image
+    meta_image = config.ui.meta.image or default_meta_image
 
     tags = f"""<title>{config.ui.name}</title>
     <meta name="description" content="{config.ui.description}">

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -206,12 +206,15 @@ def get_html_template():
     default_url = "https://github.com/Chainlit/chainlit"
     url = config.ui.github or default_url
 
+    default_meta_image = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
+    meta_image = config.ui.meta_image or default_meta_image
+
     tags = f"""<title>{config.ui.name}</title>
     <meta name="description" content="{config.ui.description}">
     <meta property="og:type" content="website">
     <meta property="og:title" content="{config.ui.name}">
     <meta property="og:description" content="{config.ui.description}">
-    <meta property="og:image" content="https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png">
+    <meta property="og:image" content={meta_image}>
     <meta property="og:url" content="{url}">"""
 
     js = f"""<script>{f"window.theme = {json.dumps(config.ui.theme.to_dict())}; " if config.ui.theme else ""}</script>"""


### PR DESCRIPTION
This lets you set the meta_image that appears when sharing your Chainlit app, by default it is https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png but by adding to your config your own banner you can use your own.

e.g. within `.chainlit/config.toml`


```toml

[UI]
# Name of the app and chatbot.
name = "Your app name"

# the metadata image that appears when sharing links
meta_image = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"

```
