### PR TITLE
Remove value equals empty input.tsx

### DIFF
--- a/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -102,7 +102,7 @@ const Input = memo(
     }, [loading, disabled]);
 
     const submit = useCallback(() => {
-      if (value === '' || disabled) {
+      if disabled {
         return;
       }
       if (askUser) {


### PR DESCRIPTION
Allow the chat string to be empty. This enables a scenario where a user wishes to only submit attachments, for example.