### PR TITLE
fix: Azure authentication

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -332,7 +332,7 @@ def get_user_facing_url(url: URL):
     if config_url.path.endswith("/"):
         config_url = config_url.replace(path=config_url.path[:-1])
 
-    return config_url.__str__()
+    return config_url.__str__() + url.path
 
 
 @router.get("/auth/config")


### PR DESCRIPTION
The callback path for authentication in Azure AD, and possibly others, was unintentionally broken in 8ecd415 by modifying the user-facing path.

This commit reverts one line of that change to restore it to its previous state.