### PR TITLE
BUGFIX | SQLAlchemy - Fix show_input on chat resume

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -578,7 +578,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         tags=step_feedback.get("step_tags"),
                         input=(
                             step_feedback.get("step_input", "")
-                            if step_feedback["step_showinput"] == "true"
+                            if step_feedback.get("step_showinput") not in [None, "false"]
                             else None
                         ),
                         output=step_feedback.get("step_output", ""),


### PR DESCRIPTION
The [step attribute show_input](https://github.com/Chainlit/chainlit/blob/main/backend/chainlit/step.py#L62) can be None, True/False, or the markdown syntax language. The code currently only handles `bool` not `str` so when resuming chats input is not displayed.

```py
showInput: Optional[Union[bool, str]]
```

I switched the if/then to only return None when it's None or "false" (data layer makes this a string)