### PR TITLE
FIX: Add feedback_id in SQLAlchemy query

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -504,6 +504,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 s."language" AS step_language,
                 s."indent" AS step_indent,
                 f."value" AS feedback_value,
+                f."id" AS feedback_id,
                 f."comment" AS feedback_comment
             FROM steps s LEFT JOIN feedbacks f ON s."id" = f."forId"
             WHERE s."threadId" IN {thread_ids}


### PR DESCRIPTION
`feedback_id` is referenced in the other code parts but `steps_feedbacks_query` doesn't include it. This PR fixes this