### PR TITLE
Add UVICORN_TIMEOUT_KEEP_ALIVE to fix Invalid HTTP request received.

### DIFF
--- a/backend/chainlit/cli/__init__.py
+++ b/backend/chainlit/cli/__init__.py
@@ -41,6 +41,9 @@ def run_chainlit(target: str):
     ws_per_message_deflate_env = os.environ.get(
         "UVICORN_WS_PER_MESSAGE_DEFLATE", "true"
     )
+    timeout_keep_alive = os.environ.get(
+        "UVICORN_TIMEOUT_KEEP_ALIVE", 5
+    )
     ws_per_message_deflate = ws_per_message_deflate_env.lower() in [
         "true",
         "1",
@@ -75,6 +78,7 @@ def run_chainlit(target: str):
             port=port,
             log_level=log_level,
             ws_per_message_deflate=ws_per_message_deflate,
+            timeout_keep_alive=timeout_keep_alive
         )
         server = uvicorn.Server(config)
         await server.serve()


### PR DESCRIPTION
Me and my users have been experiencing a `Invalid HTTP request received` periodically. After some debugging i narrowed it down to uvicorn and found [this suggested fix ](https://github.com/encode/uvicorn/issues/441#issuecomment-535652028) from someone also using Async/FastAPI. I only get this error when deployed to Azure App Service, like many of the commenters.

This PR gives users the option via an environment variable `UVICORN_TIMEOUT_KEEP_ALIVE` to adjust to 0 like recommended. The default is 5 which is the current default value used.