### PR TITLE
multiline text input

### DIFF
--- a/backend/chainlit/input_widget.py
+++ b/backend/chainlit/input_widget.py
@@ -127,6 +127,7 @@ class TextInput(InputWidget):
     type: InputWidgetType = "textinput"
     initial: Optional[str] = None
     placeholder: Optional[str] = None
+    multiline: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -137,6 +138,7 @@ class TextInput(InputWidget):
             "placeholder": self.placeholder,
             "tooltip": self.tooltip,
             "description": self.description,
+            "multiline": self.multiline,
         }
 
 


### PR DESCRIPTION
Allow for multiline `TextInput`

```python
@cl.on_chat_start
async def on_chat_start():
    await cl.ChatSettings(
        [
            TextInput(
                id="AgentName",
                label="Agent Name",
                initial="AI",
                multiline=True
            )
        ]
    ).send()
```