### PR TITLE
Add font colors to config.toml 

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -143,6 +143,9 @@ hide_cot = false
         #main = "#F80061"
         #dark = "#980039"
         #light = "#FFE7EB"
+    [UI.theme.light.text]
+        #primary = "#212121"
+        #secondary = "#616161"
 
 # Override default MUI dark theme. (Check theme.ts)
 [UI.theme.dark]
@@ -153,7 +156,9 @@ hide_cot = false
         #main = "#F80061"
         #dark = "#980039"
         #light = "#FFE7EB"
-
+    [UI.theme.dark.text]
+        #primary = "#EEEEEE"
+        #secondary = "#BDBDBD"
 
 [meta]
 generated_by = "{__version__}"
@@ -183,12 +188,17 @@ class PaletteOptions(DataClassJsonMixin):
     light: Optional[str] = ""
     dark: Optional[str] = ""
 
+@dataclass()
+class TextOptions(DataClassJsonMixin):
+    primary: Optional[str] = ""
+    secondary: Optional[str] = ""
 
 @dataclass()
 class Palette(DataClassJsonMixin):
     primary: Optional[PaletteOptions] = None
     background: Optional[str] = ""
     paper: Optional[str] = ""
+    text: Optional[TextOptions] = None
 
 
 @dataclass()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,10 +29,16 @@ type Primary = {
   main?: string;
 };
 
+type Text = {
+  primary?: string;
+  secondary?: string;
+};
+
 type ThemOverride = {
   primary?: Primary;
   background?: string;
   paper?: string;
+  text?: Text;
 };
 
 declare global {
@@ -61,6 +67,12 @@ export function overrideTheme(theme: Theme) {
   }
   if (variantOverride?.primary?.light) {
     theme.palette.primary.light = variantOverride.primary.light;
+  }
+  if (variantOverride?.text?.primary) {
+    theme.palette.text.primary = variantOverride.text.primary;
+  }
+  if (variantOverride?.text?.secondary) {
+    theme.palette.text.secondary = variantOverride.text.secondary;
   }
 
   return theme;


### PR DESCRIPTION
Enable option to change primary/secondary font colors for light/dark mode. Useful when using non-standard background colors.

@tpatel @willydouhard Need your guidance here as I'm not a frontend expert and permission issues prevent me from fully testing.

```toml
    [UI.theme.light.text]
        #primary = "#212121"
        #secondary = "#616161"
    [UI.theme.dark.text]
        #primary = "#EEEEEE"
        #secondary = "#BDBDBD"
```

Resolves #673 

Example before this PR aims to solve. when setting light mode with the below options:
![image](https://github.com/Chainlit/chainlit/assets/35790761/25d69309-69a3-452e-a0dd-1b04565f3527)
Settings:
```toml
[UI.theme.light]
    background = "#17234E"
    paper = "#1F397F"

    [UI.theme.light.primary]
        main = "#f5f5f5"
        dark = "#00CED1"
        light = "#D3D3D3"
```
