### PR TITLE
Newly created thread displayed in the side bar; Resumed threads content is revalidated when navigating in the side bar

### DIFF
--- a/frontend/src/components/organisms/threadHistory/sidebar/ThreadList.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/ThreadList.tsx
@@ -17,6 +17,7 @@ import Typography from '@mui/material/Typography';
 import {
   ThreadHistory,
   useChatInteract,
+  useChatMessages,
   useChatSession
 } from '@chainlit/react-client';
 
@@ -41,6 +42,7 @@ const ThreadList = ({
 }: Props) => {
   const { idToResume } = useChatSession();
   const { clear } = useChatInteract();
+  const { messages } = useChatMessages();
   const navigate = useNavigate();
   if (isFetching || (!threadHistory?.timeGroupedThreads && isLoadingMore)) {
     return (
@@ -153,6 +155,14 @@ const ThreadList = ({
                   const isSelected =
                     isResumed || threadHistory.currentThreadId === thread.id;
 
+                  const isThreadOpened = messages
+                    .map((m) => m.threadId)
+                    .includes(thread.id);
+                  const redirectToOpenChat = isThreadOpened || isResumed;
+
+                  let redirectTo = isSelected ? '' : `/thread/${thread.id}`;
+                  if (redirectToOpenChat) redirectTo = '/';
+
                   return (
                     <Stack
                       component={Link}
@@ -179,7 +189,7 @@ const ThreadList = ({
                               : 'grey.200'
                         }
                       })}
-                      to={isResumed ? '' : `/thread/${thread.id}`}
+                      to={redirectTo}
                     >
                       <Stack
                         direction="row"

--- a/frontend/src/components/organisms/threadHistory/sidebar/index.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/index.tsx
@@ -140,12 +140,21 @@ const _ThreadHistorySideBar = () => {
     if (!firstInteraction) {
       return;
     }
+    // distinguish between the first interaction containing the word "resume"
+    // and the actual resume message
+    const isActualResume =
+      firstInteraction === 'resume' &&
+      messages.at(0)?.output.toLowerCase() !== 'resume';
+
+    if (isActualResume) {
+      return;
+    }
 
     fetchThreads(undefined, true).then(() => {
       const currectThreadId = messages
         .map((message) => message.threadId)
         .find((threadId) => threadId);
-      if (currectThreadId) {
+      if (currectThreadId !== threadHistory?.currentThreadId) {
         setThreadHistory((prev) => ({
           ...prev,
           currentThreadId: currectThreadId

--- a/frontend/src/pages/Thread.tsx
+++ b/frontend/src/pages/Thread.tsx
@@ -4,7 +4,12 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { Box } from '@mui/material';
 
-import { IThread, threadHistoryState, useApi } from '@chainlit/react-client';
+import {
+  IThread,
+  threadHistoryState,
+  threadIdToResumeState,
+  useApi
+} from '@chainlit/react-client';
 
 import { Thread } from 'components/organisms/threadHistory/Thread';
 
@@ -16,8 +21,9 @@ import ResumeButton from './ResumeButton';
 export default function ThreadPage() {
   const { id } = useParams();
   const apiClient = useRecoilValue(apiClientState);
+  const threadIdToResume = useRecoilValue(threadIdToResumeState);
 
-  const { data, error, isLoading } = useApi<IThread>(
+  const { data, error, isLoading, mutate } = useApi<IThread>(
     apiClient,
     id ? `/project/thread/${id}` : null,
     {
@@ -25,6 +31,12 @@ export default function ThreadPage() {
       revalidateIfStale: false
     }
   );
+
+  useEffect(() => {
+    if (threadIdToResume === id && !isLoading) {
+      mutate();
+    }
+  }, [threadIdToResume, id]);
 
   const [threadHistory, setThreadHistory] = useRecoilState(threadHistoryState);
 


### PR DESCRIPTION
Hi!

I recently posted two issues:
- https://github.com/Chainlit/chainlit/issues/824
- https://github.com/Chainlit/chainlit/issues/823

Here's my proposal for solving it

There are two main ideas:

- when the new thread is created we refresh the list of the threads
  > I detect it with a combination of `firstInteraction` and `messages` states, since, as mentioned in https://github.com/Chainlit/chainlit/issues/837 there is no clear way to determine a newly created thread
- when the thread is resumed - we set the current thread page data as '' with `mutate()` so it'll be invalidated on the next render.
- also, when the already resumed/opened thread is clicked in the thread history sidebar the user is redirected to this opened chat, instead of a suggestion to resume the thread again


Here's a demo of how it works

https://github.com/Chainlit/chainlit/assets/14301123/99f90677-5854-4925-b815-30c6e0dedde4

