### PR TITLE
Added threadId to Element

### DIFF
--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -94,7 +94,7 @@ class BaseDataLayer:
         pass
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
+    async def delete_element(self, element_id: str, thread_id: Optional[str] = None):
         pass
 
     @queue_until_user_message()
@@ -340,7 +340,7 @@ class ChainlitDataLayer(BaseDataLayer):
         return self.attachment_to_element_dict(attachment)
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
+    async def delete_element(self, element_id: str, thread_id: Optional[str] = None):
         await self.client.api.delete_attachment(id=element_id)
 
     @queue_until_user_message()

--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -94,7 +94,7 @@ class BaseDataLayer:
         pass
 
     @queue_until_user_message()
-    async def delete_element(self, thread_id: str, element_id: str):
+    async def delete_element(self, element_id: str):
         pass
 
     @queue_until_user_message()
@@ -340,7 +340,7 @@ class ChainlitDataLayer(BaseDataLayer):
         return self.attachment_to_element_dict(attachment)
 
     @queue_until_user_message()
-    async def delete_element(self, thread_id: str, element_id: str):
+    async def delete_element(self, element_id: str):
         await self.client.api.delete_attachment(id=element_id)
 
     @queue_until_user_message()

--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -94,7 +94,7 @@ class BaseDataLayer:
         pass
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
+    async def delete_element(self, thread_id: str, element_id: str):
         pass
 
     @queue_until_user_message()
@@ -340,7 +340,7 @@ class ChainlitDataLayer(BaseDataLayer):
         return self.attachment_to_element_dict(attachment)
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
+    async def delete_element(self, thread_id: str, element_id: str):
         await self.client.api.delete_attachment(id=element_id)
 
     @queue_until_user_message()

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -57,7 +57,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self.async_session = sessionmaker(bind=self.engine, expire_on_commit=False, class_=AsyncSession)  # type: ignore
         if storage_provider:
             self.storage_provider: Optional[BaseStorageClient] = storage_provider
-            if self.show_logger: logger.info("SQLAlchemyDataLayer storage client initialized")
+            if self.show_logger:
+                logger.info("SQLAlchemyDataLayer storage client initialized")
         else:
             self.storage_provider = None
             logger.warn(
@@ -104,7 +105,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### User ######
     async def get_user(self, identifier: str) -> Optional[PersistedUser]:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
         query = "SELECT * FROM users WHERE identifier = :identifier"
         parameters = {"identifier": identifier}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -114,20 +116,23 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return None
 
     async def create_user(self, user: User) -> Optional[PersistedUser]:
-        if self.show_logger: logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
         existing_user: Optional["PersistedUser"] = await self.get_user(user.identifier)
         user_dict: Dict[str, Any] = {
             "identifier": str(user.identifier),
             "metadata": json.dumps(user.metadata) or {},
         }
         if not existing_user:  # create the user
-            if self.show_logger: logger.info("SQLAlchemy: create_user, creating the user")
+            if self.show_logger:
+                logger.info("SQLAlchemy: create_user, creating the user")
             user_dict["id"] = str(uuid.uuid4())
             user_dict["createdAt"] = await self.get_current_timestamp()
             query = """INSERT INTO users ("id", "identifier", "createdAt", "metadata") VALUES (:id, :identifier, :createdAt, :metadata)"""
             await self.execute_sql(query=query, parameters=user_dict)
         else:  # update the user
-            if self.show_logger: logger.info("SQLAlchemy: update user metadata")
+            if self.show_logger:
+                logger.info("SQLAlchemy: update user metadata")
             query = """UPDATE users SET "metadata" = :metadata WHERE "identifier" = :identifier"""
             await self.execute_sql(
                 query=query, parameters=user_dict
@@ -136,7 +141,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Threads ######
     async def get_thread_author(self, thread_id: str) -> str:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
         query = """SELECT "userIdentifier" FROM threads WHERE "id" = :id"""
         parameters = {"id": thread_id}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -147,7 +153,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         raise ValueError(f"Author not found for thread_id {thread_id}")
 
     async def get_thread(self, thread_id: str) -> Optional[ThreadDict]:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
         user_threads: Optional[List[ThreadDict]] = await self.get_all_user_threads(
             thread_id=thread_id
         )
@@ -164,7 +171,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
     ):
-        if self.show_logger: logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
         if context.session.user is not None:
             user_identifier = context.session.user.identifier
         else:
@@ -201,7 +209,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=parameters)
 
     async def delete_thread(self, thread_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
         # Delete feedbacks/elements/steps/thread
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" IN (SELECT "id" FROM steps WHERE "threadId" = :id)"""
         elements_query = """DELETE FROM elements WHERE "threadId" = :id"""
@@ -216,9 +225,10 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def list_threads(
         self, pagination: Pagination, filters: ThreadFilter
     ) -> PaginatedResponse:
-        if self.show_logger: logger.info(
-            f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
-        )
+        if self.show_logger:
+            logger.info(
+                f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
+            )
         if not filters.userId:
             raise ValueError("userId is required")
         all_user_threads: List[ThreadDict] = (
@@ -276,7 +286,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Steps ######
     @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
-        if self.show_logger: logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         step_dict["showInput"] = (
@@ -306,12 +317,14 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     @queue_until_user_message()
     async def update_step(self, step_dict: "StepDict"):
-        if self.show_logger: logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
         await self.create_step(step_dict)
 
     @queue_until_user_message()
     async def delete_step(self, step_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
         # Delete feedbacks/elements/steps
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" = :id"""
         elements_query = """DELETE FROM elements WHERE "forId" = :id"""
@@ -323,7 +336,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Feedback ######
     async def upsert_feedback(self, feedback: Feedback) -> str:
-        if self.show_logger: logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
         feedback.id = feedback.id or str(uuid.uuid4())
         feedback_dict = asdict(feedback)
         parameters = {
@@ -345,7 +359,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return feedback.id
 
     async def delete_feedback(self, feedback_id: str) -> bool:
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
         query = """DELETE FROM feedbacks WHERE "id" = :feedback_id"""
         parameters = {"feedback_id": feedback_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -354,7 +369,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Elements ######
     @queue_until_user_message()
     async def create_element(self, element: "Element"):
-        if self.show_logger: logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         if isinstance(element, Avatar):  # Skip creating elements of type avatar
@@ -416,8 +432,9 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=element_dict_cleaned)
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
+    async def delete_element(self, element_id: str, thread_id: Optional[str] = None):
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
         query = """DELETE FROM elements WHERE "id" = :id"""
         parameters = {"id": element_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -429,7 +446,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self, user_id: Optional[str] = None, thread_id: Optional[str] = None
     ) -> Optional[List[ThreadDict]]:
         """Fetch all user threads up to self.user_thread_limit, or one thread by id if thread_id is provided."""
-        if self.show_logger: logger.info(f"SQLAlchemy: get_all_user_threads")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_all_user_threads")
         user_threads_query = """
             SELECT
                 "id" AS thread_id,
@@ -563,7 +581,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         tags=step_feedback.get("step_tags"),
                         input=(
                             step_feedback.get("step_input", "")
-                            if step_feedback["step_showinput"] == "true" 
+                            if step_feedback["step_showinput"] == "true"
                             else None
                         ),
                         output=step_feedback.get("step_output", ""),

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -57,7 +57,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self.async_session = sessionmaker(bind=self.engine, expire_on_commit=False, class_=AsyncSession)  # type: ignore
         if storage_provider:
             self.storage_provider: Optional[BaseStorageClient] = storage_provider
-            if self.show_logger: logger.info("SQLAlchemyDataLayer storage client initialized")
+            if self.show_logger:
+                logger.info("SQLAlchemyDataLayer storage client initialized")
         else:
             self.storage_provider = None
             logger.warn(
@@ -104,7 +105,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### User ######
     async def get_user(self, identifier: str) -> Optional[PersistedUser]:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
         query = "SELECT * FROM users WHERE identifier = :identifier"
         parameters = {"identifier": identifier}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -114,20 +116,23 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return None
 
     async def create_user(self, user: User) -> Optional[PersistedUser]:
-        if self.show_logger: logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
         existing_user: Optional["PersistedUser"] = await self.get_user(user.identifier)
         user_dict: Dict[str, Any] = {
             "identifier": str(user.identifier),
             "metadata": json.dumps(user.metadata) or {},
         }
         if not existing_user:  # create the user
-            if self.show_logger: logger.info("SQLAlchemy: create_user, creating the user")
+            if self.show_logger:
+                logger.info("SQLAlchemy: create_user, creating the user")
             user_dict["id"] = str(uuid.uuid4())
             user_dict["createdAt"] = await self.get_current_timestamp()
             query = """INSERT INTO users ("id", "identifier", "createdAt", "metadata") VALUES (:id, :identifier, :createdAt, :metadata)"""
             await self.execute_sql(query=query, parameters=user_dict)
         else:  # update the user
-            if self.show_logger: logger.info("SQLAlchemy: update user metadata")
+            if self.show_logger:
+                logger.info("SQLAlchemy: update user metadata")
             query = """UPDATE users SET "metadata" = :metadata WHERE "identifier" = :identifier"""
             await self.execute_sql(
                 query=query, parameters=user_dict
@@ -136,7 +141,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Threads ######
     async def get_thread_author(self, thread_id: str) -> str:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
         query = """SELECT "userIdentifier" FROM threads WHERE "id" = :id"""
         parameters = {"id": thread_id}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -147,7 +153,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         raise ValueError(f"Author not found for thread_id {thread_id}")
 
     async def get_thread(self, thread_id: str) -> Optional[ThreadDict]:
-        if self.show_logger: logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
         user_threads: Optional[List[ThreadDict]] = await self.get_all_user_threads(
             thread_id=thread_id
         )
@@ -164,7 +171,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
     ):
-        if self.show_logger: logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
         if context.session.user is not None:
             user_identifier = context.session.user.identifier
         else:
@@ -201,7 +209,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=parameters)
 
     async def delete_thread(self, thread_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
         # Delete feedbacks/elements/steps/thread
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" IN (SELECT "id" FROM steps WHERE "threadId" = :id)"""
         elements_query = """DELETE FROM elements WHERE "threadId" = :id"""
@@ -216,9 +225,10 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def list_threads(
         self, pagination: Pagination, filters: ThreadFilter
     ) -> PaginatedResponse:
-        if self.show_logger: logger.info(
-            f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
-        )
+        if self.show_logger:
+            logger.info(
+                f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
+            )
         if not filters.userId:
             raise ValueError("userId is required")
         all_user_threads: List[ThreadDict] = (
@@ -276,7 +286,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Steps ######
     @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
-        if self.show_logger: logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         step_dict["showInput"] = (
@@ -306,12 +317,14 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     @queue_until_user_message()
     async def update_step(self, step_dict: "StepDict"):
-        if self.show_logger: logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
         await self.create_step(step_dict)
 
     @queue_until_user_message()
     async def delete_step(self, step_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
         # Delete feedbacks/elements/steps
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" = :id"""
         elements_query = """DELETE FROM elements WHERE "forId" = :id"""
@@ -323,7 +336,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Feedback ######
     async def upsert_feedback(self, feedback: Feedback) -> str:
-        if self.show_logger: logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
         feedback.id = feedback.id or str(uuid.uuid4())
         feedback_dict = asdict(feedback)
         parameters = {
@@ -345,7 +359,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return feedback.id
 
     async def delete_feedback(self, feedback_id: str) -> bool:
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
         query = """DELETE FROM feedbacks WHERE "id" = :feedback_id"""
         parameters = {"feedback_id": feedback_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -354,7 +369,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Elements ######
     @queue_until_user_message()
     async def create_element(self, element: "Element"):
-        if self.show_logger: logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         if isinstance(element, Avatar):  # Skip creating elements of type avatar
@@ -416,8 +432,9 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=element_dict_cleaned)
 
     @queue_until_user_message()
-    async def delete_element(self, element_id: str):
-        if self.show_logger: logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
+    async def delete_element(self, thread_id: str, element_id: str):
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
         query = """DELETE FROM elements WHERE "id" = :id"""
         parameters = {"id": element_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -429,7 +446,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self, user_id: Optional[str] = None, thread_id: Optional[str] = None
     ) -> Optional[List[ThreadDict]]:
         """Fetch all user threads up to self.user_thread_limit, or one thread by id if thread_id is provided."""
-        if self.show_logger: logger.info(f"SQLAlchemy: get_all_user_threads")
+        if self.show_logger:
+            logger.info(f"SQLAlchemy: get_all_user_threads")
         user_threads_query = """
             SELECT
                 "id" AS thread_id,
@@ -563,7 +581,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         tags=step_feedback.get("step_tags"),
                         input=(
                             step_feedback.get("step_input", "")
-                            if step_feedback["step_showinput"] == "true" 
+                            if step_feedback["step_showinput"] == "true"
                             else None
                         ),
                         output=step_feedback.get("step_output", ""),

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -57,8 +57,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self.async_session = sessionmaker(bind=self.engine, expire_on_commit=False, class_=AsyncSession)  # type: ignore
         if storage_provider:
             self.storage_provider: Optional[BaseStorageClient] = storage_provider
-            if self.show_logger:
-                logger.info("SQLAlchemyDataLayer storage client initialized")
+            if self.show_logger: logger.info("SQLAlchemyDataLayer storage client initialized")
         else:
             self.storage_provider = None
             logger.warn(
@@ -105,8 +104,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### User ######
     async def get_user(self, identifier: str) -> Optional[PersistedUser]:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
+        if self.show_logger: logger.info(f"SQLAlchemy: get_user, identifier={identifier}")
         query = "SELECT * FROM users WHERE identifier = :identifier"
         parameters = {"identifier": identifier}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -116,23 +114,20 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return None
 
     async def create_user(self, user: User) -> Optional[PersistedUser]:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
+        if self.show_logger: logger.info(f"SQLAlchemy: create_user, user_identifier={user.identifier}")
         existing_user: Optional["PersistedUser"] = await self.get_user(user.identifier)
         user_dict: Dict[str, Any] = {
             "identifier": str(user.identifier),
             "metadata": json.dumps(user.metadata) or {},
         }
         if not existing_user:  # create the user
-            if self.show_logger:
-                logger.info("SQLAlchemy: create_user, creating the user")
+            if self.show_logger: logger.info("SQLAlchemy: create_user, creating the user")
             user_dict["id"] = str(uuid.uuid4())
             user_dict["createdAt"] = await self.get_current_timestamp()
             query = """INSERT INTO users ("id", "identifier", "createdAt", "metadata") VALUES (:id, :identifier, :createdAt, :metadata)"""
             await self.execute_sql(query=query, parameters=user_dict)
         else:  # update the user
-            if self.show_logger:
-                logger.info("SQLAlchemy: update user metadata")
+            if self.show_logger: logger.info("SQLAlchemy: update user metadata")
             query = """UPDATE users SET "metadata" = :metadata WHERE "identifier" = :identifier"""
             await self.execute_sql(
                 query=query, parameters=user_dict
@@ -141,8 +136,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Threads ######
     async def get_thread_author(self, thread_id: str) -> str:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: get_thread_author, thread_id={thread_id}")
         query = """SELECT "userIdentifier" FROM threads WHERE "id" = :id"""
         parameters = {"id": thread_id}
         result = await self.execute_sql(query=query, parameters=parameters)
@@ -153,8 +147,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         raise ValueError(f"Author not found for thread_id {thread_id}")
 
     async def get_thread(self, thread_id: str) -> Optional[ThreadDict]:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: get_thread, thread_id={thread_id}")
         user_threads: Optional[List[ThreadDict]] = await self.get_all_user_threads(
             thread_id=thread_id
         )
@@ -171,8 +164,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
     ):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: update_thread, thread_id={thread_id}")
         if context.session.user is not None:
             user_identifier = context.session.user.identifier
         else:
@@ -209,8 +201,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=parameters)
 
     async def delete_thread(self, thread_id: str):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
         # Delete feedbacks/elements/steps/thread
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" IN (SELECT "id" FROM steps WHERE "threadId" = :id)"""
         elements_query = """DELETE FROM elements WHERE "threadId" = :id"""
@@ -225,10 +216,9 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def list_threads(
         self, pagination: Pagination, filters: ThreadFilter
     ) -> PaginatedResponse:
-        if self.show_logger:
-            logger.info(
-                f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
-            )
+        if self.show_logger: logger.info(
+            f"SQLAlchemy: list_threads, pagination={pagination}, filters={filters}"
+        )
         if not filters.userId:
             raise ValueError("userId is required")
         all_user_threads: List[ThreadDict] = (
@@ -286,8 +276,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Steps ######
     @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
+        if self.show_logger: logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         step_dict["showInput"] = (
@@ -317,14 +306,12 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     @queue_until_user_message()
     async def update_step(self, step_dict: "StepDict"):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
+        if self.show_logger: logger.info(f"SQLAlchemy: update_step, step_id={step_dict.get('id')}")
         await self.create_step(step_dict)
 
     @queue_until_user_message()
     async def delete_step(self, step_id: str):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: delete_step, step_id={step_id}")
         # Delete feedbacks/elements/steps
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" = :id"""
         elements_query = """DELETE FROM elements WHERE "forId" = :id"""
@@ -336,8 +323,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
     ###### Feedback ######
     async def upsert_feedback(self, feedback: Feedback) -> str:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: upsert_feedback, feedback_id={feedback.id}")
         feedback.id = feedback.id or str(uuid.uuid4())
         feedback_dict = asdict(feedback)
         parameters = {
@@ -359,8 +345,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         return feedback.id
 
     async def delete_feedback(self, feedback_id: str) -> bool:
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: delete_feedback, feedback_id={feedback_id}")
         query = """DELETE FROM feedbacks WHERE "id" = :feedback_id"""
         parameters = {"feedback_id": feedback_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -369,8 +354,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Elements ######
     @queue_until_user_message()
     async def create_element(self, element: "Element"):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
+        if self.show_logger: logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
         if not getattr(context.session.user, "id", None):
             raise ValueError("No authenticated user in context")
         if isinstance(element, Avatar):  # Skip creating elements of type avatar
@@ -432,9 +416,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         await self.execute_sql(query=query, parameters=element_dict_cleaned)
 
     @queue_until_user_message()
-    async def delete_element(self, thread_id: str, element_id: str):
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
+    async def delete_element(self, element_id: str):
+        if self.show_logger: logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
         query = """DELETE FROM elements WHERE "id" = :id"""
         parameters = {"id": element_id}
         await self.execute_sql(query=query, parameters=parameters)
@@ -446,8 +429,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         self, user_id: Optional[str] = None, thread_id: Optional[str] = None
     ) -> Optional[List[ThreadDict]]:
         """Fetch all user threads up to self.user_thread_limit, or one thread by id if thread_id is provided."""
-        if self.show_logger:
-            logger.info(f"SQLAlchemy: get_all_user_threads")
+        if self.show_logger: logger.info(f"SQLAlchemy: get_all_user_threads")
         user_threads_query = """
             SELECT
                 "id" AS thread_id,
@@ -581,7 +563,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         tags=step_feedback.get("step_tags"),
                         input=(
                             step_feedback.get("step_input", "")
-                            if step_feedback["step_showinput"] == "true"
+                            if step_feedback["step_showinput"] == "true" 
                             else None
                         ),
                         output=step_feedback.get("step_output", ""),

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -1,11 +1,11 @@
 import json
+import mimetypes
 import uuid
 from enum import Enum
 from io import BytesIO
 from typing import Any, ClassVar, List, Literal, Optional, TypedDict, TypeVar, Union
 
 import filetype
-import mimetypes
 from chainlit.context import context
 from chainlit.data import get_data_layer
 from chainlit.logger import logger
@@ -150,7 +150,7 @@ class Element:
         trace_event(f"remove {self.__class__.__name__}")
         data_layer = get_data_layer()
         if data_layer and self.persisted:
-            await data_layer.delete_element(self.id)
+            await data_layer.delete_element(self.id, self.thread_id)
         await context.emitter.emit("remove_element", {"id": self.id})
 
     async def send(self, for_id: str):
@@ -168,7 +168,7 @@ class Element:
             )
             if not self.mime and self.url:
                 self.mime = mimetypes.guess_type(self.url)[0]
-            
+
         await self._create()
 
         if not self.url and not self.chainlit_key:

--- a/cypress/e2e/data_layer/main.py
+++ b/cypress/e2e/data_layer/main.py
@@ -114,7 +114,7 @@ class TestDataLayer(cl_data.BaseDataLayer):
         return "admin"
 
     async def list_threads(
-        self, pagination: cl_data.Pagination, filter: cl_data.ThreadFilter
+        self, pagination: cl_data.Pagination, filters: cl_data.ThreadFilter
     ) -> cl_data.PaginatedResponse[cl_data.ThreadDict]:
         return cl_data.PaginatedResponse(
             data=[t for t in thread_history if t["id"] not in deleted_thread_ids],

--- a/cypress/e2e/data_layer/main.py
+++ b/cypress/e2e/data_layer/main.py
@@ -114,7 +114,7 @@ class TestDataLayer(cl_data.BaseDataLayer):
         return "admin"
 
     async def list_threads(
-        self, pagination: cl_data.Pagination, filters: cl_data.ThreadFilter
+        self, pagination: cl_data.Pagination, filter: cl_data.ThreadFilter
     ) -> cl_data.PaginatedResponse[cl_data.ThreadDict]:
         return cl_data.PaginatedResponse(
             data=[t for t in thread_history if t["id"] not in deleted_thread_ids],


### PR DESCRIPTION
Adding this as prep for a custom data layer. This change will allow more flexible custom data layers, especially document ones like Dynamo.

Currently you can get the threadId in create element:
```python
async def create_element(self, element: "Element"):
        thread_id = element.thread_id)
```

This change adds the thread_id param to delete element:
```python
async def delete_element(self, element_id: str, thread_id: Optional[str]):
```

All current data layers have been modified to accept the new param. The [Custom Data Layer API Docs](https://docs.chainlit.io/api-reference/data-persistence/custom-data-layer) will need to be updated. Should not be a breaking change but should be a mention in a migration guide.