### PR TITLE
Various improvements in tests/CI

### DIFF
--- a/.github/actions/poetry-python-install/action.yaml
+++ b/.github/actions/poetry-python-install/action.yaml
@@ -1,0 +1,46 @@
+name: 'Install Python, poetry and dependencies.'
+description: 'Install Python, Poetry and poetry dependencies using cache'
+
+inputs:
+  python-version:
+    description: 'Python version'
+    required: true
+  poetry-version:
+    description: 'Poetry version'
+    required: true
+  poetry-working-directory:
+    description: 'Working directory for poetry command.'
+    required: false
+    default: '.'
+  poetry-install-args:
+    description: 'Extra arguments for poetry install, e.g. --with tests.'
+    required: false
+
+defaults:
+  run:
+    shell: bash
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cache poetry install
+      uses: actions/cache@v2
+      with:
+        path: ~/.local
+        key: poetry-${{ runner.os }}-${{ inputs.poetry-version }}-0
+    - name: Install Poetry
+      run: pipx install 'poetry==${{ inputs.poetry-version }}'
+      shell: bash
+    - name: Set up Python ${{ inputs.python-version }}
+      id: setup_python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: poetry
+        cache-dependency-path: ${{ inputs.poetry-working-directory }}/poetry.lock
+    - name: Set Poetry environment
+      run: poetry -C '${{ inputs.poetry-working-directory }}' env use '${{ steps.setup_python.outputs.python-path }}'
+      shell: bash
+    - name: Install Python dependencies
+      run: poetry -C '${{ inputs.poetry-working-directory }}' install ${{ inputs.poetry-install-args }}
+      shell: bash

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -8,34 +8,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+    env:
+      BACKEND_DIR: ./backend
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
           version: 8.6.9
+      - uses: ./.github/actions/poetry-python-install
+        name: Install Python, poetry and Python dependencies
+        with:
+          python-version: 3.9
+          poetry-version: 1.8.3
+          poetry-working-directory: ${{ env.BACKEND_DIR }}
+          poetry-install-args: --with tests
       - name: Use Node.js 16.15.0
         uses: actions/setup-node@v3
         with:
           node-version: '16.15.0'
           cache: 'pnpm'
-      - name: cache poetry install
-        uses: actions/cache@v2
-        with:
-          path: ~/.local
-          key: poetry-1.8.3-0
-      - name: Install Poetry
-        run: pipx install poetry==1.8.3
-      - name: Set up Python
-        id: python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-          cache: poetry
-          cache-dependency-path: backend/poetry.lock
-      - name: Set Poetry environment
-        run: poetry -C ./backend env use '${{ steps.python.outputs.python-path }}'
-      - name: Install Python dependencies
-        run: poetry -C ./backend install --with tests
       - name: Install JS dependencies
         run: pnpm install --no-frozen-lockfile
       - name: Build UI

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -18,21 +18,30 @@ jobs:
         with:
           node-version: '16.15.0'
           cache: 'pnpm'
+      - name: cache poetry install
+        uses: actions/cache@v2
+        with:
+          path: ~/.local
+          key: poetry-1.8.3-0
+      - name: Install Poetry
+        run: pipx install poetry==1.8.3
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
-      - name: Install Poetry
-        run: pip install poetry
+          python-version: 3.9
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
+      - name: Set Poetry environment
+        run: poetry -C ./backend env use '${{ steps.python.outputs.python-path }}'
+      - name: Install Python dependencies
+        run: poetry -C ./backend install --with tests
       - name: Install JS dependencies
         run: pnpm install --no-frozen-lockfile
       - name: Build UI
         run: pnpm run buildUi
       - name: Lint UI
         run: pnpm run lintUi
-      - name: Install Python dependencies
-        run: poetry install -C ./backend --with tests
       - name: Run tests
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -5,23 +5,17 @@ on: [workflow_call]
 jobs:
   mypy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./backend
+    env:
+      BACKEND_DIR: ./backend
     steps:
       - uses: actions/checkout@v3
-      - name: Install Poetry
-        run: pipx install poetry
-      - name: Set up Python
-        id: python
-        uses: actions/setup-python@v4
+      - uses: ./.github/actions/poetry-python-install
+        name: Install Python, poetry and Python dependencies
         with:
           python-version: 3.9
-          cache: poetry
-          cache-dependency-path: backend/poetry.lock
-      - name: Set Poetry environment
-        run: poetry env use '${{ steps.python.outputs.python-path }}'
-      - name: Install dependencies
-        run: poetry install --with tests --with mypy --with custom-data
+          poetry-version: 1.8.3
+          poetry-install-args: --with tests --with mypy --with custom-data
+          poetry-working-directory: ${{ env.BACKEND_DIR }}
       - name: Run Mypy
         run: poetry run mypy chainlit/
+        working-directory: ${{ env.BACKEND_DIR }}

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -10,13 +10,17 @@ jobs:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v3
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
-      - name: Install Poetry
-        run: pip install poetry
+          python-version: 3.9
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
+      - name: Set Poetry environment
+        run: poetry env use '${{ steps.python.outputs.python-path }}'
       - name: Install dependencies
         run: poetry install --with tests --with mypy --with custom-data
       - name: Run Mypy

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,23 +8,17 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-    defaults:
-      run:
-        working-directory: ./backend
+    env:
+      BACKEND_DIR: ./backend
     steps:
       - uses: actions/checkout@v3
-      - name: Install Poetry
-        run: pipx install poetry
-      - name: Set up Python
-        id: python
-        uses: actions/setup-python@v4
+      - uses: ./.github/actions/poetry-python-install
+        name: Install Python, poetry and Python dependencies
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-          cache-dependency-path: backend/poetry.lock
-      - name: Set Poetry environment
-        run: poetry env use '${{ steps.python.outputs.python-path }}'
-      - name: Install dependencies
-        run: poetry install --with tests --with mypy --with custom-data
+          poetry-version: 1.8.3
+          poetry-install-args: --with tests --with mypy --with custom-data
+          poetry-working-directory: ${{ env.BACKEND_DIR }}
       - name: Run Pytest
         run: poetry run pytest --cov=chainlit/
+        working-directory: ${{ env.BACKEND_DIR }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,8 +3,11 @@ name: Pytest
 on: [workflow_call]
 
 jobs:
-  mypy:
+  pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     defaults:
       run:
         working-directory: ./backend
@@ -13,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install Poetry
         run: pip install poetry

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,13 +13,17 @@ jobs:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v3
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-      - name: Install Poetry
-        run: pip install poetry
+          cache: poetry
+          cache-dependency-path: backend/poetry.lock
+      - name: Set Poetry environment
+        run: poetry env use '${{ steps.python.outputs.python-path }}'
       - name: Install dependencies
         run: poetry install --with tests --with mypy --with custom-data
       - name: Run Pytest


### PR DESCRIPTION
* Run unittest on all supported Python versions, to provide stronger support guarantees.
* Local GH action Python/Poetry (dependency) install with caching.

Faster test runs, more consistency, less duplication. 

Saving test minutes and being gets important once we start doing things like testing multiple FastAPI versions.