### PR TITLE
fix en-US.json small typo

### DIFF
--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -20,7 +20,7 @@
         "TaskList": {
           "title": "🗒️ Task List",
           "loading": "Loading...",
-          "error": "An error occured"
+          "error": "An error occurred"
         }
       },
       "attachments": {


### PR DESCRIPTION
fix small typo (occured->occurred)
