### PR TITLE
Improve translations

### DIFF
--- a/backend/chainlit/cli/__init__.py
+++ b/backend/chainlit/cli/__init__.py
@@ -16,6 +16,7 @@ from chainlit.config import (
     DEFAULT_PORT,
     config,
     init_config,
+    lint_translations,
     load_module,
 )
 from chainlit.logger import logger
@@ -176,3 +177,11 @@ def chainlit_create_secret(args=None, **kwargs):
     print(
         f"Copy the following secret into your .env file. Once it is set, changing it will logout all users with active sessions.\nCHAINLIT_AUTH_SECRET={random_secret()}"
     )
+
+
+@cli.command("lint-translations")
+@click.argument("args", nargs=-1)
+def chainlit_lint_translations(args=None, **kwargs):
+    trace_event("chainlit lint-translation")
+
+    lint_translations()

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import tomli
 from chainlit.logger import logger
+from chainlit.translations import lint_translation_json
 from chainlit.version import __version__
 from dataclasses_json import DataClassJsonMixin
 from pydantic.dataclasses import Field, dataclass
@@ -112,7 +113,7 @@ hide_cot = false
 # Specify a custom font url.
 # custom_font = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
 
-# Specify a custom build directory for the frontend. 
+# Specify a custom build directory for the frontend.
 # This can be used to customize the frontend code.
 # Be careful: If this is a relative path, it should not start with a slash.
 # custom_build = "./public/build"
@@ -244,9 +245,9 @@ class CodeSettings:
     on_message: Optional[Callable[[str], Any]] = None
     author_rename: Optional[Callable[[str], str]] = None
     on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
-    set_chat_profiles: Optional[Callable[[Optional["User"]], List["ChatProfile"]]] = (
-        None
-    )
+    set_chat_profiles: Optional[
+        Callable[[Optional["User"]], List["ChatProfile"]]
+    ] = None
 
 
 @dataclass()
@@ -427,6 +428,24 @@ def load_config():
     )
 
     return config
+
+
+def lint_translations():
+    # Load the ground truth (en-US.json file from chainlit source code)
+    src = os.path.join(TRANSLATIONS_DIR, "en-US.json")
+    with open(src, "r", encoding="utf-8") as f:
+        truth = json.load(f)
+
+        # Find the local app translations
+        for file in os.listdir(config_translation_dir):
+            if file.endswith(".json"):
+                # Load the translation file
+                to_lint = os.path.join(config_translation_dir, file)
+                with open(to_lint, "r", encoding="utf-8") as f:
+                    translation = json.load(f)
+
+                    # Lint the translation file
+                    lint_translation_json(file, truth, translation)
 
 
 config = load_config()

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -282,9 +282,14 @@ class ChainlitConfig:
     def load_translation(self, language: str):
         translation = {}
         default_language = "en-US"
+        # fallback to root language (ex: `de` when `de-DE` is not found)
+        parent_language = language.split("-")[0]
 
         translation_lib_file_path = os.path.join(
             config_translation_dir, f"{language}.json"
+        )
+        translation_lib_parent_language_file_path = os.path.join(
+            config_translation_dir, f"{parent_language}.json"
         )
         default_translation_lib_file_path = os.path.join(
             config_translation_dir, f"{default_language}.json"
@@ -292,6 +297,14 @@ class ChainlitConfig:
 
         if os.path.exists(translation_lib_file_path):
             with open(translation_lib_file_path, "r", encoding="utf-8") as f:
+                translation = json.load(f)
+        elif os.path.exists(translation_lib_parent_language_file_path):
+            logger.warning(
+                f"Translation file for {language} not found. Using parent translation {parent_language}."
+            )
+            with open(
+                translation_lib_parent_language_file_path, "r", encoding="utf-8"
+            ) as f:
                 translation = json.load(f)
         elif os.path.exists(default_translation_lib_file_path):
             logger.warning(

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -53,6 +53,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.staticfiles import StaticFiles
@@ -185,6 +186,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(GZipMiddleware)
 
 socket = SocketManager(
     app,

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -140,7 +140,9 @@ def get_build_dir(local_target: str, packaged_target: str):
     local_build_dir = os.path.join(PACKAGE_ROOT, local_target, "dist")
     packaged_build_dir = os.path.join(BACKEND_ROOT, packaged_target, "dist")
 
-    if config.ui.custom_build and os.path.exists(os.path.join(APP_ROOT, config.ui.custom_build, packaged_target, "dist")):
+    if config.ui.custom_build and os.path.exists(
+        os.path.join(APP_ROOT, config.ui.custom_build, packaged_target, "dist")
+    ):
         return os.path.join(APP_ROOT, config.ui.custom_build, packaged_target, "dist")
     elif os.path.exists(local_build_dir):
         return local_build_dir
@@ -501,15 +503,28 @@ async def get_providers(
     return JSONResponse(content={"providers": providers})
 
 
+@app.get("/project/translations")
+async def project_translations(
+    language: str = Query(default="en-US", description="Language code"),
+):
+    """Return project translations."""
+
+    # Load translation based on the provided language
+    translation = config.load_translation(language)
+
+    return JSONResponse(
+        content={
+            "translation": translation,
+        }
+    )
+
+
 @app.get("/project/settings")
 async def project_settings(
     current_user: Annotated[Union[User, PersistedUser], Depends(get_current_user)],
     language: str = Query(default="en-US", description="Language code"),
 ):
     """Return project settings. This is called by the UI before the establishing the websocket connection."""
-
-    # Load translation based on the provided language
-    translation = config.load_translation(language)
 
     # Load the markdown file based on the provided language
     markdown = get_markdown_str(config.root, language)
@@ -528,7 +543,6 @@ async def project_settings(
             "threadResumable": bool(config.code.on_chat_resume),
             "markdown": markdown,
             "chatProfiles": profiles,
-            "translation": translation,
         }
     )
 

--- a/backend/chainlit/translations.py
+++ b/backend/chainlit/translations.py
@@ -1,0 +1,60 @@
+# TODO:
+# - Support linting plural
+# - Support interpolation
+
+
+def compare_json_structures(truth, to_compare, path=""):
+    """
+    Compare the structure of two deeply nested JSON objects.
+    Args:
+        truth (dict): The 'truth' JSON object.
+        to_compare (dict): The 'to_compare' JSON object.
+        path (str): The current path for error reporting (used internally).
+    Returns:
+        A list of differences found.
+    """
+    if not isinstance(truth, dict) or not isinstance(to_compare, dict):
+        raise ValueError("Both inputs must be dictionaries.")
+
+    errors = []
+
+    truth_keys = set(truth.keys())
+    to_compare_keys = set(to_compare.keys())
+
+    extra_keys = to_compare_keys - truth_keys
+    missing_keys = truth_keys - to_compare_keys
+
+    for key in extra_keys:
+        errors.append(f"⚠️ Extra key: '{path + '.' + key if path else key}'")
+
+    for key in missing_keys:
+        errors.append(f"❌ Missing key: '{path + '.' + key if path else key}'")
+
+    for key in truth_keys & to_compare_keys:
+        if isinstance(truth[key], dict) and isinstance(to_compare[key], dict):
+            # Recursive call to navigate through nested dictionaries
+            errors += compare_json_structures(
+                truth[key], to_compare[key], path + "." + key if path else key
+            )
+        elif not isinstance(truth[key], dict) and not isinstance(to_compare[key], dict):
+            # If both are not dicts, we are at leaf nodes and structure matches; skip value comparison
+            continue
+        else:
+            # Structure mismatch: one is a dict, the other is not
+            errors.append(
+                f"❌ Structure mismatch at: '{path + '.' + key if path else key}'"
+            )
+
+    return errors
+
+
+def lint_translation_json(file, truth, to_compare):
+    print(f"\nLinting {file}...")
+
+    errors = compare_json_structures(truth, to_compare)
+
+    if errors:
+        for error in errors:
+            print(f"{error}")
+    else:
+        print(f"✅ No errors found in {file}")

--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -38,6 +38,76 @@
         "expandMessages": "Expand Messages",
         "hideChainOfThought": "Hide Chain of Thought",
         "darkMode": "Dark Mode"
+      },
+      "detailsButton": {
+        "using": "Using",
+        "running": "Running",
+        "took_one": "Took {{count}} step",
+        "took_other": "Took {{count}} steps"
+      },
+      "auth": {
+        "authLogin": {
+          "title": "Login to access the app.",
+          "form": {
+            "email": "Email address",
+            "password": "Password",
+            "noAccount": "Don't have an account?",
+            "alreadyHaveAccount": "Already have an account?",
+            "signup": "Sign Up",
+            "signin": "Sign In",
+            "or": "OR",
+            "continue": "Continue",
+            "forgotPassword": "Forgot password?",
+            "passwordMustContain": "Your password must contain:",
+            "emailRequired": "email is a required field",
+            "passwordRequired": "password is a required field"
+          },
+          "error": {
+            "default": "Unable to sign in.",
+            "signin": "Try signing in with a different account.",
+            "oauthsignin": "Try signing in with a different account.",
+            "redirect_uri_mismatch": "The redirect URI is not matching the oauth app configuration.",
+            "oauthcallbackerror": "Try signing in with a different account.",
+            "oauthcreateaccount": "Try signing in with a different account.",
+            "emailcreateaccount": "Try signing in with a different account.",
+            "callback": "Try signing in with a different account.",
+            "oauthaccountnotlinked": "To confirm your identity, sign in with the same account you used originally.",
+            "emailsignin": "The e-mail could not be sent.",
+            "emailverify": "Please verify your email, a new email has been sent.",
+            "credentialssignin": "Sign in failed. Check the details you provided are correct.",
+            "sessionrequired": "Please sign in to access this page."
+          }
+        },
+        "authVerifyEmail": {
+          "almostThere": "You're almost there! We've sent an email to ",
+          "verifyEmailLink": "Please click on the link in that email to complete your signup.",
+          "didNotReceive": "Can't find the email?",
+          "resendEmail": "Resend email",
+          "goBack": "Go Back",
+          "emailSent": "Email sent successfully.",
+          "verifyEmail": "Verify your email address"
+        },
+        "providerButton": {
+          "continue": "Continue with {{provider}}",
+          "signup": "Sign up with {{provider}}"
+        },
+        "authResetPassword": {
+          "newPasswordRequired": "New password is a required field",
+          "passwordsMustMatch": "Passwords must match",
+          "confirmPasswordRequired": "Confirm password is a required field",
+          "newPassword": "New password",
+          "confirmPassword": "Confirm password",
+          "resetPassword": "Reset Password"
+        },
+        "authForgotPassword": {
+          "email": "Email address",
+          "emailRequired": "email is a required field",
+          "emailSent": "Please check the email address {{email}} for instructions to reset your password.",
+          "enterEmail": "Enter your email address and we will send you instructions to reset your password.",
+          "resendEmail": "Resend email",
+          "continue": "Continue",
+          "goBack": "Go Back"
+        }
       }
     },
     "organisms": {
@@ -118,7 +188,7 @@
           },
           "ThreadList": {
             "empty": "Empty...",
-            "today":  "Today",
+            "today": "Today",
             "yesterday": "Yesterday",
             "previous7days": "Previous 7 days",
             "previous30days": "Previous 30 days"

--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -33,6 +33,11 @@ export default function AppWrapper() {
       : null
   );
 
+  const { data: translations } = useApi<IProjectSettings>(
+    apiClient,
+    `/project/translations?language=${languageInUse}`
+  );
+
   if (
     isReady &&
     !isAuthenticated &&
@@ -51,8 +56,12 @@ export default function AppWrapper() {
       expandAll: !!data.ui.default_expand_messages,
       hideCot: !!data.ui.hide_cot
     }));
-    handleChangeLanguage(data.translation);
   }, [data, setProjectSettings, setAppSettings]);
+
+  useEffect(() => {
+    if (!translations) return;
+    handleChangeLanguage(translations.translation);
+  }, [translations]);
 
   if (!isReady) {
     return null;

--- a/frontend/src/components/i18n/Translator.tsx
+++ b/frontend/src/components/i18n/Translator.tsx
@@ -1,13 +1,40 @@
-import { useTranslation } from 'react-i18next';
+import { TOptions } from 'i18next';
+import { $Dictionary } from 'i18next/typescript/helpers';
+import { useTranslation as usei18nextTranslation } from 'react-i18next';
+
+import { Skeleton } from '@mui/material';
+
+type options = TOptions<$Dictionary>;
 
 type TranslatorProps = {
-  path: string;
+  path: string | string[];
+  options?: options;
 };
 
-const Translator = ({ path }: TranslatorProps) => {
-  const { t } = useTranslation();
+const Translator = ({ path, options }: TranslatorProps) => {
+  const { t, i18n } = usei18nextTranslation();
 
-  return <div>{t(path)}</div>;
+  if (!i18n.exists(path, options)) {
+    return <Skeleton variant="text" width={20} />;
+  }
+
+  return <span>{t(path, options)}</span>;
+};
+
+export const useTranslation = () => {
+  const { t, ready, i18n } = usei18nextTranslation();
+
+  return {
+    t: (path: string | string[], options?: options) => {
+      if (!i18n.exists(path, options)) {
+        return '...';
+      }
+
+      return t(path, options);
+    },
+    ready,
+    i18n
+  };
 };
 
 export default Translator;

--- a/frontend/src/components/molecules/auth/AuthForgotPassword.tsx
+++ b/frontend/src/components/molecules/auth/AuthForgotPassword.tsx
@@ -9,6 +9,7 @@ import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 
 import { TextInput } from 'components/atoms/inputs/TextInput';
+import Translator, { useTranslation } from 'components/i18n/Translator';
 
 import { AuthTemplate } from './AuthTemplate';
 
@@ -24,13 +25,19 @@ const AuthForgotPassword = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showConfirmation, setShowConfirmation] = useState(false);
+  const { t } = useTranslation();
 
   const formik = useFormik({
     initialValues: {
       email: ''
     },
     validationSchema: yup.object({
-      email: yup.string().email().required()
+      email: yup
+        .string()
+        .email()
+        .required(
+          t('components.molecules.auth.authForgotPassword.emailRequired')
+        )
     }),
     onSubmit: async ({ email }) => {
       setLoading(true);
@@ -71,8 +78,10 @@ const AuthForgotPassword = ({
       }
       title={
         showConfirmation
-          ? `Please check the email address ${formik.values.email} for instructions to reset your password.`
-          : 'Enter your email address and we will send you instructions to reset your password.'
+          ? t('components.molecules.auth.authForgotPassword.emailSent', {
+              email: formik.values.email
+            })
+          : t('components.molecules.auth.authForgotPassword.enterEmail')
       }
     >
       {error ? (
@@ -87,13 +96,15 @@ const AuthForgotPassword = ({
           variant="outlined"
           sx={{ marginTop: 1 }}
         >
-          Resend email
+          <Translator path="components.molecules.auth.authForgotPassword.resendEmail" />
         </Button>
       ) : (
         <form onSubmit={formik.handleSubmit}>
           <TextInput
             id="email"
-            placeholder="Email adress"
+            placeholder={t(
+              'components.molecules.auth.authForgotPassword.email'
+            )}
             size="medium"
             value={formik.values.email}
             hasError={!!formik.errors.email}
@@ -110,12 +121,12 @@ const AuthForgotPassword = ({
             variant="contained"
             sx={{ marginTop: 1, width: '100%' }}
           >
-            Continue
+            <Translator path="components.molecules.auth.authForgotPassword.continue" />
           </Button>
         </form>
       )}
       <Link component="button" marginTop={1} onClick={onGoBack}>
-        Go Back
+        <Translator path="components.molecules.auth.authForgotPassword.goBack" />
       </Link>
     </AuthTemplate>
   );

--- a/frontend/src/components/molecules/auth/AuthLogin.tsx
+++ b/frontend/src/components/molecules/auth/AuthLogin.tsx
@@ -1,5 +1,5 @@
 import { useFormik } from 'formik';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PasswordChecklist, { RuleNames } from 'react-password-checklist';
 import { grey } from 'theme/palette';
 import { useToggle } from 'usehooks-ts';
@@ -17,38 +17,13 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 import { TextInput } from 'components/atoms/inputs/TextInput';
+import Translator, { useTranslation } from 'components/i18n/Translator';
 
 import { AuthTemplate } from './AuthTemplate';
 import { ProviderButton } from './ProviderButton';
 
-const signinErrors: Record<string, string> = {
-  default: 'Unable to sign in.',
-  signin: 'Try signing in with a different account.',
-  oauthsignin: 'Try signing in with a different account.',
-  redirect_uri_mismatch:
-    'The redirect URI is not matching the oauth app configuration.',
-  oauthcallbackerror: 'Try signing in with a different account.',
-  oauthcreateaccount: 'Try signing in with a different account.',
-  emailcreateaccount: 'Try signing in with a different account.',
-  callback: 'Try signing in with a different account.',
-  oauthaccountnotlinked:
-    'To confirm your identity, sign in with the same account you used originally.',
-  emailsignin: 'The e-mail could not be sent.',
-  emailverify: 'Please verify your email, a new email has been sent.',
-  credentialssignin:
-    'Sign in failed. Check the details you provided are correct.',
-  sessionrequired: 'Please sign in to access this page.'
-};
-
-const getErrorMessage = (errorType?: string): string => {
-  if (!errorType) {
-    return '';
-  }
-  return signinErrors[errorType.toLowerCase()] ?? signinErrors.default;
-};
-
 type AuthLoginProps = {
-  title: string;
+  title: React.ReactNode | string;
   error?: string;
   providers: string[];
   callbackUrl: string;
@@ -92,6 +67,7 @@ const AuthLogin = ({
   const [showSignIn, toggleShowSignIn] = useToggle(true);
   const [showPassword, toggleShowPassword] = useToggle();
   const [errorState, setErrorState] = useState(error);
+  const { t } = useTranslation();
 
   const oAuthReady = onOAuthSignIn && providers.length;
 
@@ -109,8 +85,14 @@ const AuthLogin = ({
       password: ''
     },
     validationSchema: yup.object({
-      email: yup.string().required(),
-      password: yup.string().required()
+      email: yup
+        .string()
+        .required(t('components.molecules.auth.authLogin.form.emailRequired')),
+      password: yup
+        .string()
+        .required(
+          t('components.molecules.auth.authLogin.form.passwordRequired')
+        )
     }),
     onSubmit: async ({ email, password }) => {
       setLoading(true);
@@ -138,7 +120,10 @@ const AuthLogin = ({
     <AuthTemplate title={title} renderLogo={renderLogo}>
       {errorState ? (
         <Alert sx={{ my: 1 }} severity="error">
-          {getErrorMessage(errorState)}
+          {t([
+            `components.molecules.auth.authLogin.error.${errorState.toLowerCase()}`,
+            `components.molecules.auth.authLogin.error.default`
+          ])}
         </Alert>
       ) : null}
 
@@ -146,7 +131,7 @@ const AuthLogin = ({
         <form onSubmit={formik.handleSubmit}>
           <TextInput
             id="email"
-            placeholder="Email address"
+            placeholder={t('components.molecules.auth.authLogin.form.email')}
             size="medium"
             value={formik.values.email}
             hasError={!!formik.errors.email}
@@ -158,7 +143,7 @@ const AuthLogin = ({
           />
           <TextInput
             id="password"
-            placeholder="Password"
+            placeholder={t('components.molecules.auth.authLogin.form.password')}
             value={formik.values.password}
             hasError={!!formik.errors.password}
             description={
@@ -198,7 +183,7 @@ const AuthLogin = ({
                 fontSize: 14
               }}
             >
-              Your password must contain:
+              <Translator path="components.molecules.auth.authLogin.form.passwordMustContain" />
               <PasswordChecklist
                 rules={passwordChecklistSettings.rules}
                 minLength={passwordChecklistSettings.minLength}
@@ -212,7 +197,7 @@ const AuthLogin = ({
 
           {showSignIn && onForgotPassword ? (
             <Link href="#" marginTop={1} onClick={onForgotPassword}>
-              Forgot password?
+              <Translator path="components.molecules.auth.authLogin.form.forgotPassword" />
             </Link>
           ) : null}
           <Button
@@ -221,7 +206,7 @@ const AuthLogin = ({
             variant="contained"
             sx={{ marginTop: 3, width: '100%' }}
           >
-            Continue
+            <Translator path="components.molecules.auth.authLogin.form.continue" />
           </Button>
         </form>
       ) : null}
@@ -230,16 +215,20 @@ const AuthLogin = ({
         <Stack direction="row" alignItems="center" gap={0.5} marginTop={1}>
           {showSignIn ? (
             <>
-              <Typography color="text.primary">{`${"Don't have an account?"}`}</Typography>
+              <Typography color="text.primary">
+                <Translator path="components.molecules.auth.authLogin.form.noAccount" />
+              </Typography>
               <Link component="button" onClick={toggleShowSignIn}>
-                Sign Up
+                <Translator path="components.molecules.auth.authLogin.form.signup" />
               </Link>
             </>
           ) : (
             <>
-              <Typography color="text.primary">{`${'Already have an account?'}`}</Typography>
+              <Typography color="text.primary">
+                <Translator path="components.molecules.auth.authLogin.form.alreadyHaveAccount" />
+              </Typography>
               <Link component="button" onClick={toggleShowSignIn}>
-                Sign In
+                <Translator path="components.molecules.auth.authLogin.form.signin" />
               </Link>
             </>
           )}
@@ -263,7 +252,7 @@ const AuthLogin = ({
             }
           }}
         >
-          OR
+          <Translator path="components.molecules.auth.authLogin.form.or" />
         </Typography>
       ) : null}
       {oAuthReady ? (

--- a/frontend/src/components/molecules/auth/AuthResetPassword.tsx
+++ b/frontend/src/components/molecules/auth/AuthResetPassword.tsx
@@ -6,6 +6,7 @@ import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 
 import { TextInput } from 'components/atoms/inputs/TextInput';
+import Translator, { useTranslation } from 'components/i18n/Translator';
 
 import { AuthTemplate } from './AuthTemplate';
 
@@ -30,6 +31,7 @@ const AuthResetPassword = ({
 }: AuthResetPasswordProps): JSX.Element => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const { t } = useTranslation();
 
   const formik = useFormik({
     initialValues: {
@@ -37,11 +39,20 @@ const AuthResetPassword = ({
       confirmPassword: ''
     },
     validationSchema: yup.object({
-      newPassword: yup.string().required('New password is a required field'),
+      newPassword: yup
+        .string()
+        .required(
+          t('components.molecules.auth.authResetPassword.newPasswordRequired')
+        ),
       confirmPassword: yup
         .string()
-        .oneOf([yup.ref('newPassword'), undefined], 'Passwords must match')
-        .required('Confirm password is a required field')
+        .oneOf(
+          [yup.ref('newPassword'), undefined],
+          t('components.molecules.auth.authResetPassword.passwordsMustMatch')
+        )
+        .required(
+          'components.molecules.auth.authResetPassword.confirmPasswordRequired'
+        )
     }),
     onSubmit: async ({ newPassword }) => {
       setLoading(true);
@@ -71,7 +82,9 @@ const AuthResetPassword = ({
       <form onSubmit={formik.handleSubmit}>
         <TextInput
           id="newPassword"
-          placeholder="New password"
+          placeholder={t(
+            'components.molecules.auth.authResetPassword.newPassword'
+          )}
           size="medium"
           value={formik.values.newPassword}
           hasError={!!formik.errors.newPassword}
@@ -87,7 +100,9 @@ const AuthResetPassword = ({
 
         <TextInput
           id="confirmPassword"
-          placeholder="Confirm password"
+          placeholder={t(
+            'components.molecules.auth.authResetPassword.confirmPassword'
+          )}
           size="medium"
           value={formik.values.confirmPassword}
           hasError={!!formik.errors.confirmPassword}
@@ -109,7 +124,7 @@ const AuthResetPassword = ({
           variant="contained"
           sx={{ marginTop: 3, width: '100%' }}
         >
-          Reset Password
+          <Translator path="components.molecules.auth.authResetPassword.resetPassword" />
         </Button>
       </form>
     </AuthTemplate>

--- a/frontend/src/components/molecules/auth/AuthTemplate.tsx
+++ b/frontend/src/components/molecules/auth/AuthTemplate.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography';
 interface AuthTemplateProps {
   children: React.ReactNode;
   renderLogo?: React.ReactElement;
-  title?: string;
+  title?: React.ReactNode | string;
 }
 
 const AuthTemplate = ({

--- a/frontend/src/components/molecules/auth/AuthVerifyEmail.tsx
+++ b/frontend/src/components/molecules/auth/AuthVerifyEmail.tsx
@@ -7,6 +7,9 @@ import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 
+import { Translator } from 'components/i18n';
+import { useTranslation } from 'components/i18n/Translator';
+
 import { AuthTemplate } from './AuthTemplate';
 
 interface AuthVerifyEmailProps {
@@ -23,13 +26,14 @@ const AuthVerifyEmail = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const { t } = useTranslation();
 
   const onSubmit = async () => {
     setLoading(true);
 
     try {
       await onResend(email);
-      setSuccess('Email sent successfully.');
+      setSuccess(t('components.molecules.auth.authVerifyEmail.emailSent'));
     } catch (error) {
       if (error instanceof Error) {
         setError(error.message);
@@ -57,7 +61,7 @@ const AuthVerifyEmail = ({
             <MailOutline color="success" fontSize="large" />
           </Box>
           <Typography fontSize="18px" fontWeight={700} color="text.primary">
-            {'Verify your email address'}
+            <Translator path="components.molecules.auth.authVerifyEmail.verifyEmail" />
           </Typography>
         </>
       }
@@ -77,17 +81,19 @@ const AuthVerifyEmail = ({
       <Box display="flex" flexDirection="column" gap={3}>
         <Box>
           <Typography>
-            {"You're almost there! We've sent an email to "}
+            <Translator path="components.molecules.auth.authVerifyEmail.almostThere" />
           </Typography>
           <Typography fontWeight="fontWeightMedium" component="span">
             {email}
           </Typography>
         </Box>
         <Typography>
-          Please click on the link in that email to complete your signup.
+          <Translator path="components.molecules.auth.authVerifyEmail.verifyEmailLink" />
         </Typography>
 
-        <Typography>{"Can't find the email?"}</Typography>
+        <Typography>
+          <Translator path="components.molecules.auth.authVerifyEmail.didNotReceive" />
+        </Typography>
       </Box>
 
       <Button
@@ -97,11 +103,11 @@ const AuthVerifyEmail = ({
         sx={{ marginTop: 1 }}
         disabled={loading}
       >
-        Resend email
+        <Translator path="components.molecules.auth.authVerifyEmail.resendEmail" />
       </Button>
 
       <Link component="button" marginTop={1} onClick={onGoBack}>
-        Go Back
+        <Translator path="components.molecules.auth.authVerifyEmail.goBack" />
       </Link>
     </AuthTemplate>
   );

--- a/frontend/src/components/molecules/auth/ProviderButton.tsx
+++ b/frontend/src/components/molecules/auth/ProviderButton.tsx
@@ -9,6 +9,7 @@ import { Auth0 } from 'components/atoms/icons/Auth0';
 import { Cognito } from 'components/atoms/icons/Cognito';
 import { Descope } from 'components/atoms/icons/Descope';
 import { Okta } from 'components/atoms/icons/Okta';
+import { useTranslation } from 'components/i18n/Translator';
 
 function capitalizeFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
@@ -63,6 +64,7 @@ const ProviderButton = ({
   onClick,
   isSignIn
 }: ProviderButtonProps): JSX.Element => {
+  const { t } = useTranslation();
   return (
     <Button
       variant="outlined"
@@ -78,7 +80,13 @@ const ProviderButton = ({
         justifyContent: 'flex-start'
       }}
     >
-      {`${isSignIn ? 'Continue' : 'Sign up'} with ${getProviderName(provider)}`}
+      {isSignIn
+        ? t('components.molecules.auth.providerButton.continue', {
+            provider: getProviderName(provider)
+          })
+        : t('components.molecules.auth.providerButton.signup', {
+            provider: getProviderName(provider)
+          })}
     </Button>
   );
 };

--- a/frontend/src/components/molecules/messages/components/DetailsButton.tsx
+++ b/frontend/src/components/molecules/messages/components/DetailsButton.tsx
@@ -6,6 +6,7 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import { GreyButton } from 'components/atoms/buttons/GreyButton';
+import { Translator } from 'components/i18n';
 
 import type { IStep } from 'client-types/';
 
@@ -42,11 +43,29 @@ const DetailsButton = ({ message, opened, onClick, loading }: Props) => {
     ? message.steps!.filter((m) => !!m.output || m.steps?.length).length
     : 0;
 
-  const text = loading
-    ? tool
-      ? `Using ${tool}`
-      : 'Running'
-    : `Took ${stepCount} step${stepCount <= 1 ? '' : 's'}`;
+  const text = (
+    <span>
+      {loading ? (
+        tool ? (
+          <>
+            <Translator path="components.molecules.detailsButton.using" />{' '}
+            {tool}
+          </>
+        ) : (
+          <Translator path="components.molecules.detailsButton.running" />
+        )
+      ) : (
+        <>
+          <Translator
+            path="components.molecules.detailsButton.took"
+            options={{
+              count: stepCount
+            }}
+          />
+        </>
+      )}
+    </span>
+  );
 
   let id = '';
   if (tool) {

--- a/frontend/src/components/organisms/chat/Messages/index.tsx
+++ b/frontend/src/components/organisms/chat/Messages/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'sonner';
 
@@ -15,6 +14,8 @@ import {
   useChatMessages,
   useChatSession
 } from '@chainlit/react-client';
+
+import { useTranslation } from 'components/i18n/Translator';
 
 import { apiClientState } from 'state/apiClient';
 import { IProjectSettings } from 'state/project';

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -1,6 +1,5 @@
 import { useUpload } from 'hooks';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
@@ -17,6 +16,7 @@ import {
 import { ErrorBoundary } from 'components/atoms/ErrorBoundary';
 import SideView from 'components/atoms/element/sideView';
 import { Translator } from 'components/i18n';
+import { useTranslation } from 'components/i18n/Translator';
 import ChatProfiles from 'components/molecules/chatProfiles';
 import { TaskList } from 'components/molecules/tasklist/TaskList';
 

--- a/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import 'regenerator-runtime';
 
@@ -9,6 +8,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 
 import { FileSpec, useChatData } from '@chainlit/react-client';
 
+import { useTranslation } from 'components/i18n/Translator';
 import { Attachments } from 'components/molecules/attachments';
 import HistoryButton from 'components/organisms/chat/history';
 

--- a/frontend/src/components/organisms/header.tsx
+++ b/frontend/src/components/organisms/header.tsx
@@ -1,6 +1,5 @@
 import { useAuth } from 'api/auth';
-import { memo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { memo, useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import MenuIcon from '@mui/icons-material/Menu';
@@ -19,6 +18,7 @@ import { RegularButton } from 'components/atoms/buttons';
 import GithubButton from 'components/atoms/buttons/githubButton';
 import UserButton from 'components/atoms/buttons/userButton';
 import { Logo } from 'components/atoms/logo';
+import { Translator } from 'components/i18n';
 import NewChatButton from 'components/molecules/newChatButton';
 
 import { IProjectSettings } from 'state/project';
@@ -27,7 +27,7 @@ import { OpenThreadListButton } from './threadHistory/sidebar/OpenThreadListButt
 
 interface INavItem {
   to: string;
-  label: string;
+  label: React.ReactElement | string;
 }
 
 function ActiveNavItem({ to, label }: INavItem) {
@@ -69,20 +69,20 @@ const Nav = ({ dataPersistence, hasReadme, matches }: NavProps) => {
   const [open, setOpen] = useState(false);
   const ref = useRef<any>();
 
-  const { t } = useTranslation();
-
   let anchorEl;
 
   if (open && ref.current) {
     anchorEl = ref.current;
   }
 
-  const tabs = [{ to: '/', label: t('components.organisms.header.chat') }];
+  const tabs = [
+    { to: '/', label: <Translator path="components.organisms.header.chat" /> }
+  ];
 
   if (hasReadme) {
     tabs.push({
       to: '/readme',
-      label: t('components.organisms.header.readme')
+      label: <Translator path="components.organisms.header.readme" />
     });
   }
 

--- a/frontend/src/components/organisms/threadHistory/sidebar/TriggerButton.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/TriggerButton.tsx
@@ -1,7 +1,7 @@
-import { useTranslation } from 'react-i18next';
-
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
+
+import { useTranslation } from 'components/i18n/Translator';
 
 interface TriggerButtonProps {
   onClick: () => void;

--- a/frontend/src/components/organisms/threadHistory/sidebar/filters/FeedbackSelect.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/filters/FeedbackSelect.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilState } from 'recoil';
 import { grey } from 'theme';
 
@@ -10,6 +9,8 @@ import { IconButton } from '@mui/material';
 import Box from '@mui/material/Box';
 import Menu from '@mui/material/Menu';
 import Stack from '@mui/material/Stack';
+
+import { useTranslation } from 'components/i18n/Translator';
 
 import { threadsFiltersState } from 'state/threads';
 

--- a/frontend/src/components/organisms/threadHistory/sidebar/filters/SearchBar.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/filters/SearchBar.tsx
@@ -1,6 +1,5 @@
 import debounce from 'lodash/debounce';
 import { useRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilState } from 'recoil';
 import { grey } from 'theme';
 
@@ -9,6 +8,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import TextField from '@mui/material/TextField';
+
+import { useTranslation } from 'components/i18n/Translator';
 
 import { threadsFiltersState } from 'state/threads';
 

--- a/frontend/src/hooks/useLLMProviders.ts
+++ b/frontend/src/hooks/useLLMProviders.ts
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'sonner';
 
 import { useApi } from '@chainlit/react-client';
+
+import { useTranslation } from 'components/i18n/Translator';
 
 import { apiClientState } from 'state/apiClient';
 import { playgroundState } from 'state/playground';

--- a/frontend/src/pages/Env.tsx
+++ b/frontend/src/pages/Env.tsx
@@ -1,5 +1,4 @@
 import { useFormik } from 'formik';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { toast } from 'sonner';
@@ -9,6 +8,7 @@ import { Alert, Box, Button, Typography } from '@mui/material';
 
 import { TextInput } from 'components/atoms/inputs/TextInput';
 import { Translator } from 'components/i18n';
+import { useTranslation } from 'components/i18n/Translator';
 import { Header } from 'components/organisms/header';
 
 import { projectSettingsState } from 'state/project';

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { Logo } from 'components/atoms/logo';
+import { Translator } from 'components/i18n';
 import { AuthLogin } from 'components/molecules/auth';
 
 import { useQuery } from 'hooks/query';
@@ -67,7 +68,7 @@ export default function Login() {
 
   return (
     <AuthLogin
-      title="Login to access the app."
+      title={<Translator path="components.molecules.auth.authLogin.title" />}
       error={error}
       callbackUrl="/"
       providers={config?.oauthProviders || []}

--- a/frontend/tests/message.spec.tsx
+++ b/frontend/tests/message.spec.tsx
@@ -16,8 +16,8 @@ const i18nConfig = {
   defaultNS: 'translation'
 };
 
-beforeAll(() => {
-  i18n.use(initReactI18next).init(i18nConfig);
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init(i18nConfig);
   i18n.addResourceBundle('en-US', 'translation', json);
 });
 

--- a/frontend/tests/message.spec.tsx
+++ b/frontend/tests/message.spec.tsx
@@ -1,11 +1,25 @@
 import { fireEvent, render } from '@testing-library/react';
 import { MessageContext, defaultMessageContext } from 'contexts/MessageContext';
+import i18n from 'i18next';
 import { ComponentProps } from 'react';
-import { describe, expect, it } from 'vitest';
+import { initReactI18next } from 'react-i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { ThemeProvider, createTheme } from '@mui/material';
 
 import { Message } from 'components/molecules/messages/Message';
+
+import json from '../../backend/chainlit/translations/en-US.json';
+
+const i18nConfig = {
+  fallbackLng: 'en-US',
+  defaultNS: 'translation'
+};
+
+beforeAll(() => {
+  i18n.use(initReactI18next).init(i18nConfig);
+  i18n.addResourceBundle('en-US', 'translation', json);
+});
 
 describe('Message', () => {
   const defaultProps: ComponentProps<typeof Message> = {
@@ -59,7 +73,7 @@ describe('Message', () => {
         <Message {...defaultProps} />
       </ThemeProvider>
     );
-    let detailsButton = getByRole('button', { name: 'Took 1 step' });
+    let detailsButton = getByRole('button', {});
 
     expect(detailsButton).toBeInTheDocument();
     fireEvent.click(detailsButton);

--- a/libs/copilot/src/app.tsx
+++ b/libs/copilot/src/app.tsx
@@ -1,6 +1,5 @@
 import { WidgetContext } from 'context';
 import { useContext, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Toaster } from 'sonner';
 import { IWidgetConfig } from 'types';
@@ -9,6 +8,7 @@ import Widget from 'widget';
 import { Theme, ThemeProvider } from '@mui/material/styles';
 
 import { overrideTheme } from '@chainlit/app/src/App';
+import { useTranslation } from '@chainlit/app/src/components/i18n/Translator';
 import { apiClientState } from '@chainlit/app/src/state/apiClient';
 import {
   IProjectSettings,

--- a/libs/copilot/src/app.tsx
+++ b/libs/copilot/src/app.tsx
@@ -66,6 +66,14 @@ export default function App({ config }: Props) {
           );
           setTheme(_theme);
           setProjectSettings(data);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+      apiClient
+        .get(`/project/translations?language=${languageInUse}`, accessToken)
+        .then((res) => res.json())
+        .then((data) => {
           i18n.addResourceBundle(
             languageInUse,
             'translation',

--- a/libs/copilot/src/components/Input.tsx
+++ b/libs/copilot/src/components/Input.tsx
@@ -1,11 +1,11 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import 'regenerator-runtime';
 
 import TuneIcon from '@mui/icons-material/Tune';
 import { Box, IconButton, Stack, TextField } from '@mui/material';
 
+import { useTranslation } from '@chainlit/app/src/components/i18n/Translator';
 import { Attachments } from '@chainlit/app/src/components/molecules/attachments';
 import { SubmitButton } from '@chainlit/app/src/components/organisms/chat/inputBox/SubmitButton';
 import UploadButton from '@chainlit/app/src/components/organisms/chat/inputBox/UploadButton';


### PR DESCRIPTION
- add a translation linter
- add translation file fallback
- move translations api from settings to its own route
- add fastapi gzip middleware
- enable a fallback (skeleton component) in the existing Translator component
- add a new hook to return a string (with a `...` fallback)
- switch to using the Translator as much as possible (to benefit from the skeleton fallback)
- if the Translator can't be used, use the new `useTranslation` hook instead of the one from `react-i18next` (to benefit from the fallback which avoids displaying the translation keys)

Example of a simulated long translation loading time:

![CleanShot 2024-03-28 at 12 01 49](https://github.com/Chainlit/chainlit/assets/494686/abc84867-e518-4245-9376-e2face8be704)

# Limitations

- If a key is missing from your translation file, it won't load in the UI, this is why you should use the translation linter to check your local translation files.
- The translation linter doesn't check the translation files for the plural and interpolation features of i18next, this will be added in a future version to make it more solid.