### PR TITLE
Fix Haystack tool step text

### DIFF
--- a/backend/chainlit/haystack/callbacks.py
+++ b/backend/chainlit/haystack/callbacks.py
@@ -124,7 +124,7 @@ class HaystackAgentCallbackHandler:
 
     def on_tool_start(self, tool_input: str, tool: Tool, **kwargs: Any) -> None:
         # Tool started, create step
-        parent_id = self.stack.items[0].id if self.stack.items[0] else None
+        parent_id = self.stack.items[0].parent_id if self.stack.items[0] else None
         tool_step = Step(name=tool.name, type="tool", parent_id=parent_id)
         tool_step.input = tool_input
         tool_step.start = utc_now()
@@ -139,9 +139,9 @@ class HaystackAgentCallbackHandler:
     ) -> None:
         # Tool finished, send step with tool_result
         tool_step = self.stack.pop()
-        tool_step.output = tool_result
         tool_step.end = utc_now()
         run_sync(tool_step.update())
+        run_sync(tool_step.stream_token(tool_result))
 
     def on_tool_error(self, exception: Exception, tool: Tool, **kwargs: Any) -> None:
         # Tool error, send error message


### PR DESCRIPTION
Fixing a bug where the tool_result text is not displayed in the UI.
* replaced the tool_result update by calling stream_token
* replaced the id of the tool step with the parent id of the step above it, instead of the id itself.