### PR TITLE
Update thread list on first interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Nothing unreleased!
 ### Added
 
 - The user's browser language configuration is available in `cl.user_session.get("languages")`
+- Allow html in text elements - @jdb78
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Nothing unreleased!
 
+## [1.0.505] - 2024-04-23
+
+### Added
+
+- The user's browser language configuration is available in `cl.user_session.get("languages")`
+
+### Changed
+
+- The thread auto-tagging feature is now opt-in using `auto_tag_thread` in the config.toml file
+
 ## [1.0.504] - 2024-04-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Nothing unreleased!
 
 - The thread auto-tagging feature is now opt-in using `auto_tag_thread` in the config.toml file
 
+### Fixed
+
+- Enabled having a `storage_provider` set to `None` in SQLAlchemyDataLayer - @mohamedalani
+- Correctly serialize `generation` in SQLAlchemyDataLayer - @mohamedalani
+
 ## [1.0.504] - 2024-04-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Nothing unreleased!
 
 ### Fixed
 
+- Fixed incorrect step ancestor in the OpenAI instrumentation
 - Enabled having a `storage_provider` set to `None` in SQLAlchemyDataLayer - @mohamedalani
 - Correctly serialize `generation` in SQLAlchemyDataLayer - @mohamedalani
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Nothing unreleased!
 
 ### Changed
 
+- The thread history refreshes right after a new thread is created.
 - The thread auto-tagging feature is now opt-in using `auto_tag_thread` in the config.toml file
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Nothing unreleased!
 
 - The user's browser language configuration is available in `cl.user_session.get("languages")`
 - Allow html in text elements - @jdb78
+- Allow for setting a ChatProfile default - @kevinwmerritt
 
 ### Changed
 

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -188,14 +188,6 @@ class ChainlitEmitter(BaseChainlitEmitter):
                         tags=tags,
                     )
                 )
-                asyncio.create_task(
-                    data_layer.update_thread(
-                        thread_id=self.session.thread_id,
-                        name=interaction,
-                        user_id=user_id,
-                        tags=tags,
-                    )
-                )
             except Exception as e:
                 logger.error(f"Error updating thread: {e}")
             asyncio.create_task(self.session.flush_method_queue())

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -188,13 +188,27 @@ class ChainlitEmitter(BaseChainlitEmitter):
                         tags=tags,
                     )
                 )
+                asyncio.create_task(
+                    data_layer.update_thread(
+                        thread_id=self.session.thread_id,
+                        name=interaction,
+                        user_id=user_id,
+                        tags=tags,
+                    )
+                )
             except Exception as e:
                 logger.error(f"Error updating thread: {e}")
             asyncio.create_task(self.session.flush_method_queue())
 
     async def init_thread(self, interaction: str):
         await self.flush_thread_queues(interaction)
-        await self.emit("first_interaction", interaction)
+        await self.emit(
+            "first_interaction",
+            {
+                "interaction": interaction,
+                "thread_id": self.session.thread_id,
+            },
+        )
 
     async def process_user_message(self, payload: UIMessagePayload):
         step_dict = payload["message"]

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -169,7 +169,10 @@ async def connection_successful(sid):
         thread = await resume_thread(context.session)
         if thread:
             context.session.has_first_interaction = True
-            await context.emitter.emit("first_interaction", "resume")
+            await context.emitter.emit(
+                "first_interaction",
+                {"interaction": "resume", "thread_id": thread.get("id")},
+            )
             await context.emitter.resume_thread(thread)
             await config.code.on_chat_resume(thread)
             return

--- a/cypress/e2e/data_layer/main.py
+++ b/cypress/e2e/data_layer/main.py
@@ -77,7 +77,7 @@ class TestDataLayer(cl_data.BaseDataLayer):
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
     ):
-        thread = next((t for t in thread_history if t["id"] == "test2"), None)
+        thread = next((t for t in thread_history if t["id"] == thread_id), None)
         if thread:
             if name:
                 thread["name"] = name
@@ -85,11 +85,30 @@ class TestDataLayer(cl_data.BaseDataLayer):
                 thread["metadata"] = metadata
             if tags:
                 thread["tags"] = tags
+        else:
+            thread_history.append(
+                {
+                    "id": thread_id,
+                    "name": name,
+                    "metadata": metadata,
+                    "tags": tags,
+                    "createdAt": utc_now(),
+                    "userId": user_id,
+                    "userIdentifier": "admin",
+                    "steps": [],
+                }
+            )
 
     @cl_data.queue_until_user_message()
     async def create_step(self, step_dict: StepDict):
         global create_step_counter
         create_step_counter += 1
+
+        thread = next(
+            (t for t in thread_history if t["id"] == step_dict.get("threadId")), None
+        )
+        if thread:
+            thread["steps"].append(step_dict)
 
     async def get_thread_author(self, thread_id: str):
         return "admin"

--- a/cypress/e2e/data_layer/spec.cy.ts
+++ b/cypress/e2e/data_layer/spec.cy.ts
@@ -44,6 +44,7 @@ function threadList() {
 }
 
 function resumeThread() {
+  // Go to the "thread 2" thread and resume it
   cy.get('#thread-test2').click();
   let initialUrl;
   cy.url().then((url) => {
@@ -52,6 +53,7 @@ function resumeThread() {
   cy.get(`#chat-input`).should('not.exist');
   cy.get('#resumeThread').click();
   cy.get(`#chat-input`).should('exist');
+  // Make sure the url stays the same after resuming
   cy.url().then((newUrl) => {
     expect(newUrl).to.equal(initialUrl);
   });
@@ -65,7 +67,6 @@ function resumeThread() {
   cy.get('.step').should('have.length', 8);
 
   cy.get('.step').eq(0).should('contain', 'Hello');
-  // Thread name should be renamed with first interaction
   cy.get('.step').eq(5).should('contain', 'Welcome back to Hello');
   // Because the Thread was closed, the metadata should have been updated automatically
   cy.get('.step').eq(6).should('contain', 'metadata');

--- a/cypress/e2e/data_layer/spec.cy.ts
+++ b/cypress/e2e/data_layer/spec.cy.ts
@@ -45,25 +45,31 @@ function threadList() {
 
 function resumeThread() {
   cy.get('#thread-test2').click();
-  cy.get(`#chat-input`).should('not.exist');
-  cy.get('#resumeThread').click();
   let initialUrl;
   cy.url().then((url) => {
     initialUrl = url;
   });
+  cy.get(`#chat-input`).should('not.exist');
+  cy.get('#resumeThread').click();
   cy.get(`#chat-input`).should('exist');
   cy.url().then((newUrl) => {
     expect(newUrl).to.equal(initialUrl);
   });
 
-  cy.get('.step').should('have.length', 4);
+  // back to the "hello" thread
+  cy.get('a').contains('Hello').click();
+  cy.get(`#chat-input`).should('not.exist');
+  cy.get('#resumeThread').click();
+  cy.get(`#chat-input`).should('exist');
 
-  cy.get('.step').eq(0).should('contain', 'Message 3');
-  cy.get('.step').eq(1).should('contain', 'Message 4');
+  cy.get('.step').should('have.length', 8);
+
+  cy.get('.step').eq(0).should('contain', 'Hello');
   // Thread name should be renamed with first interaction
-  cy.get('.step').eq(2).should('contain', 'Welcome back to Hello');
-  cy.get('.step').eq(3).should('contain', 'metadata');
-  cy.get('.step').eq(3).should('contain', 'chat_profile');
+  cy.get('.step').eq(5).should('contain', 'Welcome back to Hello');
+  // Because the Thread was closed, the metadata should have been updated automatically
+  cy.get('.step').eq(6).should('contain', 'metadata');
+  cy.get('.step').eq(6).should('contain', 'chat_profile');
 }
 
 describe('Data Layer', () => {

--- a/cypress/e2e/data_layer/spec.cy.ts
+++ b/cypress/e2e/data_layer/spec.cy.ts
@@ -6,7 +6,14 @@ function login() {
 }
 
 function feedback() {
+  cy.location('pathname').should((loc) => {
+    expect(loc).to.eq('/');
+  });
   submitMessage('Hello');
+  cy.location('pathname').should((loc) => {
+    // starts with /thread/
+    expect(loc).to.match(/^\/thread\//);
+  });
   cy.get('.negative-feedback-off').should('have.length', 1);
   cy.get('.positive-feedback-off').should('have.length', 1).click();
   cy.get('#feedbackSubmit').click();
@@ -40,7 +47,14 @@ function resumeThread() {
   cy.get('#thread-test2').click();
   cy.get(`#chat-input`).should('not.exist');
   cy.get('#resumeThread').click();
+  let initialUrl;
+  cy.url().then((url) => {
+    initialUrl = url;
+  });
   cy.get(`#chat-input`).should('exist');
+  cy.url().then((newUrl) => {
+    expect(newUrl).to.equal(initialUrl);
+  });
 
   cy.get('.step').should('have.length', 4);
 

--- a/frontend/src/components/molecules/chatProfiles.tsx
+++ b/frontend/src/components/molecules/chatProfiles.tsx
@@ -1,5 +1,6 @@
 import size from 'lodash/size';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { grey } from 'theme';
 
@@ -30,10 +31,12 @@ export default function ChatProfiles() {
   const [newChatProfile, setNewChatProfile] = useState<string | null>(null);
   const [openDialog, setOpenDialog] = useState(false);
   const isDarkMode = useIsDarkMode();
+  const navigate = useNavigate();
 
   const handleClose = () => {
     setOpenDialog(false);
     setNewChatProfile(null);
+    navigate('/');
   };
 
   const handleConfirm = (newChatProfileWithoutConfirm?: string) => {

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -10,6 +10,7 @@ import {
   threadHistoryState,
   useChatData,
   useChatInteract,
+  useChatMessages,
   useChatSession
 } from '@chainlit/react-client';
 import { sideViewState } from '@chainlit/react-client';
@@ -151,10 +152,12 @@ const Chat = () => {
     options: { noClick: true }
   });
 
+  const { threadId } = useChatMessages();
+
   useEffect(() => {
     setThreads((prev) => ({
       ...prev,
-      currentThreadId: undefined
+      currentThreadId: threadId
     }));
   }, []);
 

--- a/frontend/src/components/organisms/chat/index.tsx
+++ b/frontend/src/components/organisms/chat/index.tsx
@@ -1,5 +1,6 @@
 import { useUpload } from 'hooks';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
@@ -43,6 +44,7 @@ const Chat = () => {
   const { error, disabled } = useChatData();
   const { uploadFile } = useChatInteract();
   const uploadFileRef = useRef(uploadFile);
+  const navigate = useNavigate();
 
   const fileSpec = useMemo(
     () => ({
@@ -155,10 +157,19 @@ const Chat = () => {
   const { threadId } = useChatMessages();
 
   useEffect(() => {
-    setThreads((prev) => ({
-      ...prev,
-      currentThreadId: threadId
-    }));
+    const currentPage = new URL(window.location.href);
+    if (
+      projectSettings?.dataPersistence &&
+      threadId &&
+      currentPage.pathname === '/'
+    ) {
+      navigate(`/thread/${threadId}`);
+    } else {
+      setThreads((prev) => ({
+        ...prev,
+        currentThreadId: threadId
+      }));
+    }
   }, []);
 
   const enableMultiModalUpload =

--- a/frontend/src/components/organisms/threadHistory/Thread.tsx
+++ b/frontend/src/components/organisms/threadHistory/Thread.tsx
@@ -13,7 +13,8 @@ import {
   IStep,
   IThread,
   accessTokenState,
-  nestMessages
+  nestMessages,
+  useChatMessages
 } from '@chainlit/react-client';
 
 import SideView from 'components/atoms/element/sideView';
@@ -33,6 +34,7 @@ const Thread = ({ thread, error, isLoading }: Props) => {
   const [steps, setSteps] = useState<IStep[]>([]);
   const apiClient = useRecoilValue(apiClientState);
   const { t } = useTranslation();
+  const { threadId } = useChatMessages();
 
   useEffect(() => {
     if (!thread) return;
@@ -164,7 +166,12 @@ const Thread = ({ thread, error, isLoading }: Props) => {
             id="thread-info"
             severity="info"
             action={
-              <Button component={Link} color="inherit" size="small" to="/">
+              <Button
+                component={Link}
+                color="inherit"
+                size="small"
+                to={`/thread/${threadId}`}
+              >
                 <Translator path="components.organisms.threadHistory.Thread.backToChat" />
               </Button>
             }

--- a/frontend/src/components/organisms/threadHistory/Thread.tsx
+++ b/frontend/src/components/organisms/threadHistory/Thread.tsx
@@ -170,7 +170,7 @@ const Thread = ({ thread, error, isLoading }: Props) => {
                 component={Link}
                 color="inherit"
                 size="small"
-                to={`/thread/${threadId}`}
+                to={threadId ? `/thread/${threadId}` : '/'}
               >
                 <Translator path="components.organisms.threadHistory.Thread.backToChat" />
               </Button>

--- a/frontend/src/components/organisms/threadHistory/sidebar/ThreadList.tsx
+++ b/frontend/src/components/organisms/threadHistory/sidebar/ThreadList.tsx
@@ -17,6 +17,7 @@ import Typography from '@mui/material/Typography';
 import {
   ThreadHistory,
   useChatInteract,
+  useChatMessages,
   useChatSession
 } from '@chainlit/react-client';
 
@@ -41,6 +42,7 @@ const ThreadList = ({
 }: Props) => {
   const { idToResume } = useChatSession();
   const { clear } = useChatInteract();
+  const { threadId: currentThreadId } = useChatMessages();
   const navigate = useNavigate();
   if (isFetching || (!threadHistory?.timeGroupedThreads && isLoadingMore)) {
     return (
@@ -89,7 +91,7 @@ const ThreadList = ({
   }
 
   const handleDeleteThread = (threadId: string) => {
-    if (threadId === idToResume) {
+    if (threadId === idToResume || threadId === currentThreadId) {
       clear();
     }
     if (threadId === threadHistory.currentThreadId) {

--- a/frontend/src/pages/ResumeButton.tsx
+++ b/frontend/src/pages/ResumeButton.tsx
@@ -28,7 +28,9 @@ export default function ResumeButton({ threadId }: Props) {
     clear();
     setIdToResume(threadId!);
     toast.success('Chat resumed!');
-    navigate('/');
+    if (!pSettings?.dataPersistence) {
+      navigate('/');
+    }
   };
 
   return (

--- a/frontend/src/pages/Thread.tsx
+++ b/frontend/src/pages/Thread.tsx
@@ -4,8 +4,14 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { Box } from '@mui/material';
 
-import { IThread, threadHistoryState, useApi } from '@chainlit/react-client';
+import {
+  IThread,
+  threadHistoryState,
+  useApi,
+  useChatMessages
+} from '@chainlit/react-client';
 
+import Chat from 'components/organisms/chat';
 import { Thread } from 'components/organisms/threadHistory/Thread';
 
 import { apiClientState } from 'state/apiClient';
@@ -28,6 +34,10 @@ export default function ThreadPage() {
 
   const [threadHistory, setThreadHistory] = useRecoilState(threadHistoryState);
 
+  const { threadId } = useChatMessages();
+
+  const isCurrentThread = threadId === id;
+
   useEffect(() => {
     if (threadHistory?.currentThreadId !== id) {
       setThreadHistory((prev) => {
@@ -38,19 +48,24 @@ export default function ThreadPage() {
 
   return (
     <Page>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          flexGrow: 1,
-          gap: 2
-        }}
-      >
-        <Box sx={{ width: '100%', flexGrow: 1, overflow: 'auto' }}>
-          <Thread thread={data} error={error} isLoading={isLoading} />
-        </Box>
-        <ResumeButton threadId={id} />
-      </Box>
+      <>
+        {isCurrentThread && <Chat />}
+        {!isCurrentThread && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              flexGrow: 1,
+              gap: 2
+            }}
+          >
+            <Box sx={{ width: '100%', flexGrow: 1, overflow: 'auto' }}>
+              <Thread thread={data} error={error} isLoading={isLoading} />
+            </Box>
+            <ResumeButton threadId={id} />
+          </Box>
+        )}
+      </>
     </Page>
   );
 }

--- a/libs/react-client/src/state.ts
+++ b/libs/react-client/src/state.ts
@@ -170,3 +170,8 @@ export const sideViewState = atom<IMessageElement | undefined>({
   key: 'SideView',
   default: undefined
 });
+
+export const currentThreadIdState = atom<string | undefined>({
+  key: 'CurrentThreadId',
+  default: undefined
+});

--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -7,6 +7,7 @@ import {
   avatarState,
   chatSettingsInputsState,
   chatSettingsValueState,
+  currentThreadIdState,
   elementState,
   firstUserInteraction,
   loadingState,
@@ -43,6 +44,7 @@ const useChatInteract = () => {
   const setTokenCount = useSetRecoilState(tokenCountState);
   const setIdToResume = useSetRecoilState(threadIdToResumeState);
   const setSideView = useSetRecoilState(sideViewState);
+  const setCurrentThreadId = useSetRecoilState(currentThreadIdState);
 
   const clear = useCallback(() => {
     session?.socket.emit('clear_session');
@@ -59,6 +61,7 @@ const useChatInteract = () => {
     resetChatSettings();
     resetChatSettingsValue();
     setSideView(undefined);
+    setCurrentThreadId(undefined);
   }, [session]);
 
   const sendMessage = useCallback(

--- a/libs/react-client/src/useChatMessages.ts
+++ b/libs/react-client/src/useChatMessages.ts
@@ -6,7 +6,9 @@ const useChatMessages = () => {
   const messages = useRecoilValue(messagesState);
   const firstInteraction = useRecoilValue(firstUserInteraction);
 
-  const threadId = messages.find((message) => message.threadId)?.threadId;
+  const threadId = firstInteraction
+    ? messages.find((message) => message.threadId)?.threadId
+    : undefined;
 
   return {
     threadId,

--- a/libs/react-client/src/useChatMessages.ts
+++ b/libs/react-client/src/useChatMessages.ts
@@ -1,14 +1,15 @@
 import { useRecoilValue } from 'recoil';
 
-import { firstUserInteraction, messagesState } from './state';
+import {
+  currentThreadIdState,
+  firstUserInteraction,
+  messagesState
+} from './state';
 
 const useChatMessages = () => {
   const messages = useRecoilValue(messagesState);
   const firstInteraction = useRecoilValue(firstUserInteraction);
-
-  const threadId = firstInteraction
-    ? messages.find((message) => message.threadId)?.threadId
-    : undefined;
+  const threadId = useRecoilValue(currentThreadIdState);
 
   return {
     threadId,

--- a/libs/react-client/src/useChatMessages.ts
+++ b/libs/react-client/src/useChatMessages.ts
@@ -6,7 +6,10 @@ const useChatMessages = () => {
   const messages = useRecoilValue(messagesState);
   const firstInteraction = useRecoilValue(firstUserInteraction);
 
+  const threadId = messages.find((message) => message.threadId)?.threadId;
+
   return {
+    threadId,
     messages,
     firstInteraction
   };

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -15,6 +15,7 @@ import {
   chatProfileState,
   chatSettingsInputsState,
   chatSettingsValueState,
+  currentThreadIdState,
   elementState,
   firstUserInteraction,
   loadingState,
@@ -64,6 +65,7 @@ const useChatSession = () => {
   const setTokenCount = useSetRecoilState(tokenCountState);
   const [chatProfile, setChatProfile] = useRecoilState(chatProfileState);
   const idToResume = useRecoilValue(threadIdToResumeState);
+  const setCurrentThreadId = useSetRecoilState(currentThreadIdState);
 
   const _connect = useCallback(
     ({
@@ -147,9 +149,13 @@ const useChatSession = () => {
         setMessages((oldMessages) => addMessage(oldMessages, message));
       });
 
-      socket.on('first_interaction', (interaction: string) => {
-        setFirstUserInteraction(interaction);
-      });
+      socket.on(
+        'first_interaction',
+        (event: { interaction: string; thread_id: string }) => {
+          setFirstUserInteraction(event.interaction);
+          setCurrentThreadId(event.thread_id);
+        }
+      );
 
       socket.on('update_message', (message: IStep) => {
         setMessages((oldMessages) =>


### PR DESCRIPTION
- re-fetch the thread list on first interaction
- navigate to /thread/:id url when creating a new conversation
- update the /thread/:id page to allow for displaying the current chat
- add `threadId` to `useChatMessages` to get the current conversation thread id
- update "back to conversation" links
- clear current conversation when deleting the current thread


based on the work from @BrittleFoot in https://github.com/Chainlit/chainlit/pull/838