### PR TITLE
Eliminate auto capitalization of thread names

### DIFF
--- a/frontend/src/components/organisms/sidebar/threadHistory/ThreadList.tsx
+++ b/frontend/src/components/organisms/sidebar/threadHistory/ThreadList.tsx
@@ -204,7 +204,7 @@ const ThreadList = ({
                             textOverflow: 'ellipsis'
                           }}
                         >
-                          {capitalize(thread.name || 'Unknown')}
+                          {thread.name || 'Unknown'}
                         </Typography>
                       </Stack>
                       {isSelected ? (


### PR DESCRIPTION
Removing auto-capitalization of thread names because it is not necessary and forces this design decision on developers.