### PR TITLE
Add custom tabs to FE

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -174,6 +174,12 @@ class Theme(DataClassJsonMixin):
     dark: Optional[Palette] = None
 
 
+@dataclass()
+class Tab(DataClassJsonMixin):
+    to: Optional[str] = None
+    label: Optional[str] = None
+
+
 @dataclass
 class SpeechToTextFeature:
     enabled: Optional[bool] = None
@@ -193,6 +199,7 @@ class FeaturesSettings(DataClassJsonMixin):
 class UISettings(DataClassJsonMixin):
     name: str
     show_readme_as_default: bool = True
+    injected_tabs: Optional[List[Tab]] = None
     description: str = ""
     hide_cot: bool = False
     # Large size content are by default collapsed for a cleaner ui
@@ -213,8 +220,10 @@ class CodeSettings:
     # Module object loaded from the module_name
     module: Any = None
     # Bunch of callbacks defined by the developer
-    password_auth_callback: Optional[Callable[[str, str], Optional["User"]]] = None
-    header_auth_callback: Optional[Callable[[Headers], Optional["User"]]] = None
+    password_auth_callback: Optional[Callable[[
+        str, str], Optional["User"]]] = None
+    header_auth_callback: Optional[Callable[[
+        Headers], Optional["User"]]] = None
     oauth_callback: Optional[
         Callable[[str, str, Dict[str, str], "User"], Optional["User"]]
     ] = None
@@ -309,7 +318,8 @@ def init_config(log=False):
                     translation = json.load(f)
                     with open(dst, "w", encoding="utf-8") as f:
                         json.dump(translation, f, indent=4)
-                        logger.info(f"Created default translation file at {dst}")
+                        logger.info(
+                            f"Created default translation file at {dst}")
 
 
 def load_module(target: str, force_refresh: bool = False):
@@ -400,7 +410,8 @@ def load_config():
 
     settings = load_settings()
 
-    chainlit_server = os.environ.get("CHAINLIT_SERVER", "https://cloud.chainlit.io")
+    chainlit_server = os.environ.get(
+        "CHAINLIT_SERVER", "https://cloud.chainlit.io")
 
     config = ChainlitConfig(
         chainlit_server=chainlit_server,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,7 +22,6 @@ chainlit = 'chainlit.cli:cli'
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0.0"
-setuptools = "^69.1.1"
 httpx = ">=0.23.0"
 literalai = "0.0.204"
 dataclasses_json = "^0.5.7"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,7 @@ chainlit = 'chainlit.cli:cli'
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0.0"
+setuptools = "^69.1.1"
 httpx = ">=0.23.0"
 literalai = "0.0.204"
 dataclasses_json = "^0.5.7"

--- a/frontend/src/components/organisms/header.tsx
+++ b/frontend/src/components/organisms/header.tsx
@@ -62,9 +62,11 @@ interface NavProps {
   dataPersistence?: boolean;
   hasReadme?: boolean;
   matches?: boolean;
+  injectedTabs?: { to: string; label: string; }[];
 }
 
-const Nav = ({ dataPersistence, hasReadme, matches }: NavProps) => {
+const Nav = ({ dataPersistence, hasReadme, matches, injectedTabs = [] }: NavProps) => {
+  console.log('injectedTabs', injectedTabs);
   const location = useLocation();
   const { isAuthenticated } = useAuth();
   const [open, setOpen] = useState(false);
@@ -85,6 +87,15 @@ const Nav = ({ dataPersistence, hasReadme, matches }: NavProps) => {
       to: '/readme',
       label: t('components.organisms.header.readme')
     });
+
+
+    injectedTabs.forEach((tab: { to: any; label: any; }) => {
+      tabs.push({
+        to: tab.to,
+        label: tab.label
+      });
+    });
+
   }
 
   const nav = (
@@ -146,6 +157,7 @@ const Nav = ({ dataPersistence, hasReadme, matches }: NavProps) => {
 
 const Header = memo(
   ({ projectSettings }: { projectSettings?: IProjectSettings }) => {
+    console.log('projectSettings', projectSettings);
     const matches = useMediaQuery('(max-width: 66rem)');
 
     return (
@@ -166,6 +178,7 @@ const Header = memo(
               matches={matches}
               dataPersistence={projectSettings?.dataPersistence}
               hasReadme={!!projectSettings?.markdown}
+              injectedTabs={projectSettings?.ui.injected_tabs}
             />
           </Stack>
           <Stack

--- a/frontend/src/components/organisms/header.tsx
+++ b/frontend/src/components/organisms/header.tsx
@@ -159,7 +159,6 @@ const Nav = ({
 
 const Header = memo(
   ({ projectSettings }: { projectSettings?: IProjectSettings }) => {
-    console.log('projectSettings', projectSettings);
     const matches = useMediaQuery('(max-width: 66rem)');
 
     return (

--- a/frontend/src/components/organisms/header.tsx
+++ b/frontend/src/components/organisms/header.tsx
@@ -62,11 +62,15 @@ interface NavProps {
   dataPersistence?: boolean;
   hasReadme?: boolean;
   matches?: boolean;
-  injectedTabs?: { to: string; label: string; }[];
+  injectedTabs?: { to: string; label: string }[];
 }
 
-const Nav = ({ dataPersistence, hasReadme, matches, injectedTabs = [] }: NavProps) => {
-  console.log('injectedTabs', injectedTabs);
+const Nav = ({
+  dataPersistence,
+  hasReadme,
+  matches,
+  injectedTabs = []
+}: NavProps) => {
   const location = useLocation();
   const { isAuthenticated } = useAuth();
   const [open, setOpen] = useState(false);
@@ -88,14 +92,12 @@ const Nav = ({ dataPersistence, hasReadme, matches, injectedTabs = [] }: NavProp
       label: t('components.organisms.header.readme')
     });
 
-
-    injectedTabs.forEach((tab: { to: any; label: any; }) => {
+    injectedTabs.forEach((tab: { to: any; label: any }) => {
       tabs.push({
         to: tab.to,
         label: tab.label
       });
     });
-
   }
 
   const nav = (

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -13,6 +13,7 @@ export interface IProjectSettings {
   ui: {
     name: string;
     show_readme_as_default?: boolean;
+    injected_tabs?: { to: string; label: string }[];
     description?: string;
     hide_cot?: boolean;
     default_collapse_content?: boolean;


### PR DESCRIPTION
Hi All, First want to say excellent work on ChainLit.  

So this a PoC PR to see how to add tabs to the NavBar.  The use case for this would be people wanting a full site with ChainLit at its core.  Having the option to navigate to other full pages would deepen the customisation options.  (I am thinking about Pages such as About Us, or even fuller analytics view.

In `config.toml` it would look like:

```
injected_tabs = [
    { to = "/custom-tab", label = "Custom Tab" },
    { to = "/about", label = "About" }
]
```