### PR TITLE
Fix 'completion' referenced before assignment in LangchainTracer

### DIFF
--- a/backend/chainlit/langchain/callbacks.py
+++ b/backend/chainlit/langchain/callbacks.py
@@ -532,6 +532,7 @@ class LangchainTracer(BaseTracer, GenerationHelper, FinalStreamHelper):
     
                 current_step.language = "json"
                 current_step.output = json.dumps(message_completion)
+                completion = message_completion.get("content", "")
             else:
                 completion_start = self.completion_generations[str(run.id)]
                 completion = generation.get("text", "")


### PR DESCRIPTION
**Issue**
Running this code:
```
@cl.on_message
async def main(message: cl.Message) -> cl.Message:
    cb = cl.AsyncLangchainCallbackHandler(
        stream_final_answer=True,
        answer_prefix_tokens=["FINAL", "ANSWER"],
    )
    cb.answer_reached = True
    chain = cl.user_session.get("chain")
    await chain.ainvoke(
        message.content,
        cast(RunnableConfig, {"callbacks": [cb]}),
        return_only_outputs=False,
        include_run_info=False,
    )
```
you get an UnboundLocalError while updading the final stream:

`Errror in LangchainTracer.on_llm_end callback: local variable 'completion' referenced before assignment")`

This happens because a branch of the `if` (at line 502) does not initiate the `completion` variable, and it fails at line 562 since `completion` is not defined.

**Fix**
Define `completion` as needed.