### PR TITLE
Adding CHAINLIT_APP_ROOT to modify APP_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Adding `CHAINLIT_APP_ROOT` Environment Variable to modify `APP_ROOT`, enabling the ability to set the location of config.toml and other setting files.
 - changing the default host from 0.0.0.0 to 127.0.0.1  
   
 ## [1.1.403rc0] - 2024-08-13

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -29,7 +29,7 @@ TRANSLATIONS_DIR = os.path.join(BACKEND_ROOT, "translations")
 
 
 # Get the directory the script is running from
-APP_ROOT = os.getcwd()
+APP_ROOT = os.getenv("CHAINLIT_APP_ROOT", os.getcwd())
 
 # Create the directory to store the uploaded files
 FILES_DIRECTORY = Path(APP_ROOT) / ".files"


### PR DESCRIPTION
Adding `CHAINLIT_APP_ROOT` ENV Variable to modify `APP_ROOT`

* This is vital. When deploying, it can rely on a centralised config files. 
* Very Minor Change
* Only one line change 
* Replacing `APP_ROOT = os.getcwd()` with `APP_ROOT = os.getenv("CHAINLIT_APP_ROOT", os.getcwd())`