### PR TITLE
feat: Add node metadata in element content for CBEventType.RETRIEVE in Llama_index callback.

### DIFF
--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -137,7 +137,7 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
                 step.elements = [
                     Text(
                         name=f"Source {idx}",
-                        content=source.node.get_text() or "Empty node",
+                        content=f"Metadata:\n{source.node.get_metadata_str()}\n\nContent:\n{source.node.get_text()}" or "Empty node",
                     )
                     for idx, source in enumerate(sources)
                 ]


### PR DESCRIPTION
Commit non testé.