### PR TITLE
1.3.0rc0 Bug Fix | SQLAlchemy | Properly quote identifier

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -155,7 +155,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def _get_user_id_by_thread(self, thread_id: str) -> Optional[str]:
         if self.show_logger:
             logger.info(f"SQLAlchemy: _get_user_id_by_thread, thread_id={thread_id}")
-        query = "SELECT userId FROM threads WHERE id = :thread_id"
+        query = """SELECT "userId" FROM threads WHERE id = :thread_id"""
         parameters = {"thread_id": thread_id}
         result = await self.execute_sql(query=query, parameters=parameters)
         if result:


### PR DESCRIPTION
Fixes the SQLAlchemy bug raised in #1394 

Bug introduced in @1319 where `userId` wasn't encased with double-quotes so the SQL engine converts `userId` to `userid` which doesn't exist. Encasing with double-quotes fixes this issue.
