### PR TITLE
feat: add HEAD route for '/' to support status checks

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -740,6 +740,11 @@ async def get_logo(theme: Optional[Theme] = Query(Theme.light)):
     return FileResponse(logo_path, media_type=media_type)
 
 
+@app.head('/')
+def status_check():
+    return {"message": "Site is operational"}
+
+
 def register_wildcard_route_handler():
     @app.get("/{path:path}")
     async def serve(request: Request, path: str):


### PR DESCRIPTION
Services like uptime-robot use a HEAD request to do status checks; this discards the response body and returns only headers. I've added a head route on top of '/' that returns properly. Right now uvicorn returns a 405 method not allowed

This doesn't interfere with the GET wildcard route, but we can easily move this over to a /status route if so desired. 