### PR TITLE
Update sql_alchemy.py - bugfix for delete_step

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -328,7 +328,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         # Delete feedbacks/elements/steps
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" = :id"""
         elements_query = """DELETE FROM elements WHERE "forId" = :id"""
-        steps_query = """DELETE FROM steps WHERE "forId" = :id"""
+        steps_query = """DELETE FROM steps WHERE "id" = :id"""
         parameters = {"id": step_id}
         await self.execute_sql(query=feedbacks_query, parameters=parameters)
         await self.execute_sql(query=elements_query, parameters=parameters)


### PR DESCRIPTION
Fixed bug in sql_alchemy.py:delete_step: Wrong/non-existing primary key name for steps_query (was "forId" instead of "id", "forId" does not exist in table "steps") - probably a copy/paste bug from the previous line of code.