### PR TITLE
fix BaseDataLayer create_element type

### DIFF
--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -64,7 +64,7 @@ class BaseDataLayer:
         return ""
 
     @queue_until_user_message()
-    async def create_element(self, element_dict: "ElementDict"):
+    async def create_element(self, element: "Element"):
         pass
 
     async def get_element(


### PR DESCRIPTION
There is argument type inconsistency between BaseDataLayer.create_element and ChainlitDataLayer.create_element.
I checked the type running on my local environment and confirmed that it is Element type.