### PR TITLE
Adding SSL certificate + key file parameters to run command (passthrough to uvicorn webserver)

### DIFF
--- a/backend/chainlit/cli/__init__.py
+++ b/backend/chainlit/cli/__init__.py
@@ -37,6 +37,8 @@ def cli():
 def run_chainlit(target: str):
     host = os.environ.get("CHAINLIT_HOST", DEFAULT_HOST)
     port = int(os.environ.get("CHAINLIT_PORT", DEFAULT_PORT))
+    ssl_cert_file = os.environ.get("CHAINLIT_SSL_CERT_FILE")
+    ssl_key_file = os.environ.get("CHAINLIT_SSL_KEY_FILE")
 
     ws_per_message_deflate_env = os.environ.get(
         "UVICORN_WS_PER_MESSAGE_DEFLATE", "true"
@@ -49,6 +51,8 @@ def run_chainlit(target: str):
 
     config.run.host = host
     config.run.port = port
+    config.run.ssl_cert_file = ssl_cert_file
+    config.run.ssl_key_file = ssl_key_file
 
     check_file(target)
     # Load the module provided by the user
@@ -76,6 +80,10 @@ def run_chainlit(target: str):
             log_level=log_level,
             ws_per_message_deflate=ws_per_message_deflate,
         )
+        if ssl_cert_file:
+            config.ssl_certfile = ssl_cert_file
+        if ssl_key_file:
+            config.ssl_keyfile = ssl_key_file
         server = uvicorn.Server(config)
         await server.serve()
 
@@ -128,11 +136,34 @@ def run_chainlit(target: str):
 )
 @click.option("--host", help="Specify a different host to run the server on")
 @click.option("--port", help="Specify a different port to run the server on")
-def chainlit_run(target, watch, headless, debug, ci, no_cache, host, port):
+@click.option(
+    "--ssl-cert-file",
+    help="SSL certificate file for passthrough to webserver (uvicorn)",
+)
+@click.option(
+    "--ssl-key-file",
+    help="SSL certificate key file for passthrough to webserver (uvicorn)",
+)
+def chainlit_run(
+    target,
+    watch,
+    headless,
+    debug,
+    ci,
+    no_cache,
+    host,
+    port,
+    ssl_cert_file,
+    ssl_key_file,
+):
     if host:
         os.environ["CHAINLIT_HOST"] = host
     if port:
         os.environ["CHAINLIT_PORT"] = port
+    if ssl_cert_file:
+        os.environ["CHAINLIT_SSL_CERT_FILE"] = ssl_cert_file
+    if ssl_key_file:
+        os.environ["CHAINLIT_SSL_KEY_FILE"] = ssl_key_file
     if ci:
         logger.info("Running in CI mode")
 

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -157,6 +157,8 @@ class RunSettings:
     module_name: Optional[str] = None
     host: str = DEFAULT_HOST
     port: int = DEFAULT_PORT
+    ssl_cert_file: str = None
+    ssl_key_file: str = None
     headless: bool = False
     watch: bool = False
     no_cache: bool = False

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -70,10 +70,15 @@ async def lifespan(app: FastAPI):
     host = config.run.host
     port = config.run.port
 
-    if host == DEFAULT_HOST:
-        url = f"http://localhost:{port}"
+    if config.run.ssl_cert_file:
+        urlProtocol = "https"
     else:
-        url = f"http://{host}:{port}"
+        urlProtocol = "http"
+
+    if host == DEFAULT_HOST:
+        url = f"{urlProtocol}://localhost:{port}"
+    else:
+        url = f"{urlProtocol}://{host}:{port}"
 
     logger.info(f"Your app is available at {url}")
 


### PR DESCRIPTION
I added optional parameters to pass an SSL certificate file and key file through to the webserver in the run command, as either a CLI or env var using the existing pattern, so that traffic can be secured from the app source (installing behind a reverse-proxy might not be desirable in all cases, and if the proxy is outside the host or container of this app there might be security constraints requiring that traffic to be encrypted as well, which was the reason I implemented this for my use case).  This passes through to the webserver (uvicorn) config object, and I have confirmed it provides an SSL connection from the source when proper cert+key files are used.