### PR TITLE
Fix: defined default var for langchain cache path to enable custom path (issue 987)

### DIFF
--- a/backend/chainlit/cache.py
+++ b/backend/chainlit/cache.py
@@ -19,7 +19,7 @@ def init_lc_cache():
         if config.project.lc_cache_path is not None:
             set_llm_cache(SQLiteCache(database_path=config.project.lc_cache_path))
 
-            if not os.path.exists(config.project.lc_cache_path):
+            if os.path.exists(config.project.lc_cache_path):
                 logger.info(
                     f"LangChain cache created at: {config.project.lc_cache_path}"
                 )

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -54,6 +54,9 @@ session_timeout = 3600
 # Enable third parties caching (e.g LangChain cache)
 cache = false
 
+# Set langchain cache path (default is .langchain.db inside config dir)
+# lc_cache_path = './.my-cache-path.db'
+
 # Authorized origins
 allow_origins = ["*"]
 
@@ -268,9 +271,9 @@ class CodeSettings:
 
     author_rename: Optional[Callable[[str], str]] = None
     on_settings_update: Optional[Callable[[Dict[str, Any]], Any]] = None
-    set_chat_profiles: Optional[Callable[[Optional["User"]], List["ChatProfile"]]] = (
-        None
-    )
+    set_chat_profiles: Optional[
+        Callable[[Optional["User"]], List["ChatProfile"]]
+    ] = None
 
 
 @dataclass()
@@ -280,7 +283,8 @@ class ProjectSettings(DataClassJsonMixin):
     # List of environment variables to be provided by each user to use the app. If empty, no environment variables will be asked to the user.
     user_env: Optional[List[str]] = None
     # Path to the local langchain cache database
-    lc_cache_path: Optional[str] = None
+    # default to "{config_dir}/.langchain.db"
+    lc_cache_path: Optional[str] = os.path.join(config_dir, ".langchain.db")
     # Path to the local chat db
     # Duration (in seconds) during which the session is saved when the connection is lost
     session_timeout: int = 3600
@@ -420,10 +424,7 @@ def load_settings():
                 "Your config file is outdated. Please delete it and restart the app to regenerate it."
             )
 
-        lc_cache_path = os.path.join(config_dir, ".langchain.db")
-
         project_settings = ProjectSettings(
-            lc_cache_path=lc_cache_path,
             **project_config,
         )
 


### PR DESCRIPTION
When defining `lc_cache_path`  and enabling cache in config:
``` toml
# Enable third parties caching (e.g LangChain cache)
cache = true
lc_cache_path = './.custom-cache-path.db'
```

TypeError is thrown:
``` bash
TypeError: chainlit.config.ProjectSettings() got multiple values for keyword argument 'lc_cache_path'
```