### PR TITLE
Added missing feedback_id.

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -504,7 +504,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 s."language" AS step_language,
                 s."indent" AS step_indent,
                 f."value" AS feedback_value,
-                f."comment" AS feedback_comment
+                f."comment" AS feedback_comment,
+                f."id" AS feedback_id
             FROM steps s LEFT JOIN feedbacks f ON s."id" = f."forId"
             WHERE s."threadId" IN {thread_ids}
             ORDER BY s."createdAt" ASC


### PR DESCRIPTION
`SQLAlchemyDataLayer` (`get_all_user_threads` method) doesn't return feedback_id of already existing feedback, when resuming already existing chat. This results in duplicating feedback when you want to change already existing feedback. Proposed change should fix this issue.