### PR TITLE
Multi-modal support for file size, mime types and number of files

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -3,7 +3,7 @@ import os
 import sys
 from importlib import util
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import tomli
 from chainlit.logger import logger
@@ -71,7 +71,7 @@ latex = false
     enabled = true
     accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/pdf"]
     max_files = 10
-    max_size_mb = 20
+    max_size_mb = 1
 
 # Allows user to use speech to text
 [features.speech_to_text]
@@ -187,7 +187,7 @@ class SpeechToTextFeature:
 @dataclass
 class MultiModalFeature:
     enabled: Optional[bool] = None
-    accept: Optional[List[str]] = None
+    accept: Optional[Union[List[str], Dict[str, List[str]]]] = None
     max_files: Optional[int] = None
     max_size_mb: Optional[int] = None
 

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -71,7 +71,7 @@ latex = false
     enabled = true
     accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/pdf"]
     max_files = 10
-    max_size_mb = 1
+    max_size_mb = 20
 
 # Allows user to use speech to text
 [features.speech_to_text]

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -69,9 +69,9 @@ latex = false
 # Authorize users to upload files with messages
 [features.multi_modal]
     enabled = true
-    accept = ["text/plain", "text/x-python", "text/x-c++src"]
-    max_files = 10
-    max_size_mb = 20
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 # Allows user to use speech to text
 [features.speech_to_text]

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -50,7 +50,7 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
-# Authorized origins 
+# Authorized origins
 allow_origins = ["*"]
 
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
@@ -67,7 +67,11 @@ unsafe_allow_html = false
 latex = false
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]
+    max_files = 10
+    max_size_in_mb = 20
 
 # Allows user to use speech to text
 [features.speech_to_text]
@@ -180,10 +184,18 @@ class SpeechToTextFeature:
     language: Optional[str] = None
 
 
+@dataclass
+class MultiModalFeature:
+    enabled: Optional[bool] = None
+    accept: Optional[List[str]] = None
+    max_files: Optional[int] = None
+    max_size_in_mb: Optional[int] = None
+
+
 @dataclass()
 class FeaturesSettings(DataClassJsonMixin):
     prompt_playground: bool = True
-    multi_modal: bool = True
+    multi_modal: Optional[MultiModalFeature] = None
     latex: bool = False
     unsafe_allow_html: bool = False
     speech_to_text: Optional[SpeechToTextFeature] = None

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -69,7 +69,7 @@ latex = false
 # Authorize users to upload files with messages
 [features.multi_modal]
     enabled = true
-    accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/pdf"]
+    accept = ["text/plain", "text/x-python", "text/x-c++src"]
     max_files = 10
     max_size_mb = 20
 

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -69,9 +69,9 @@ latex = false
 # Authorize users to upload files with messages
 [features.multi_modal]
     enabled = true
-    accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"]
+    accept = ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/pdf"]
     max_files = 10
-    max_size_in_mb = 20
+    max_size_mb = 20
 
 # Allows user to use speech to text
 [features.speech_to_text]
@@ -189,7 +189,7 @@ class MultiModalFeature:
     enabled: Optional[bool] = None
     accept: Optional[List[str]] = None
     max_files: Optional[int] = None
-    max_size_in_mb: Optional[int] = None
+    max_size_mb: Optional[int] = None
 
 
 @dataclass()

--- a/cypress/e2e/ask_multiple_files/.chainlit/config.toml
+++ b/cypress/e2e/ask_multiple_files/.chainlit/config.toml
@@ -19,7 +19,11 @@ cache = false
 prompt_playground = true
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 [UI]
 # Name of the app and chatbot.

--- a/cypress/e2e/chat_profiles/.chainlit/config.toml
+++ b/cypress/e2e/chat_profiles/.chainlit/config.toml
@@ -25,7 +25,11 @@ unsafe_allow_html = false
 latex = false
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 # Allows user to use speech to text
 [features.speech_to_text]

--- a/cypress/e2e/copilot/.chainlit/config.toml
+++ b/cypress/e2e/copilot/.chainlit/config.toml
@@ -12,7 +12,7 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
-# Authorized origins 
+# Authorized origins
 allow_origins = ["*"]
 
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
@@ -29,7 +29,11 @@ unsafe_allow_html = false
 latex = false
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 # Allows user to use speech to text
 [features.speech_to_text]

--- a/cypress/e2e/copilot/.chainlit/config.toml
+++ b/cypress/e2e/copilot/.chainlit/config.toml
@@ -67,6 +67,10 @@ hide_cot = false
 # The CSS file can be served from the public directory or via an external link.
 # custom_css = "/public/test.css"
 
+# Specify a Javascript file that can be used to customize the user interface.
+# The Javascript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
 
@@ -94,4 +98,4 @@ hide_cot = false
 
 
 [meta]
-generated_by = "1.0.101"
+generated_by = "1.0.400"

--- a/cypress/e2e/custom_build/.chainlit/config.toml
+++ b/cypress/e2e/custom_build/.chainlit/config.toml
@@ -12,7 +12,7 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
-# Authorized origins 
+# Authorized origins
 allow_origins = ["*"]
 
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
@@ -29,7 +29,11 @@ unsafe_allow_html = false
 latex = false
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 # Allows user to use speech to text
 [features.speech_to_text]
@@ -72,6 +76,7 @@ hide_cot = false
 
 # Specify a custom build directory for the frontend. 
 # This can be used to customize the frontend code.
+# Be careful: If this is a relative path, it should not start with a slash.
 custom_build = "./public/build"
 
 # Override default MUI light theme. (Check theme.ts)

--- a/cypress/e2e/elements/.chainlit/config.toml
+++ b/cypress/e2e/elements/.chainlit/config.toml
@@ -2,6 +2,7 @@
 # Whether to enable telemetry (default: true). No personal data is collected.
 enable_telemetry = true
 
+
 # List of environment variables to be provided by each user to use the app.
 user_env = []
 
@@ -11,6 +12,9 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
+# Authorized origins
+allow_origins = ["*"]
+
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
 # follow_symlink = false
 
@@ -18,9 +22,31 @@ cache = false
 # Show the prompt playground
 prompt_playground = true
 
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Authorize users to upload files with messages
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+# Allows user to use speech to text
+[features.speech_to_text]
+    enabled = false
+    # See all languages here https://github.com/JamesBrill/react-speech-recognition/blob/HEAD/docs/API.md#language-string
+    # language = "en-US"
+
 [UI]
 # Name of the app and chatbot.
 name = "Chatbot"
+
+# Show the readme while the thread is empty.
+show_readme_as_default = true
 
 # Description of the app and chatbot. This is used for HTML tags.
 # description = ""
@@ -37,7 +63,20 @@ hide_cot = false
 # Link to your github repo. This will add a github button in the UI's header.
 # github = ""
 
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# Specify a Javascript file that can be used to customize the user interface.
+# The Javascript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# Specify a custom font url.
+# custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+
 # Override default MUI light theme. (Check theme.ts)
+[UI.theme]
+    #font_family = "Inter, sans-serif"
 [UI.theme.light]
     #background = "#FAFAFA"
     #paper = "#FFFFFF"
@@ -59,4 +98,4 @@ hide_cot = false
 
 
 [meta]
-generated_by = "0.6.402"
+generated_by = "1.0.400"

--- a/cypress/e2e/llama_index_cb/.chainlit/config.toml
+++ b/cypress/e2e/llama_index_cb/.chainlit/config.toml
@@ -2,6 +2,7 @@
 # Whether to enable telemetry (default: true). No personal data is collected.
 enable_telemetry = true
 
+
 # List of environment variables to be provided by each user to use the app.
 user_env = []
 
@@ -11,6 +12,9 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
+# Authorized origins
+allow_origins = ["*"]
+
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
 # follow_symlink = false
 
@@ -18,9 +22,31 @@ cache = false
 # Show the prompt playground
 prompt_playground = true
 
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Authorize users to upload files with messages
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+# Allows user to use speech to text
+[features.speech_to_text]
+    enabled = false
+    # See all languages here https://github.com/JamesBrill/react-speech-recognition/blob/HEAD/docs/API.md#language-string
+    # language = "en-US"
+
 [UI]
 # Name of the app and chatbot.
 name = "Chatbot"
+
+# Show the readme while the thread is empty.
+show_readme_as_default = true
 
 # Description of the app and chatbot. This is used for HTML tags.
 # description = ""
@@ -37,13 +63,20 @@ hide_cot = false
 # Link to your github repo. This will add a github button in the UI's header.
 # github = ""
 
-[features.multi_modal]
-    enabled = true
-    accept = ["*/*"]
-    max_files = 20
-    max_size_mb = 500
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# Specify a Javascript file that can be used to customize the user interface.
+# The Javascript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# Specify a custom font url.
+# custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
 
 # Override default MUI light theme. (Check theme.ts)
+[UI.theme]
+    #font_family = "Inter, sans-serif"
 [UI.theme.light]
     #background = "#FAFAFA"
     #paper = "#FFFFFF"
@@ -65,4 +98,4 @@ hide_cot = false
 
 
 [meta]
-generated_by = "0.6.402"
+generated_by = "1.0.400"

--- a/cypress/e2e/llama_index_cb/.chainlit/config.toml
+++ b/cypress/e2e/llama_index_cb/.chainlit/config.toml
@@ -37,6 +37,12 @@ hide_cot = false
 # Link to your github repo. This will add a github button in the UI's header.
 # github = ""
 
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
 # Override default MUI light theme. (Check theme.ts)
 [UI.theme.light]
     #background = "#FAFAFA"

--- a/cypress/e2e/plotly/.chainlit/config.toml
+++ b/cypress/e2e/plotly/.chainlit/config.toml
@@ -19,7 +19,11 @@ cache = false
 prompt_playground = true
 
 # Authorize users to upload files with messages
-multi_modal = true
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
 
 # Allows user to use speech to text
 [features.speech_to_text]

--- a/cypress/e2e/tasklist/.chainlit/config.toml
+++ b/cypress/e2e/tasklist/.chainlit/config.toml
@@ -2,6 +2,7 @@
 # Whether to enable telemetry (default: true). No personal data is collected.
 enable_telemetry = true
 
+
 # List of environment variables to be provided by each user to use the app.
 user_env = []
 
@@ -11,6 +12,9 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
+# Authorized origins
+allow_origins = ["*"]
+
 # Follow symlink for asset mount (see https://github.com/Chainlit/chainlit/issues/317)
 # follow_symlink = false
 
@@ -18,9 +22,31 @@ cache = false
 # Show the prompt playground
 prompt_playground = true
 
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Authorize users to upload files with messages
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
+# Allows user to use speech to text
+[features.speech_to_text]
+    enabled = false
+    # See all languages here https://github.com/JamesBrill/react-speech-recognition/blob/HEAD/docs/API.md#language-string
+    # language = "en-US"
+
 [UI]
 # Name of the app and chatbot.
 name = "Chatbot"
+
+# Show the readme while the thread is empty.
+show_readme_as_default = true
 
 # Description of the app and chatbot. This is used for HTML tags.
 # description = ""
@@ -37,7 +63,20 @@ hide_cot = false
 # Link to your github repo. This will add a github button in the UI's header.
 # github = ""
 
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# Specify a Javascript file that can be used to customize the user interface.
+# The Javascript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# Specify a custom font url.
+# custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+
 # Override default MUI light theme. (Check theme.ts)
+[UI.theme]
+    #font_family = "Inter, sans-serif"
 [UI.theme.light]
     #background = "#FAFAFA"
     #paper = "#FFFFFF"
@@ -59,4 +98,4 @@ hide_cot = false
 
 
 [meta]
-generated_by = "0.6.402"
+generated_by = "1.0.400"

--- a/cypress/e2e/upload_attachments/.chainlit/config.toml
+++ b/cypress/e2e/upload_attachments/.chainlit/config.toml
@@ -41,6 +41,12 @@ hide_cot = false
 # The CSS file can be served from the public directory or via an external link.
 # custom_css = "/public/test.css"
 
+[features.multi_modal]
+    enabled = true
+    accept = ["*/*"]
+    max_files = 20
+    max_size_mb = 500
+
 # Override default MUI light theme. (Check theme.ts)
 [UI.theme.light]
     #background = "#FAFAFA"

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -41,7 +41,14 @@ const Chat = () => {
   const { uploadFile } = useChatInteract();
   const uploadFileRef = useRef(uploadFile);
 
-  const fileSpec = useMemo(() => ({ max_size_mb: 500 }), []);
+  const fileSpec = useMemo(
+    () => ({
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
+      max_files: projectSettings?.features?.multi_modal?.max_files,
+      accept: projectSettings?.features?.multi_modal?.accept
+    }),
+    [projectSettings]
+  );
 
   const { t } = useTranslation();
 
@@ -150,7 +157,7 @@ const Chat = () => {
   }, []);
 
   const enableMultiModalUpload =
-    !disabled && projectSettings?.features?.multi_modal;
+    !disabled && projectSettings?.features?.multi_modal?.enabled;
 
   return (
     <Box

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -43,11 +43,11 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
-      max_files: projectSettings?.features?.multi_modal?.max_files,
-      accept: projectSettings?.features?.multi_modal?.accept
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb || 500,
+      max_files: projectSettings?.features?.multi_modal?.max_files || 20,
+      accept: projectSettings?.features?.multi_modal?.accept || ['*/*']
     }),
-    [projectSettings]
+    []
   );
 
   const { t } = useTranslation();

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -43,8 +43,9 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
-      max_files: projectSettings?.features?.multi_modal?.max_files,
+      max_size_mb:
+        (projectSettings?.features?.multi_modal?.max_size_mb || 2) * 1000000,
+      max_files: projectSettings?.features?.multi_modal?.max_files || undefined,
       accept: projectSettings?.features?.multi_modal?.accept
     }),
     [projectSettings]

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -43,9 +43,8 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb:
-        (projectSettings?.features?.multi_modal?.max_size_mb || 2) * 1000000,
-      max_files: projectSettings?.features?.multi_modal?.max_files || undefined,
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
+      max_files: projectSettings?.features?.multi_modal?.max_files,
       accept: projectSettings?.features?.multi_modal?.accept
     }),
     [projectSettings]

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -47,7 +47,7 @@ const Chat = () => {
       max_files: projectSettings?.features?.multi_modal?.max_files || 20,
       accept: projectSettings?.features?.multi_modal?.accept || ['*/*']
     }),
-    []
+    [projectSettings]
   );
 
   const { t } = useTranslation();
@@ -138,8 +138,8 @@ const Chat = () => {
   );
 
   const onFileUploadError = useCallback(
-    () => (error: string) => toast.error(error),
-    []
+    (error: string) => toast.error(error),
+    [toast]
   );
 
   const upload = useUpload({

--- a/frontend/src/components/organisms/chat/inputBox/UploadButton.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/UploadButton.tsx
@@ -36,7 +36,7 @@ const UploadButton = ({
     ? 'small'
     : 'medium';
 
-  if (!upload || !pSettings?.features?.multi_modal) return null;
+  if (!upload || !pSettings?.features?.multi_modal?.enabled) return null;
   const { getRootProps, getInputProps } = upload;
 
   return (

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -21,7 +21,12 @@ export interface IProjectSettings {
     theme: any;
   };
   features: {
-    multi_modal?: boolean;
+    multi_modal?: {
+      enabled?: boolean;
+      max_size_mb?: number;
+      max_files?: number;
+      accept?: string[] | Record<string, string[]>;
+    };
     unsafe_allow_html?: boolean;
     latex?: boolean;
     speech_to_text?: {

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -51,7 +51,7 @@ const Chat = () => {
       max_files: projectSettings?.features?.multi_modal?.max_files || 20,
       accept: projectSettings?.features?.multi_modal?.accept || ['*/*']
     }),
-    []
+    [projectSettings]
   );
 
   useEffect(() => {
@@ -132,8 +132,8 @@ const Chat = () => {
   );
 
   const onFileUploadError = useCallback(
-    () => (error: string) => toast.error(error),
-    []
+    (error: string) => toast.error(error),
+    [toast]
   );
 
   const upload = useUpload({

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -47,8 +47,9 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
-      max_files: projectSettings?.features?.multi_modal?.max_files,
+      max_size_mb:
+        (projectSettings?.features?.multi_modal?.max_size_mb || 2) * 1000000,
+      max_files: projectSettings?.features?.multi_modal?.max_files || undefined,
       accept: projectSettings?.features?.multi_modal?.accept
     }),
     [projectSettings]

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -47,9 +47,8 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb:
-        (projectSettings?.features?.multi_modal?.max_size_mb || 2) * 1000000,
-      max_files: projectSettings?.features?.multi_modal?.max_files || undefined,
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
+      max_files: projectSettings?.features?.multi_modal?.max_files,
       accept: projectSettings?.features?.multi_modal?.accept
     }),
     [projectSettings]

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -47,11 +47,11 @@ const Chat = () => {
 
   const fileSpec = useMemo(
     () => ({
-      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
-      max_files: projectSettings?.features?.multi_modal?.max_files,
-      accept: projectSettings?.features?.multi_modal?.accept
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb || 500,
+      max_files: projectSettings?.features?.multi_modal?.max_files || 20,
+      accept: projectSettings?.features?.multi_modal?.accept || ['*/*']
     }),
-    [projectSettings]
+    []
   );
 
   useEffect(() => {

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -45,7 +45,14 @@ const Chat = () => {
   const { uploadFile } = useChatInteract();
   const uploadFileRef = useRef(uploadFile);
 
-  const fileSpec = useMemo(() => ({ max_size_mb: 500 }), []);
+  const fileSpec = useMemo(
+    () => ({
+      max_size_mb: projectSettings?.features?.multi_modal?.max_size_mb,
+      max_files: projectSettings?.features?.multi_modal?.max_files,
+      accept: projectSettings?.features?.multi_modal?.accept
+    }),
+    [projectSettings]
+  );
 
   useEffect(() => {
     uploadFileRef.current = uploadFile;
@@ -144,7 +151,7 @@ const Chat = () => {
   }, []);
 
   const enableMultiModalUpload =
-    !disabled && projectSettings?.features?.multi_modal;
+    !disabled && projectSettings?.features?.multi_modal?.enabled;
 
   return (
     <Box

--- a/libs/react-components/hooks/useUpload.tsx
+++ b/libs/react-components/hooks/useUpload.tsx
@@ -19,8 +19,11 @@ const useUpload = ({ onError, onResolved, options, spec }: useUploadProps) => {
   const onDrop: DropzoneOptions['onDrop'] = useCallback(
     (acceptedFiles: FileWithPath[], fileRejections: FileRejection[]) => {
       if (fileRejections.length > 0) {
-        onError && onError(fileRejections[0].errors[0].message);
-        return;
+        if (fileRejections[0].errors[0].code === 'file-too-large') {
+          onError && onError(`File is larger than ${spec.max_size_mb} MB`);
+        } else {
+          onError && onError(fileRejections[0].errors[0].message);
+        }
       }
 
       if (!acceptedFiles.length) return;


### PR DESCRIPTION
We've implemented support for restricting multi modal inputs by mime type, file size and number of files, similar to AskFileMessage, giving developers a bit more flexibility in choosing what inputs to allow for the application.

This will not return any error, but will restrict the user from uploading files that don't match the specifications.