### PR TITLE
[fix] `LlamaIndexCallbackHandler` to support displaying function calls as tools in CoTs

### DIFF
--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -8,6 +8,7 @@ from literalai.helper import utc_now
 from llama_index.core.callbacks import TokenCountingHandler
 from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.llms import ChatMessage, ChatResponse, CompletionResponse
+from llama_index.core.tools.types import ToolMetadata
 
 DEFAULT_IGNORE = [
     CBEventType.CHUNKING,

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -60,8 +60,9 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
         if event_type == CBEventType.FUNCTION_CALL:
             step_type = "tool"
             if payload:
-                metadata: ToolMetadata = payload.get(EventPayload.TOOL)
-                step_name = getattr(metadata, "name", step_name)
+                metadata: Optional[ToolMetadata] = payload.get(EventPayload.TOOL)
+                if metadata:
+                    step_name = getattr(metadata, "name", step_name)
                 step_input = payload.get(EventPayload.FUNCTION_CALL)
         elif event_type == CBEventType.RETRIEVE:
             step_type = "tool"

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -56,7 +56,7 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
         step_type: StepType = "undefined"
         if event_type == CBEventType.FUNCTION_CALL:
             step_type = "tool"
-        if event_type == CBEventType.RETRIEVE:
+        elif event_type == CBEventType.RETRIEVE:
             step_type = "tool"
         elif event_type == CBEventType.QUERY:
             step_type = "tool"

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -99,7 +99,7 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
                 step.output = f"{response}"
                 context_var.get().loop.create_task(step.update())
 
-        if event_type == CBEventType.QUERY:
+        elif event_type == CBEventType.QUERY:
             response = payload.get(EventPayload.RESPONSE)
             source_nodes = getattr(response, "source_nodes", None)
             if source_nodes:

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -55,7 +55,7 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
         """Run when an event starts and return id of event."""
         step_type: StepType = "undefined"
         step_name: str = event_type.value
-        step_input: Dict[str, Any] = payload
+        step_input: Optional[Dict[str, Any]] = payload
         if event_type == CBEventType.FUNCTION_CALL:
             step_type = "tool"
             if payload:

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -58,9 +58,10 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
         step_input: Dict[str, Any] = payload
         if event_type == CBEventType.FUNCTION_CALL:
             step_type = "tool"
-            metadata: ToolMetadata = payload.get(EventPayload.TOOL)
-            step_name = metadata.name
-            step_input = payload.get(EventPayload.FUNCTION_CALL)
+            if payload:
+                metadata: ToolMetadata = payload.get(EventPayload.TOOL)
+                step_name = metadata.name
+                step_input = payload.get(EventPayload.FUNCTION_CALL)
         elif event_type == CBEventType.RETRIEVE:
             step_type = "tool"
         elif event_type == CBEventType.QUERY:

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -60,7 +60,7 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
             step_type = "tool"
             if payload:
                 metadata: ToolMetadata = payload.get(EventPayload.TOOL)
-                step_name = metadata.name
+                step_name = getattr(metadata, "name", step_name)
                 step_input = payload.get(EventPayload.FUNCTION_CALL)
         elif event_type == CBEventType.RETRIEVE:
             step_type = "tool"

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -58,7 +58,6 @@ class LlamaIndexCallbackHandler(TokenCountingHandler):
         step_input: Dict[str, Any] = payload
         if event_type == CBEventType.FUNCTION_CALL:
             step_type = "tool"
-            print(payload)
             metadata: ToolMetadata = payload.get(EventPayload.TOOL)
             step_name = metadata.name
             step_input = payload.get(EventPayload.FUNCTION_CALL)

--- a/backend/tests/llama_index/test_callbacks.py
+++ b/backend/tests/llama_index/test_callbacks.py
@@ -66,6 +66,29 @@ async def test_on_event_start_for_function_calls(mock_chainlit_context):
         mock_send.assert_called_once()
 
 
+async def test_on_event_start_for_function_calls_missing_payload(mock_chainlit_context):
+    TEST_EVENT_ID = "test_event_id"
+    async with mock_chainlit_context:
+        handler = LlamaIndexCallbackHandler()
+
+        with patch.object(Step, "send") as mock_send:
+            result = handler.on_event_start(
+                CBEventType.FUNCTION_CALL,
+                None,
+                TEST_EVENT_ID,
+            )
+
+        assert result == TEST_EVENT_ID
+        assert TEST_EVENT_ID in handler.steps
+        step = handler.steps[TEST_EVENT_ID]
+        assert isinstance(step, Step)
+        assert step.name == "function_call"
+        assert step.type == "tool"
+        assert step.id == TEST_EVENT_ID
+        assert step.input == "{}"
+        mock_send.assert_called_once()
+
+
 async def test_on_event_end_for_function_calls(mock_chainlit_context):
     TEST_EVENT_ID = "test_event_id"
     async with mock_chainlit_context:
@@ -84,3 +107,22 @@ async def test_on_event_end_for_function_calls(mock_chainlit_context):
         assert step.output == "test_output"
         assert TEST_EVENT_ID not in handler.steps
         mock_send.assert_called_once()
+
+
+async def test_on_event_end_for_function_calls_missing_payload(mock_chainlit_context):
+    TEST_EVENT_ID = "test_event_id"
+    async with mock_chainlit_context:
+        handler = LlamaIndexCallbackHandler()
+        # Pretend that we have started a step before.
+        step = Step(name="test_tool", type="tool", id=TEST_EVENT_ID)
+        handler.steps[TEST_EVENT_ID] = step
+
+        with patch.object(step, "update") as mock_send:
+            handler.on_event_end(
+                CBEventType.FUNCTION_CALL,
+                payload=None,
+                event_id=TEST_EVENT_ID,
+            )
+        # TODO: Is this the desired behavior? Shouldn't we still remove the step as long as we've been told it has ended, even if the payload is missing?
+        assert TEST_EVENT_ID in handler.steps
+        mock_send.assert_not_called()

--- a/backend/tests/llama_index/test_callbacks.py
+++ b/backend/tests/llama_index/test_callbacks.py
@@ -1,0 +1,66 @@
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+from chainlit.context import ChainlitContext, context_var
+
+# Import the class we're testing
+from chainlit.llama_index.callbacks import LlamaIndexCallbackHandler
+from chainlit.session import WebsocketSession
+from chainlit.step import Step
+from chainlit.user_session import UserSession
+from llama_index.core.callbacks.schema import CBEventType, EventPayload
+from llama_index.core.tools.types import ToolMetadata
+
+
+@asynccontextmanager
+async def create_chainlit_context():
+    mock_session = Mock(spec=WebsocketSession)
+    mock_session.id = "test_session_id"
+    mock_session.thread_id = "test_session_thread_id"
+    mock_session.user_env = {"test_env": "value"}
+    mock_session.chat_settings = {}
+    mock_session.user = None
+    mock_session.chat_profile = None
+    mock_session.http_referer = None
+    mock_session.client_type = "webapp"
+    mock_session.languages = ["en"]
+
+    context = ChainlitContext(mock_session)
+    token = context_var.set(context)
+    try:
+        yield context
+    finally:
+        context_var.reset(token)
+
+
+@pytest_asyncio.fixture
+async def mock_chainlit_context():
+    return create_chainlit_context()
+
+
+async def test_on_event_start(mock_chainlit_context):
+    TEST_EVENT_ID = "test_event_id"
+    async with mock_chainlit_context as context:
+        handler = LlamaIndexCallbackHandler()
+
+        result = handler.on_event_start(
+            CBEventType.FUNCTION_CALL,
+            {
+                EventPayload.TOOL: ToolMetadata(
+                    name="test_tool", description="test_description"
+                ),
+                EventPayload.FUNCTION_CALL: {"arg1": "value1"},
+            },
+            TEST_EVENT_ID,
+        )
+
+        assert result == TEST_EVENT_ID
+        assert TEST_EVENT_ID in handler.steps
+        step = handler.steps[TEST_EVENT_ID]
+        assert isinstance(step, Step)
+        assert step.name == "test_tool"
+        assert step.type == "tool"
+        assert step.id == TEST_EVENT_ID
+        assert step.input == '{\n    "arg1": "value1"\n}'

--- a/backend/tests/llama_index/test_callbacks.py
+++ b/backend/tests/llama_index/test_callbacks.py
@@ -42,7 +42,7 @@ async def mock_chainlit_context():
 
 async def test_on_event_start_for_function_calls(mock_chainlit_context):
     TEST_EVENT_ID = "test_event_id"
-    async with mock_chainlit_context as context:
+    async with mock_chainlit_context:
         handler = LlamaIndexCallbackHandler()
 
         with patch.object(Step, "send") as mock_send:
@@ -70,7 +70,7 @@ async def test_on_event_start_for_function_calls(mock_chainlit_context):
 
 async def test_on_event_end_for_function_calls(mock_chainlit_context):
     TEST_EVENT_ID = "test_event_id"
-    async with mock_chainlit_context as context:
+    async with mock_chainlit_context:
         handler = LlamaIndexCallbackHandler()
         # Pretend that we have started a step before.
         step = Step(name="test_tool", type="tool", id=TEST_EVENT_ID)

--- a/backend/tests/llama_index/test_callbacks.py
+++ b/backend/tests/llama_index/test_callbacks.py
@@ -1,7 +1,6 @@
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
-import pytest
 import pytest_asyncio
 from chainlit.context import ChainlitContext, context_var
 
@@ -9,7 +8,6 @@ from chainlit.context import ChainlitContext, context_var
 from chainlit.llama_index.callbacks import LlamaIndexCallbackHandler
 from chainlit.session import WebsocketSession
 from chainlit.step import Step
-from chainlit.user_session import UserSession
 from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.tools.types import ToolMetadata
 

--- a/backend/tests/llama_index/test_callbacks.py
+++ b/backend/tests/llama_index/test_callbacks.py
@@ -40,7 +40,7 @@ async def mock_chainlit_context():
     return create_chainlit_context()
 
 
-async def test_on_event_start(mock_chainlit_context):
+async def test_on_event_start_for_function_calls(mock_chainlit_context):
     TEST_EVENT_ID = "test_event_id"
     async with mock_chainlit_context as context:
         handler = LlamaIndexCallbackHandler()
@@ -64,3 +64,21 @@ async def test_on_event_start(mock_chainlit_context):
         assert step.type == "tool"
         assert step.id == TEST_EVENT_ID
         assert step.input == '{\n    "arg1": "value1"\n}'
+
+
+async def test_on_event_end_for_function_calls(mock_chainlit_context):
+    TEST_EVENT_ID = "test_event_id"
+    async with mock_chainlit_context as context:
+        handler = LlamaIndexCallbackHandler()
+        # Pretend that we have started a step before.
+        step = Step(name="test_tool", type="tool", id=TEST_EVENT_ID)
+        handler.steps[TEST_EVENT_ID] = step
+
+        handler.on_event_end(
+            CBEventType.FUNCTION_CALL,
+            payload={EventPayload.FUNCTION_OUTPUT: "test_output"},
+            event_id=TEST_EVENT_ID,
+        )
+
+        assert step.output == "test_output"
+        assert TEST_EVENT_ID not in handler.steps


### PR DESCRIPTION
In Llama Index, tool-calling events are emitted with the event type of `FUNCTION_CALL`. All tools in Llama Index, when used, emits these events, so they should definitely be supported in Chainlit.

**Example usage** is in [this repo](https://github.com/StarsRail/Cocai). This is a simple LLM agent that can roll a dice for you. The dice-rolling capability is implemented as simple `random.randint` call ([code](https://github.com/StarsRail/Cocai/blob/b94d26c38aae1542c8ceea316af3822aed2c3a0e/tools.py#L26)) wrapped with `FunctionTool` ([code](https://github.com/StarsRail/Cocai/blob/b94d26c38aae1542c8ceea316af3822aed2c3a0e/main.py#L125-L127)).

| Before | After | 
| --- | --- |
|  <img width="773" alt="image" src="https://github.com/user-attachments/assets/1a1d214b-eda6-4297-ae8d-34a1850f2696"> (notice that the the function-calling step is missing) | <img width="761" alt="image" src="https://github.com/user-attachments/assets/7511bb74-1b05-4c13-9d82-e5c524143624"> |
