### PR TITLE
add css class based on active theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,6 +142,7 @@ function App() {
         maxHeight="-webkit-fill-available"
         width="100vw"
         sx={{ overflowX: 'hidden' }}
+        className={`theme-${themeVariant}`}
       >
         <ChatSettingsModal />
         <RouterProvider router={router} />


### PR DESCRIPTION
The ability to inject custom CSS into the frontend is very useful but there is no way to differentiate between light and dark modes within the CSS.

This simply adds a class that changes based on the selected theme so custom css can be applied to only light or dark mode.