### PR TITLE
Allow the input chat string to be empty when have attachments.

### DIFF
--- a/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -102,7 +102,7 @@ const Input = memo(
     }, [loading, disabled]);
 
     const submit = useCallback(() => {
-      if (value === '' || disabled) {
+      if (disabled || (value === '' && attachments.length === 0)) {
         return;
       }
       if (askUser) {


### PR DESCRIPTION
This enables a scenario where a user wishes to only submit attachments
for example, a document or text translator app