### PR TITLE
fix: limit discord thread name

### DIFF
--- a/backend/chainlit/discord/app.py
+++ b/backend/chainlit/discord/app.py
@@ -315,8 +315,9 @@ async def on_message(message: discord.Message):
     elif isinstance(message.channel, discord.GroupChannel):
         thread_name = f"{message.channel.name}"
     elif isinstance(message.channel, discord.TextChannel):
+        # Discord limits thread names to 100 characters.
         channel = await message.channel.create_thread(
-            name=clean_content(message), message=message
+            name=clean_content(message)[:100], message=message
         )
         thread_name = f"{channel.name}"
     else:

--- a/backend/chainlit/discord/app.py
+++ b/backend/chainlit/discord/app.py
@@ -315,9 +315,11 @@ async def on_message(message: discord.Message):
     elif isinstance(message.channel, discord.GroupChannel):
         thread_name = f"{message.channel.name}"
     elif isinstance(message.channel, discord.TextChannel):
-        # Discord limits thread names to 100 characters.
+        # Discord limits thread names to 100 characters and does not create
+        # threads from empty messages.
+        discord_thread_name = clean_content(message)[:100] or "Untitled"
         channel = await message.channel.create_thread(
-            name=clean_content(message)[:100], message=message
+            name=discord_thread_name, message=message
         )
         thread_name = f"{channel.name}"
     else:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,20 +1,24 @@
 [tool.poetry]
 name = "chainlit"
 version = "1.1.202"
-keywords = ['LLM', 'Agents', 'gen ai', 'chat ui', 'chatbot ui', 'openai', 'copilot', 'langchain', 'conversational ai']
+keywords = [
+    'LLM',
+    'Agents',
+    'gen ai',
+    'chat ui',
+    'chatbot ui',
+    'openai',
+    'copilot',
+    'langchain',
+    'conversational ai',
+]
 description = "Build Conversational AI."
 authors = ["Chainlit"]
 license = "Apache-2.0 license"
 repository = "https://github.com/Chainlit/chainlit"
 readme = "README.md"
-exclude = [
-    "**/frontend/**/*",
-    "**/copilot/**/**/",
-]
-include = [
-    "**/frontend/dist/**/*",
-    "**/copilot/dist/**/*",
-]
+exclude = ["**/frontend/**/*", "**/copilot/**/**/"]
+include = ["**/frontend/dist/**/*", "**/copilot/dist/**/*"]
 
 [tool.poetry.scripts]
 # command_name = module_for_handler : function_for_handler
@@ -38,7 +42,7 @@ tomli = "^2.0.1"
 pydantic = ">=1,<3"
 python-dotenv = "^1.0.0"
 uptrace = "^1.22.0"
-watchfiles="^0.20.0"
+watchfiles = "^0.20.0"
 filetype = "^1.2.0"
 lazify = "^0.4.0"
 packaging = "^23.1"
@@ -56,6 +60,9 @@ transformers = "^4.30.1"
 matplotlib = "3.7.1"
 farm-haystack = "^1.18.0"
 plotly = "^5.18.0"
+slack_bolt = "^1.18.1"
+discord = "^2.3.2"
+
 
 [tool.poetry.group.mypy]
 optional = true
@@ -78,7 +85,7 @@ module = [
     "haystack.*",
     "langflow",
     "lazify",
-    "matplotlib.*",  # remove when 3.8.0 is out, it should export types
+    "matplotlib.*",                       # remove when 3.8.0 is out, it should export types
     "plotly.*",
     "nest_asyncio",
     "socketio.*",
@@ -86,7 +93,7 @@ module = [
     "syncer",
     "vertexai.language_models",
     "vertexai.preview.generative_models",
-    "google.cloud"
+    "google.cloud",
 ]
 ignore_missing_imports = true
 
@@ -99,12 +106,6 @@ SQLAlchemy = "^2.0.28"
 boto3 = "^1.34.73"
 azure-identity = "^1.14.1"
 azure-storage-file-datalake = "^12.14.0"
-
-[tool.poetry.group.slack.dependencies]
-slack_bolt = "^1.18.1"
-
-[tool.poetry.group.discord.dependencies]
-discord = "^2.3.2"
 
 
 [build-system]


### PR DESCRIPTION
Changes:
- set max thread name in Discord to 100
- if thread name is blank (trying to create a thread with only calling @Chainlit Help) -> we name it "Untitled"
- moved slack/discord poetry group deps to tests group

Slack relies either on thread timestamp to create a thread, so no need for a fix on that integration. 