### PR TITLE
Add support for displaying pandas DataFrame as a table

### DIFF
--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -23,6 +23,7 @@ from chainlit.context import context
 from chainlit.element import (
     Audio,
     Component,
+    Dataframe,
     File,
     Image,
     Pdf,

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -31,7 +31,16 @@ mime_types = {
 }
 
 ElementType = Literal[
-    "image", "text", "pdf", "tasklist", "audio", "video", "file", "plotly", "component"
+    "image",
+    "text",
+    "pdf",
+    "tasklist",
+    "audio",
+    "video",
+    "file",
+    "plotly",
+    "dataframe",
+    "component",
 ]
 ElementDisplay = Literal["inline", "side", "page"]
 ElementSize = Literal["small", "medium", "large"]
@@ -355,6 +364,13 @@ class Plotly(Element):
         self.mime = "application/json"
 
         super().__post_init__()
+
+
+@dataclass
+class Dataframe(Element):
+    type: ClassVar[ElementType] = "dataframe"
+
+    size: ElementSize = "large"
 
 
 @dataclass

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^5.14.9",
     "@mui/lab": "^5.0.0-alpha.122",
     "@mui/material": "^5.14.10",
+    "@mui/x-data-grid": "^6.20.4",
     "formik": "^2.4.3",
     "highlight.js": "^11.9.0",
     "i18next": "^23.7.16",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mui/material':
         specifier: ^5.14.10
         version: 5.14.10(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/x-data-grid':
+        specifier: ^6.20.4
+        version: 6.20.4(@mui/material@5.14.10(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.14.19(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       formik:
         specifier: ^2.4.3
         version: 2.4.3(react@18.2.0)
@@ -286,6 +289,10 @@ packages:
 
   '@babel/runtime@7.23.5':
     resolution: {integrity: sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.25.6':
+    resolution: {integrity: sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.22.15':
@@ -831,6 +838,14 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/types@7.2.17':
+    resolution: {integrity: sha512-oyumoJgB6jDV8JFzRqjBo2daUuHpzDjoO/e3IrRhhHo/FxJlaVhET6mcNrKHUq2E+R+q3ql0qAtvQ4rfWHhAeQ==}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/utils@5.14.19':
     resolution: {integrity: sha512-qAHvTXzk7basbyqPvhgWqN6JbmI2wLB/mf97GkSlz5c76MiKYV6Ffjvw9BjKZQ1YRb8rDX9kgdjRezOcoB91oQ==}
     engines: {node: '>=12.0.0'}
@@ -840,6 +855,25 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@mui/utils@5.16.6':
+    resolution: {integrity: sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/x-data-grid@6.20.4':
+    resolution: {integrity: sha512-I0JhinVV4e25hD2dB+R6biPBtpGeFrXf8RwlMPQbr9gUggPmPmNtWKo8Kk2PtBBMlGtdMAgHWe7PqhmucUxU1w==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^5.4.1
+      '@mui/system': ^5.4.1
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1203,6 +1237,9 @@ packages:
   '@types/prop-types@15.7.11':
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
+  '@types/prop-types@15.7.13':
+    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+
   '@types/react-dom@18.2.22':
     resolution: {integrity: sha512-fHkBXPeNtfvri6gdsMYyW+dW7RXFo6Ad09nLFK0VQWR7yGLai/Cyvyj696gbwYvBnhGtevUG9cET0pmUbMtoPQ==}
 
@@ -1507,6 +1544,10 @@ packages:
 
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
   color-alpha@1.0.4:
@@ -3053,6 +3094,9 @@ packages:
   react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-markdown@9.0.1:
     resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
     peerDependencies:
@@ -3178,6 +3222,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3964,6 +4011,10 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.0
 
+  '@babel/runtime@7.25.6':
+    dependencies:
+      regenerator-runtime: 0.14.0
+
   '@babel/template@7.22.15':
     dependencies:
       '@babel/code-frame': 7.23.5
@@ -4416,6 +4467,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.0
 
+  '@mui/types@7.2.17(@types/react@18.2.0)':
+    optionalDependencies:
+      '@types/react': 18.2.0
+
   '@mui/utils@5.14.19(@types/react@18.2.0)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.23.5
@@ -4425,6 +4480,32 @@ snapshots:
       react-is: 18.2.0
     optionalDependencies:
       '@types/react': 18.2.0
+
+  '@mui/utils@5.16.6(@types/react@18.2.0)(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@mui/types': 7.2.17(@types/react@18.2.0)
+      '@types/prop-types': 15.7.13
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-is: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.2.0
+
+  '@mui/x-data-grid@6.20.4(@mui/material@5.14.10(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.14.19(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@mui/material': 5.14.10(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/system': 5.14.19(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@emotion/styled@11.11.0(@emotion/react@11.11.1(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0))(@types/react@18.2.0)(react@18.2.0)
+      '@mui/utils': 5.16.6(@types/react@18.2.0)(react@18.2.0)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      reselect: 4.1.8
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4802,6 +4883,8 @@ snapshots:
 
   '@types/prop-types@15.7.11': {}
 
+  '@types/prop-types@15.7.13': {}
+
   '@types/react-dom@18.2.22':
     dependencies:
       '@types/react': 18.2.0
@@ -5105,6 +5188,8 @@ snapshots:
   clsx@1.2.1: {}
 
   clsx@2.0.0: {}
+
+  clsx@2.1.1: {}
 
   color-alpha@1.0.4:
     dependencies:
@@ -7113,6 +7198,8 @@ snapshots:
 
   react-is@18.2.0: {}
 
+  react-is@18.3.1: {}
+
   react-markdown@9.0.1(@types/react@18.2.0)(react@18.2.0):
     dependencies:
       '@types/hast': 3.0.4
@@ -7341,6 +7428,8 @@ snapshots:
       unified: 11.0.4
 
   requires-port@1.0.0: {}
+
+  reselect@4.1.8: {}
 
   resolve-from@4.0.0: {}
 

--- a/frontend/src/components/atoms/elements/Dataframe.tsx
+++ b/frontend/src/components/atoms/elements/Dataframe.tsx
@@ -1,0 +1,52 @@
+import { DataGrid } from '@mui/x-data-grid';
+
+import { useFetch } from 'hooks/useFetch';
+
+import { type IDataframeElement } from 'client-types/';
+
+interface Props {
+  element: IDataframeElement;
+}
+
+const DataframeElement = ({ element }: Props) => {
+  const { data } = useFetch(element.url || null);
+
+  if (!data) {
+    return <div>Loading...</div>;
+  }
+
+  const { index, columns, data: rowData } = JSON.parse(data);
+
+  const gridColumns = columns.map((col: string) => ({
+    field: col,
+    minWidth: 150
+  }));
+
+  const gridRows = rowData.map((row: (string | number)[], idx: number) => {
+    const rowObj: any = { id: index[idx] };
+    columns.forEach((col: string, colIdx: number) => {
+      rowObj[col] = row[colIdx];
+    });
+    return rowObj;
+  });
+
+  return (
+    <DataGrid
+      sx={{
+        bgcolor: 'background.paper'
+      }}
+      rows={gridRows}
+      columns={gridColumns}
+      initialState={{
+        pagination: {
+          paginationModel: {
+            pageSize: 10
+          }
+        }
+      }}
+      pageSizeOptions={[10, 50, 100]}
+    />
+  );
+};
+
+export { DataframeElement };

--- a/frontend/src/components/atoms/elements/Element.tsx
+++ b/frontend/src/components/atoms/elements/Element.tsx
@@ -1,6 +1,7 @@
 import type { IMessageElement } from 'client-types/';
 
 import { AudioElement } from './Audio';
+import { DataframeElement } from './Dataframe';
 import { FileElement } from './File';
 import { ImageElement } from './Image';
 import { PDFElement } from './PDF';
@@ -28,6 +29,8 @@ const Element = ({ element }: ElementProps): JSX.Element | null => {
       return <VideoElement element={element} />;
     case 'plotly':
       return <PlotlyElement element={element} />;
+    case 'dataframe':
+      return <DataframeElement element={element} />;
     default:
       return null;
   }

--- a/frontend/src/components/atoms/elements/InlinedDataframeList.tsx
+++ b/frontend/src/components/atoms/elements/InlinedDataframeList.tsx
@@ -1,0 +1,29 @@
+import Stack from '@mui/material/Stack';
+
+import type { IDataframeElement } from 'client-types/';
+
+import { DataframeElement } from './Dataframe';
+
+interface Props {
+  items: IDataframeElement[];
+}
+
+const InlinedDataframeList = ({ items }: Props) => (
+  <Stack spacing={1}>
+    {items.map((element, i) => {
+      return (
+        <div
+          key={i}
+          style={{
+            height: 450,
+            maxWidth: '650px'
+          }}
+        >
+          <DataframeElement element={element} />
+        </div>
+      );
+    })}
+  </Stack>
+);
+
+export { InlinedDataframeList };

--- a/frontend/src/components/atoms/elements/InlinedElements.tsx
+++ b/frontend/src/components/atoms/elements/InlinedElements.tsx
@@ -3,6 +3,7 @@ import Stack from '@mui/material/Stack';
 import type { ElementType, IMessageElement } from 'client-types/';
 
 import { InlinedAudioList } from './InlinedAudioList';
+import { InlinedDataframeList } from './InlinedDataframeList';
 import { InlinedFileList } from './InlinedFileList';
 import { InlinedImageList } from './InlinedImageList';
 import { InlinedPDFList } from './InlinedPDFList';
@@ -63,6 +64,9 @@ const InlinedElements = ({ elements }: Props) => {
       ) : null}
       {elementsByType.plotly?.length ? (
         <InlinedPlotlyList items={elementsByType.plotly} />
+      ) : null}
+      {elementsByType.dataframe?.length ? (
+        <InlinedDataframeList items={elementsByType.dataframe} />
       ) : null}
     </Stack>
   );

--- a/frontend/src/components/atoms/elements/index.ts
+++ b/frontend/src/components/atoms/elements/index.ts
@@ -1,4 +1,5 @@
 export { AudioElement } from './Audio';
+export { DataframeElement } from './Dataframe';
 export { Element } from './Element';
 export { ElementSideView } from './ElementSideView';
 export { ElementView } from './ElementView';
@@ -12,6 +13,7 @@ export { VideoElement } from './Video';
 
 // Inlined
 export { InlinedAudioList } from './InlinedAudioList';
+export { InlinedDataframeList } from './InlinedDataframeList';
 export { InlinedElements } from './InlinedElements';
 export { InlinedFileList } from './InlinedFileList';
 export { InlinedImageList } from './InlinedImageList';

--- a/libs/react-client/src/types/element.ts
+++ b/libs/react-client/src/types/element.ts
@@ -6,7 +6,8 @@ export type IElement =
   | IAudioElement
   | IVideoElement
   | IFileElement
-  | IPlotlyElement;
+  | IPlotlyElement
+  | IDataframeElement;
 
 export type IMessageElement =
   | IImageElement
@@ -15,7 +16,8 @@ export type IMessageElement =
   | IAudioElement
   | IVideoElement
   | IFileElement
-  | IPlotlyElement;
+  | IPlotlyElement
+  | IDataframeElement;
 
 export type ElementType = IElement['type'];
 export type IElementSize = 'small' | 'medium' | 'large';
@@ -69,3 +71,5 @@ export interface IFileElement extends TMessageElement<'file'> {
 export interface IPlotlyElement extends TMessageElement<'plotly'> {}
 
 export interface ITasklistElement extends TElement<'tasklist'> {}
+
+export interface IDataframeElement extends TMessageElement<'dataframe'> {}


### PR DESCRIPTION
This is an attempt to address issue #1350, and it may serve as a basis for future improvements and better implementations.

To use this functionality, follow these steps:

1. Convert the DataFrame to JSON: Use the to_json() method with the "split" orientation to convert the DataFrame into a JSON string, formatting the data for display.
2. Create a DataFrame Element: Pass the JSON string as the content parameter when creating the DataFrame element.
3. Append and Send: Append the DataFrame element to a message and send it for display.
    
```python
import chainlit as cl
import pandas as pd


@cl.on_chat_start
async def start():
    iris = pd.read_csv(
        "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv"
    )

    json_dataframe = iris.to_json(orient="split")

    elements = [
        cl.Dataframe(content=json_dataframe, display="inline", name="Dataframe")
    ]

    await cl.Message(content="This message has a Dataframe", elements=elements).send()

```