### PR TITLE
fix: clean sidebar when starting a new conversation

### DIFF
--- a/frontend/src/components/atoms/element/sideView.tsx
+++ b/frontend/src/components/atoms/element/sideView.tsx
@@ -1,8 +1,8 @@
 import { useRecoilState } from 'recoil';
 
-import { ElementSideView } from 'components/atoms/elements/ElementSideView';
+import { sideViewState } from '@chainlit/react-client';
 
-import { sideViewState } from 'state/project';
+import { ElementSideView } from 'components/atoms/elements/ElementSideView';
 
 interface SideViewProps {
   children: React.ReactNode;

--- a/frontend/src/components/organisms/chat/Messages/container.tsx
+++ b/frontend/src/components/organisms/chat/Messages/container.tsx
@@ -14,12 +14,13 @@ import {
   ITool,
   useChatInteract
 } from '@chainlit/react-client';
+import { sideViewState } from '@chainlit/react-client';
 
 import { MessageContainer as CMessageContainer } from 'components/molecules/messages/MessageContainer';
 
 import { apiClientState } from 'state/apiClient';
 import { playgroundState } from 'state/playground';
-import { highlightMessage, sideViewState } from 'state/project';
+import { highlightMessage } from 'state/project';
 import { projectSettingsState } from 'state/project';
 import { settingsState } from 'state/settings';
 

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -12,6 +12,7 @@ import {
   useChatInteract,
   useChatSession
 } from '@chainlit/react-client';
+import { sideViewState } from '@chainlit/react-client';
 
 import { ErrorBoundary } from 'components/atoms/ErrorBoundary';
 import SideView from 'components/atoms/element/sideView';
@@ -22,7 +23,7 @@ import { TaskList } from 'components/molecules/tasklist/TaskList';
 
 import { apiClientState } from 'state/apiClient';
 import { IAttachment, attachmentsState } from 'state/chat';
-import { projectSettingsState, sideViewState } from 'state/project';
+import { projectSettingsState } from 'state/project';
 
 import Messages from './Messages';
 import DropScreen from './dropScreen';

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-import { IMessageElement, IStep } from '@chainlit/react-client';
+import { IStep } from '@chainlit/react-client';
 
 export interface ChatProfile {
   icon: string;
@@ -43,11 +43,6 @@ export interface IProjectSettings {
 
 export const projectSettingsState = atom<IProjectSettings | undefined>({
   key: 'ProjectSettings',
-  default: undefined
-});
-
-export const sideViewState = atom<IMessageElement | undefined>({
-  key: 'SideView',
   default: undefined
 });
 

--- a/libs/copilot/src/chat/body.tsx
+++ b/libs/copilot/src/chat/body.tsx
@@ -19,15 +19,13 @@ import DropScreen from '@chainlit/app/src/components/organisms/chat/dropScreen';
 import ChatSettingsModal from '@chainlit/app/src/components/organisms/chat/settings';
 import { useUpload } from '@chainlit/app/src/hooks';
 import { IAttachment, attachmentsState } from '@chainlit/app/src/state/chat';
-import {
-  projectSettingsState,
-  sideViewState
-} from '@chainlit/app/src/state/project';
+import { projectSettingsState } from '@chainlit/app/src/state/project';
 import {
   threadHistoryState,
   useChatData,
   useChatInteract
 } from '@chainlit/react-client';
+import { sideViewState } from '@chainlit/react-client';
 
 import { ElementSideView } from 'components/ElementSideView';
 import { InputBox } from 'components/InputBox';

--- a/libs/copilot/src/chat/messages/container.tsx
+++ b/libs/copilot/src/chat/messages/container.tsx
@@ -4,10 +4,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'sonner';
 
 import { MessageContainer as CMessageContainer } from '@chainlit/app/src/components/molecules/messages/MessageContainer';
-import {
-  highlightMessage,
-  sideViewState
-} from '@chainlit/app/src/state/project';
+import { highlightMessage } from '@chainlit/app/src/state/project';
 import { projectSettingsState } from '@chainlit/app/src/state/project';
 import { settingsState } from '@chainlit/app/src/state/settings';
 import {
@@ -19,6 +16,7 @@ import {
   IStep,
   useChatInteract
 } from '@chainlit/react-client';
+import { sideViewState } from '@chainlit/react-client';
 
 interface Props {
   loading: boolean;

--- a/libs/react-client/src/state.ts
+++ b/libs/react-client/src/state.ts
@@ -165,3 +165,8 @@ export const threadHistoryState = atom<ThreadHistory | undefined>({
     }
   ]
 });
+
+export const sideViewState = atom<IMessageElement | undefined>({
+  key: 'SideView',
+  default: undefined
+});

--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -13,6 +13,7 @@ import {
   messagesState,
   sessionIdState,
   sessionState,
+  sideViewState,
   tasklistState,
   threadIdToResumeState,
   tokenCountState
@@ -41,6 +42,7 @@ const useChatInteract = () => {
   const setActions = useSetRecoilState(actionState);
   const setTokenCount = useSetRecoilState(tokenCountState);
   const setIdToResume = useSetRecoilState(threadIdToResumeState);
+  const setSideView = useSetRecoilState(sideViewState);
 
   const clear = useCallback(() => {
     session?.socket.emit('clear_session');
@@ -56,6 +58,7 @@ const useChatInteract = () => {
     setTokenCount(0);
     resetChatSettings();
     resetChatSettingsValue();
+    setSideView(undefined);
   }, [session]);
 
   const sendMessage = useCallback(


### PR DESCRIPTION
- moved the 'SideView' state into react-client
- clean up the 'SideView' state in the `clear` method from `useChatInteract`