### PR TITLE
Fix publish workflow.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,13 +6,13 @@ on:
     types: [published]
 
 jobs:
-  tests:
-    uses: ./.github/workflows/tests.yaml
+  ci:
+    uses: ./.github/workflows/ci.yaml
     secrets: inherit
   build-n-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    needs: [tests]
+    needs: [ci]
     env:
       name: pypi
       url: https://pypi.org/p/chainlit


### PR DESCRIPTION
Fixup publish workflow; tests has been renamed to e2e-tests.

We're gonna ensure the entire CI passes instead.