### PR TITLE
Allow html in text elements

### DIFF
--- a/frontend/src/components/atoms/elements/Text.tsx
+++ b/frontend/src/components/atoms/elements/Text.tsx
@@ -1,3 +1,5 @@
+import { useRecoilValue } from 'recoil';
+
 import Box from '@mui/material/Box';
 
 import { Markdown } from 'components/molecules/Markdown';
@@ -5,6 +7,7 @@ import { Markdown } from 'components/molecules/Markdown';
 import { useFetch } from 'hooks/useFetch';
 
 import { type ITextElement } from 'client-types/';
+import { projectSettingsState } from '@chainlit/app/src/state/project';
 
 interface Props {
   element: ITextElement;
@@ -12,6 +15,9 @@ interface Props {
 
 const TextElement = ({ element }: Props) => {
   const { data, error, isLoading } = useFetch(element.url || null);
+  const projectSettings = useRecoilValue(projectSettingsState);
+  const allowHtml = projectSettings?.features?.unsafe_allow_html;
+  const latex = projectSettings?.features?.latex;
 
   let content = '';
 
@@ -29,7 +35,7 @@ const TextElement = ({ element }: Props) => {
 
   return (
     <Box sx={{ fontFamily: (theme) => theme.typography.fontFamily }}>
-      <Markdown>{content}</Markdown>
+      <Markdown allowHtml={allowHtml} latex={latex}>{content}</Markdown>
     </Box>
   );
 };

--- a/frontend/src/components/atoms/elements/Text.tsx
+++ b/frontend/src/components/atoms/elements/Text.tsx
@@ -7,7 +7,7 @@ import { Markdown } from 'components/molecules/Markdown';
 import { useFetch } from 'hooks/useFetch';
 
 import { type ITextElement } from 'client-types/';
-import { projectSettingsState } from '@chainlit/app/src/state/project';
+import { projectSettingsState } from 'state/project';
 
 interface Props {
   element: ITextElement;


### PR DESCRIPTION
This fixes #597 and #862 

Text elements can now use html to render content vs just messages.