### PR TITLE
Fix: LlamaIndex 0.10.x migration

### DIFF
--- a/backend/chainlit/llama_index/__init__.py
+++ b/backend/chainlit/llama_index/__init__.py
@@ -1,6 +1,6 @@
 from chainlit.utils import check_module_version
 
-if not check_module_version("llama_index", "0.8.3"):
+if not check_module_version("llama_index.core", "0.10.15"):
     raise ValueError(
-        "Expected LlamaIndex version >= 0.8.3. Run `pip install llama_index --upgrade`"
+        "Expected LlamaIndex version >= 0.10.15. Run `pip install llama_index --upgrade`"
     )

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -5,9 +5,9 @@ from chainlit.element import Text
 from chainlit.step import Step, StepType
 from literalai import ChatGeneration, CompletionGeneration, GenerationMessage
 from literalai.helper import utc_now
-from llama_index.callbacks import TokenCountingHandler
-from llama_index.callbacks.schema import CBEventType, EventPayload
-from llama_index.llms.base import ChatMessage, ChatResponse, CompletionResponse
+from llama_index.core.callbacks import TokenCountingHandler
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.llms import ChatMessage, ChatResponse, CompletionResponse
 
 DEFAULT_IGNORE = [
     CBEventType.CHUNKING,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,7 +53,8 @@ optional = true
 [tool.poetry.group.tests.dependencies]
 openai = "^1.11.1"
 langchain = "^0.1.5"
-llama-index = "^0.9.15"
+llama-index = "^0.10.15"
+llama-index-core = "^0.10.15"
 transformers = "^4.30.1"
 matplotlib = "3.7.1"
 farm-haystack = "^1.18.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,7 +54,6 @@ optional = true
 openai = "^1.11.1"
 langchain = "^0.1.5"
 llama-index = "^0.10.15"
-llama-index-core = "^0.10.15"
 transformers = "^4.30.1"
 matplotlib = "3.7.1"
 farm-haystack = "^1.18.0"

--- a/cypress/e2e/llama_index_cb/main.py
+++ b/cypress/e2e/llama_index_cb/main.py
@@ -1,6 +1,6 @@
-from llama_index.callbacks.schema import CBEventType, EventPayload
-from llama_index.llms.base import ChatMessage, ChatResponse
-from llama_index.schema import NodeWithScore, TextNode
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.llms import ChatMessage, ChatResponse
+from llama_index.core.schema import NodeWithScore, TextNode
 
 import chainlit as cl
 


### PR DESCRIPTION
Title: Fix: LlamaIndex 0.10.x migration

---

**Description:**

This pull request addresses the issue reported in [Chainlit #752](https://github.com/Chainlit/chainlit/issues/752) regarding migration problems encountered with LlamaIndex version 0.10.x. The main focus of this fix is to ensure compatibility and smooth migration from earlier versions to LlamaIndex 0.10.x without causing disruptions to existing functionalities.

**Changes:**

- Fixed all breaking changes that resulted from deprecated methods and properties in the new version.
- Updated the llama_index test to work with this newer version.