### PR TITLE
Allow None for timeout in AskSpec to support indefinite waits

### DIFF
--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -1,5 +1,17 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union, Generic, TypeVar, Protocol, Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 if TYPE_CHECKING:
     from chainlit.element import ElementDict
@@ -37,6 +49,7 @@ class ThreadFilter(BaseModel):
     userId: Optional[str] = None
     search: Optional[str] = None
 
+
 @dataclass
 class PageInfo:
     hasNextPage: bool
@@ -59,12 +72,15 @@ class PageInfo:
             hasNextPage=hasNextPage, startCursor=startCursor, endCursor=endCursor
         )
 
+
 T = TypeVar("T", covariant=True)
+
 
 class HasFromDict(Protocol[T]):
     @classmethod
     def from_dict(cls, obj_dict: Any) -> T:
         raise NotImplementedError()
+
 
 @dataclass
 class PaginatedResponse(Generic[T]):
@@ -90,6 +106,7 @@ class PaginatedResponse(Generic[T]):
 
         return cls(pageInfo=pageInfo, data=data)
 
+
 @dataclass
 class FileSpec(DataClassJsonMixin):
     accept: Union[List[str], Dict[str, List[str]]]
@@ -106,7 +123,7 @@ class ActionSpec(DataClassJsonMixin):
 class AskSpec(DataClassJsonMixin):
     """Specification for asking the user."""
 
-    timeout: int
+    timeout: Optional[int]
     type: Literal["text", "file", "action"]
 
 


### PR DESCRIPTION
## Overview

Updated the AskSpec data class to support `None` as a valid value for the `timeout` field, allowing developers to force a wait without a timeout constraint. Previously, passing `timeout = None` would trigger a Pydantic validation error, making the only solution to pass an extremely large integer to achieve a pseudo-infinite wait.

## Changes

- Adjusted the timeout field type from `int` to `Optional[int]` within the AskSpec data class.
  - This should allow developers to add indefinite waits when using `AskUserMessage`, `AskFileMessage`, and `AskUserAction` by passing `timeout = None`.
- The `types.py` file has several adjustments to it's spacing and import structure as a result of the pre-commit hook set up in your repository, the only thing I actually changed was one line.

## Rationale

When asking the user for a file, for example, before a model can answer question, it's possible to not want the operation to timeout ever. The user may leave their computer and move onto something else for hours, but the file input should still work. Setting the variable `timeout = None` is very intuitive and clearly shows the intention of the developer to not allow a timeout to occur.

## Testing

- I followed all steps in the contribution guidelines and all tests passed locally.
- I additionally tested that `AskUserMessage`, `AskFileMessage`, and `AskUserAction` worked with passing `timeout = None` with this change, and they all did as far as I could tell.