### PR TITLE
fix: edit_message in correct place in config.toml

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -70,6 +70,9 @@ latex = false
 # Automatically tag threads with the current chat profile (if a chat profile is used)
 auto_tag_thread = true
 
+# Allow users to edit their own messages
+edit_message = true
+
 # Authorize users to spontaneously upload files with messages
 [features.spontaneous_file_upload]
     enabled = true
@@ -90,8 +93,6 @@ auto_tag_thread = true
     chunk_duration = 1000
     # Sample rate of the audio
     sample_rate = 44100
-
-edit_message = true
 
 [UI]
 # Name of the assistant.


### PR DESCRIPTION
Fixes #1204.

Also adds a comment for the setting:

> \# Allow users to edit their own messages