### PR TITLE
Bump dataclasses to latest version.

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1027,22 +1027,18 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.9"
-description = "Easily serialize dataclasses to and from JSON"
+version = "0.6.7"
+description = "Easily serialize dataclasses to and from JSON."
 optional = false
-python-versions = ">=3.6"
+python-versions = "<4.0,>=3.7"
 files = [
-    {file = "dataclasses-json-0.5.9.tar.gz", hash = "sha256:e9ac87b73edc0141aafbce02b44e93553c3123ad574958f0fe52a534b6707e8e"},
-    {file = "dataclasses_json-0.5.9-py3-none-any.whl", hash = "sha256:1280542631df1c375b7bc92e5b86d39e06c44760d7e3571a537b3b8acabf2f0c"},
+    {file = "dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a"},
+    {file = "dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0"},
 ]
 
 [package.dependencies]
-marshmallow = ">=3.3.0,<4.0.0"
-marshmallow-enum = ">=1.5.1,<2.0.0"
-typing-inspect = ">=0.4.0"
-
-[package.extras]
-dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=7.2.0)", "setuptools", "simplejson", "twine", "types-dataclasses", "wheel"]
+marshmallow = ">=3.18.0,<4.0.0"
+typing-inspect = ">=0.4.0,<1"
 
 [[package]]
 name = "deprecated"
@@ -2569,20 +2565,6 @@ packaging = ">=17.0"
 dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
 docs = ["alabaster (==1.0.0)", "autodocsumm (==0.2.13)", "sphinx (==8.0.2)", "sphinx-issues (==4.1.0)", "sphinx-version-warning (==1.1.2)"]
 tests = ["pytest", "pytz", "simplejson"]
-
-[[package]]
-name = "marshmallow-enum"
-version = "1.5.1"
-description = "Enum field for Marshmallow"
-optional = false
-python-versions = "*"
-files = [
-    {file = "marshmallow-enum-1.5.1.tar.gz", hash = "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58"},
-    {file = "marshmallow_enum-1.5.1-py2.py3-none-any.whl", hash = "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072"},
-]
-
-[package.dependencies]
-marshmallow = ">=2.0.0"
 
 [[package]]
 name = "matplotlib"
@@ -5431,4 +5413,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "2c7c18baeef86be74a58fed3fe79c46539fa2972c6b845c089cad09524b1c100"
+content-hash = "0c20ee17e5e449204c15b44de7ba5597863a97cc2195d77365d42091b09af2ff"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ chainlit = 'chainlit.cli:cli'
 python = ">=3.9,<4.0.0"
 httpx = ">=0.23.0"
 literalai = "0.0.607"
-dataclasses_json = "^0.5.7"
+dataclasses_json = "^0.6.7"
 fastapi = ">=0.110.1,<0.113"
 starlette = "^0.37.2"
 uvicorn = "^0.25.0"
@@ -102,6 +102,7 @@ module = [
     "azure.storage.filedatalake",
 ]
 ignore_missing_imports = true
+
 
 
 


### PR DESCRIPTION
As we're relying on dataclasses pretty much everywhere, and we don't nearly have enough unit test coverage, I would like to ask the community to assist in manual testing before we ship this in the latest release (in addition to contributions to increase unittest coverage).

As discussed [here](https://github.com/Chainlit/chainlit/pull/1267#issuecomment-2315006242), we prefer to be careful when upgrading dependencies and would prefer to do it one by one. Otherwise, if something goes wrong, it will be extremely challenging to figure out _where_ it went wrong. (#1267)

Depending on the amount of testing/feedback we can get in, we hope to ship this with the coming release. We're also actively working towards allowing (editable) installs straight from GIT so users won't be as dependent on our release cycle (and we can get more feedback on features/PR's/fixes). (#1224)

Specifically looking in the direction of @jpolvto, @aidanshipperley and @EWouters.

Ref:
* https://github.com/Chainlit/chainlit/issues/1266

