### PR TITLE
Fix: Run code.on_chat_resume() before emitter.resume_thread()

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -177,8 +177,8 @@ async def connection_successful(sid):
                 "first_interaction",
                 {"interaction": "resume", "thread_id": thread.get("id")},
             )
-            await context.emitter.resume_thread(thread)
             await config.code.on_chat_resume(thread)
+            await context.emitter.resume_thread(thread)
             return
 
     if config.code.on_chat_start:


### PR DESCRIPTION
Execute the on_chat_resume decorator before the resume_thread emitter. This allows the `thread` in on_chat_resume to be updated on load.

Use case: When using Elements with time-limited signed links, regenerate the signed links and update the Elements when resuming a chat.