### PR TITLE
Do not reload installed packages on file change

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import site
 import sys
 from importlib import util
 from pathlib import Path
@@ -112,7 +113,7 @@ hide_cot = false
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
 
-# Specify a custom build directory for the frontend. 
+# Specify a custom build directory for the frontend.
 # This can be used to customize the frontend code.
 # Be careful: If this is a relative path, it should not start with a slash.
 # custom_build = "./public/build"
@@ -340,12 +341,16 @@ def load_module(target: str, force_refresh: bool = False):
     sys.path.insert(0, target_dir)
 
     if force_refresh:
+        # Get current site packages dirs
+        site_package_dirs = site.getsitepackages()
+
         # Clear the modules related to the app from sys.modules
         for module_name, module in list(sys.modules.items()):
             if (
                 hasattr(module, "__file__")
                 and module.__file__
                 and module.__file__.startswith(target_dir)
+                and not any(module.__file__.startswith(p) for p in site_package_dirs)
             ):
                 sys.modules.pop(module_name, None)
 


### PR DESCRIPTION
Closes #790 .

The issue was present when the venv was created in the same dir as the project using chainlit. On reload the code that was supposed to clear the modules related to the app from `sys.modules` also cleared chainlit itself which led to a reload and a new config object being initialized when `config.py` module was loaded. The `socket.py` module still had the reference to the old config module though, which resulted in reload failing. The lesson here is - module reloading in python is HARD and should really not be attempted. ;)

The fix checks where the modules are installed (venv or regular installation) and prevents their reload. This fixes all cases EXCEPT the `hello.py` in the chainlit repo - as the chainlit code is in the same dir as the demo file it's imporsible to say what's what. A possible fix would be to move `hello.py` to a subdir.
