### PR TITLE
Don't run code on importing data module

### DIFF
--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -2,7 +2,6 @@ import os
 from typing import Optional
 
 from .base import BaseDataLayer
-from .literalai import LiteralDataLayer
 from .utils import (
     queue_until_user_message as queue_until_user_message,  # TODO: Consider deprecating re-export.; Redundant alias tells type checkers to STFU.
 )
@@ -10,11 +9,17 @@ from .utils import (
 _data_layer: Optional[BaseDataLayer] = None
 
 
-if api_key := os.environ.get("LITERAL_API_KEY"):
-    # support legacy LITERAL_SERVER variable as fallback
-    server = os.environ.get("LITERAL_API_URL") or os.environ.get("LITERAL_SERVER")
-    _data_layer = LiteralDataLayer(api_key=api_key, server=server)
-
-
 def get_data_layer():
+    global _data_layer
+
+    if not _data_layer:
+        if api_key := os.environ.get("LITERAL_API_KEY"):
+            from .literalai import LiteralDataLayer
+
+            # support legacy LITERAL_SERVER variable as fallback
+            server = os.environ.get("LITERAL_API_URL") or os.environ.get(
+                "LITERAL_SERVER"
+            )
+            _data_layer = LiteralDataLayer(api_key=api_key, server=server)
+
     return _data_layer


### PR DESCRIPTION
This avoids import loops and is a stepping stone towards pluggable data layers.