### PR TITLE
Various improvements in GH actions

### DIFF
--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -1,0 +1,27 @@
+name: 'Install Node, pnpm and dependencies.'
+description: 'Install Node, pnpm and dependencies using cache.'
+
+inputs:
+  node-version:
+    description: 'Node.js version'
+    required: true
+  pnpm-version:
+    description: 'pnpm version'
+    required: true
+  pnpm-install-args:
+    description: 'Extra arguments for pnpm install, e.g. --no-frozen-lockfile.'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+    - name: Install JS dependencies
+      run: pnpm install ${{ inputs.pnpm-install-args }}
+      shell: bash

--- a/.github/actions/poetry-python-install/action.yaml
+++ b/.github/actions/poetry-python-install/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache poetry install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local
         key: poetry-${{ runner.os }}-${{ inputs.poetry-version }}-0

--- a/.github/actions/poetry-python-install/action.yaml
+++ b/.github/actions/poetry-python-install/action.yaml
@@ -16,10 +16,6 @@ inputs:
     description: 'Extra arguments for poetry install, e.g. --with tests.'
     required: false
 
-defaults:
-  run:
-    shell: bash
-
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/poetry-python-install/action.yaml
+++ b/.github/actions/poetry-python-install/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: bash
     - name: Set up Python ${{ inputs.python-version }}
       id: setup_python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: poetry

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,9 +12,6 @@ jobs:
       BACKEND_DIR: ./backend
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9.7.0
       - uses: ./.github/actions/poetry-python-install
         name: Install Python, poetry and Python dependencies
         with:
@@ -22,8 +19,11 @@ jobs:
           poetry-version: 1.8.3
           poetry-working-directory: ${{ env.BACKEND_DIR }}
           poetry-install-args: --with tests
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.7.0
       - name: Use Node.js 16.15.0
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.15.0'
           cache: 'pnpm'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8.6.9
+          version: 9.7.0
       - uses: ./.github/actions/poetry-python-install
         name: Install Python, poetry and Python dependencies
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,10 +22,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9.7.0
-      - name: Use Node.js 16.15.0
+      - name: Use Node.js 22.7.0
         uses: actions/setup-node@v4
         with:
-          node-version: '16.15.0'
+          node-version: '22.7.0'
           cache: 'pnpm'
       - name: Install JS dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,16 +19,12 @@ jobs:
           poetry-version: 1.8.3
           poetry-working-directory: ${{ env.BACKEND_DIR }}
           poetry-install-args: --with tests
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/pnpm-node-install
+        name: Install Node, pnpm and dependencies.
         with:
-          version: 9.7.0
-      - name: Use Node.js 22.7.0
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.7.0'
-          cache: 'pnpm'
-      - name: Install JS dependencies
-        run: pnpm install --no-frozen-lockfile
+          node-version: 22.7.0
+          pnpm-version: 9.7.0
+          pnpm-install-args: --no-frozen-lockfile
       - name: Build UI
         run: pnpm run buildUi
       - name: Lint UI

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,10 +27,10 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 8.6.9
-      - name: Use Node.js 16.15.0
+      - name: Use Node.js 22.7.0
         uses: actions/setup-node@v3
         with:
-          node-version: '16.15.0'
+          node-version: '22.7.0'
           cache: 'pnpm'
       - uses: ./.github/actions/poetry-python-install
         name: Install Python, poetry and Python dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,14 +24,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: main
-      - uses: pnpm/action-setup@v2
+      - uses: ./.github/actions/pnpm-node-install
+        name: Install Node, pnpm and dependencies.
         with:
-          version: 8.6.9
-      - name: Use Node.js 22.7.0
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22.7.0'
-          cache: 'pnpm'
+          node-version: 22.7.0
+          pnpm-version: 9.7.0
+          pnpm-install-args: --no-frozen-lockfile
       - uses: ./.github/actions/poetry-python-install
         name: Install Python, poetry and Python dependencies
         with:
@@ -40,8 +38,6 @@ jobs:
           poetry-working-directory: ${{ env.BACKEND_DIR }}
       - name: Copy readme to backend
         run: cp README.md backend/
-      - name: Install JS dependencies
-        run: pnpm install --no-frozen-lockfile
       - name: Build chainlit
         run: pnpm run build
       - name: Publish package distributions to PyPI

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint ./src --ext .ts,.tsx && tsc --noemit",
     "format": "prettier src/**/*.{ts,tsx} --write --loglevel error",
     "test": "vitest run",
-    "prepublish": "pnpm run build && pnpm test"
+    "prepublishOnly": "pnpm run build && pnpm test"
   },
   "dependencies": {
     "@chainlit/react-client": "workspace:^",

--- a/libs/react-client/package.json
+++ b/libs/react-client/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier **/*.{ts,tsx} --write --loglevel error",
     "test": "echo no tests yet",
-    "prepublish": "pnpm run build"
+    "prepublishOnly": "pnpm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Upgrade actions/cache to v4, solves Node 12 not supported warning. Resolves: 
  "The following actions uses node12 which is deprecated and will be forced to run on node16: actions/cache@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/"
* Bump various action versions to latest major version.
* Bump Node for building to latest LTS (Node 16 has EOL'd a long time ago).
* DRY local action for node/pnpm builds similar to python/poetry action.
* Use `prepublishOnly` to avoid building internal deps during install (e.g. build only during publish or build).