### PR TITLE
use the label for menu item

### DIFF
--- a/frontend/src/components/atoms/inputs/selects/MenuItem.tsx
+++ b/frontend/src/components/atoms/inputs/selects/MenuItem.tsx
@@ -43,7 +43,7 @@ const MenuItem = ({
   >
     <Stack direction="row" alignItems="center" spacing={1}>
       {item.icon ? item.icon : null}
-      <span>{item.value}</span>
+      <span>{item?.label || item.value}</span>
     </Stack>
     {item.notificationCount ? (
       <NotificationCount count={item.notificationCount} />


### PR DESCRIPTION
This ensures menu items display the item label rather than value.

**ex:**
```python
@cl.on_chat_start
async def on_chat_start():
    await cl.ChatSettings(
        [
            Select(
                id="Model",
                label="OpenAI - Model",
                items={
                    "GPT-3.5-Turbo": "gpt-3.5-turbo",
                    "GPT-4": "gpt-4-turbo"
                },
                initial_value="gpt-4-turbo",
            )
        ]
    ).send()
```

**bug:** the value is displayed instead of the label for each menu option
<img width="570" alt="image" src="https://github.com/Chainlit/chainlit/assets/590874/6dda12fd-d364-4107-8325-afd1cfe6e938">

**fix:**
<img width="588" alt="Screenshot 2024-04-29 at 8 39 00 AM" src="https://github.com/Chainlit/chainlit/assets/590874/644569e6-120c-4ee2-bd2c-864cf8d7af20">