### PR TITLE
do not prevent thread revalidation

### DIFF
--- a/frontend/src/pages/Thread.tsx
+++ b/frontend/src/pages/Thread.tsx
@@ -25,11 +25,7 @@ export default function ThreadPage() {
 
   const { data, error, isLoading } = useApi<IThread>(
     apiClient,
-    id ? `/project/thread/${id}` : null,
-    {
-      revalidateOnFocus: false,
-      revalidateIfStale: false
-    }
+    id ? `/project/thread/${id}` : null
   );
 
   const [threadHistory, setThreadHistory] = useRecoilState(threadHistoryState);

--- a/frontend/src/pages/Thread.tsx
+++ b/frontend/src/pages/Thread.tsx
@@ -25,7 +25,10 @@ export default function ThreadPage() {
 
   const { data, error, isLoading } = useApi<IThread>(
     apiClient,
-    id ? `/project/thread/${id}` : null
+    id ? `/project/thread/${id}` : null,
+    {
+      revalidateOnFocus: false
+    }
   );
 
   const [threadHistory, setThreadHistory] = useRecoilState(threadHistoryState);


### PR DESCRIPTION
Ensures returning to a previously created chat will display all the messages.