### PR TITLE
Allow for setting a `ChatProfile` default

### DIFF
--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -1,5 +1,17 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, TypedDict, Union, Generic, TypeVar, Protocol, Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 if TYPE_CHECKING:
     from chainlit.element import ElementDict
@@ -37,6 +49,7 @@ class ThreadFilter(BaseModel):
     userId: Optional[str] = None
     search: Optional[str] = None
 
+
 @dataclass
 class PageInfo:
     hasNextPage: bool
@@ -59,12 +72,15 @@ class PageInfo:
             hasNextPage=hasNextPage, startCursor=startCursor, endCursor=endCursor
         )
 
+
 T = TypeVar("T", covariant=True)
+
 
 class HasFromDict(Protocol[T]):
     @classmethod
     def from_dict(cls, obj_dict: Any) -> T:
         raise NotImplementedError()
+
 
 @dataclass
 class PaginatedResponse(Generic[T]):
@@ -89,6 +105,7 @@ class PaginatedResponse(Generic[T]):
         data = [the_class.from_dict(d) for d in paginated_response_dict.get("data", [])]
 
         return cls(pageInfo=pageInfo, data=data)
+
 
 @dataclass
 class FileSpec(DataClassJsonMixin):
@@ -196,6 +213,7 @@ class ChatProfile(DataClassJsonMixin):
     name: str
     markdown_description: str
     icon: Optional[str] = None
+    default: bool = False
 
 
 FeedbackStrategy = Literal["BINARY"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,8 +100,15 @@ function App() {
   }, [userEnv, accessToken, isAuthenticated, connect, chatProfileOk]);
 
   if (pSettingsLoaded && pSettings.chatProfiles.length && !chatProfile) {
-    // Autoselect the chat profile if there is only one
-    setChatProfile(pSettings.chatProfiles[0].name);
+    // Autoselect the first default chat profile
+    const defaultChatProfile = pSettings.chatProfiles.find(
+      (profile) => profile.default
+    );
+    if (defaultChatProfile) {
+      setChatProfile(defaultChatProfile.name);
+    } else {
+      setChatProfile(pSettings.chatProfiles[0].name);
+    }
   }
 
   return (

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -3,6 +3,7 @@ import { atom } from 'recoil';
 import { IStep } from '@chainlit/react-client';
 
 export interface ChatProfile {
+  default: boolean;
   icon: string;
   name: string;
   markdown_description: string;


### PR DESCRIPTION
This change allows for setting a `default` ChatProfile.

This can be used to preselect a user's last used ChatProfile when they start a new chat.


```python
@cl.set_chat_profiles
async def chat_profile(current_user: cl.User):
    last_used_profile = await user_cache.get(current_user.identifier, "last_used_profile")

    profiles = [
        cl.ChatProfile(
            name="GPT-3.5",
            markdown_description="The underlying LLM model is **GPT-3.5**.",
            icon="https://picsum.photos/200",
        ),
        cl.ChatProfile(
            name="GPT-4",
            markdown_description="The underlying LLM model is **GPT-4**.",
            icon="https://picsum.photos/250",
        ),
    ]

    # set the default profile based on the last used profile, matching the `name` attribute
    default_profile = next((p for p in profiles if p.name == last_used_profile), None)

    if default_profile:
        default_profile.default = True

    # return the list of profiles
    return profiles