### PR TITLE
Add default dark mode to config.toml

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -135,6 +135,7 @@ hide_cot = false
 # Override default MUI light theme. (Check theme.ts)
 [UI.theme]
     #font_family = "Inter, sans-serif"
+    #default_mode = "dark" #"light", "dark", "system"
 [UI.theme.light]
     #background = "#FAFAFA"
     #paper = "#FFFFFF"
@@ -194,6 +195,7 @@ class Palette(DataClassJsonMixin):
 @dataclass()
 class Theme(DataClassJsonMixin):
     font_family: Optional[str] = None
+    default_mode: Optional[Literal["light", "dark", "system"]] = "system"
     light: Optional[Palette] = None
     dark: Optional[Palette] = None
 

--- a/frontend/src/AppWrapper.tsx
+++ b/frontend/src/AppWrapper.tsx
@@ -54,7 +54,8 @@ export default function AppWrapper() {
       ...prev,
       defaultCollapseContent: data.ui.default_collapse_content ?? true,
       expandAll: !!data.ui.default_expand_messages,
-      hideCot: !!data.ui.hide_cot
+      hideCot: !!data.ui.hide_cot,
+      defaultMode: data.theme.default_mode ?? "system"
     }));
   }, [data, setProjectSettings, setAppSettings]);
 

--- a/frontend/src/state/settings.ts
+++ b/frontend/src/state/settings.ts
@@ -1,8 +1,8 @@
 import { atom } from 'recoil';
 
-type ThemeVariant = 'dark' | 'light';
+type ThemeVariant = 'dark' | 'light' | 'system';
 
-const defaultTheme = 'light';
+const defaultTheme = window.theme.default_mode as ThemeVariant;
 
 const preferredTheme = localStorage.getItem(
   'themeVariant'


### PR DESCRIPTION
Adds option to `config.toml` to set default theme:
- Options: "dark", "light", "system"
- Default: "system"

[Relevant Discord Thread](https://discord.com/channels/1088038867602526210/1224329894666702880)