### PR TITLE
Removed redundant key/value pair from dictionary creator

### DIFF
--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -82,7 +82,6 @@ class MessageBase(ABC):
             "output": self.content,
             "name": self.author,
             "type": self.type,
-            "createdAt": self.created_at,
             "language": self.language,
             "streaming": self.streaming,
             "isError": self.is_error,


### PR DESCRIPTION
Just removing an extraneous key/value declaration set during the creation of a dictionary.

`createdAt` is set on line 79 and line 85

https://github.com/Chainlit/chainlit/blob/122369a64ebdc3d34f6f88cbe24ec612d209c20b/backend/chainlit/message.py#L74-L93