### PR TITLE
Make Auto-Login Behavior Configurable

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -39,6 +39,8 @@ class GithubOAuthProvider(OAuthProvider):
             "scope": "user:email",
             "prompt": "consent",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -98,6 +100,8 @@ class GoogleOAuthProvider(OAuthProvider):
             "access_type": "offline",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -166,6 +170,8 @@ class AzureADOAuthProvider(OAuthProvider):
             "response_mode": "query",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -251,6 +257,8 @@ class AzureADHybridOAuthProvider(OAuthProvider):
             "nonce": nonce,
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -331,6 +339,8 @@ class OktaOAuthProvider(OAuthProvider):
             "response_mode": "query",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     def get_authorization_server_path(self):
         if not self.authorization_server_id:
@@ -403,6 +413,8 @@ class Auth0OAuthProvider(OAuthProvider):
             "audience": f"{self.original_domain}/userinfo",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -461,6 +473,8 @@ class DescopeOAuthProvider(OAuthProvider):
             "audience": f"{self.domain}/userinfo",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -520,6 +534,8 @@ class AWSCognitoOAuthProvider(OAuthProvider):
             "scope": "openid profile email",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -589,6 +605,8 @@ class GitlabOAuthProvider(OAuthProvider):
             "response_type": "code",
             "prompt": "login",
         }
+        if os.environ.get("OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT", "false").lower() == "true":
+            self.authorize_params.pop("prompt", None)
 
     async def get_token(self, code: str, url: str):
         payload = {


### PR DESCRIPTION
This PR makes #1362 configurable through a new `OAUTH_DISABLE_REAUTHENTICATION_ON_LOGOUT` environment variable. If this env var isn't set, or it's anything other than `true` then the current behavior in #1362 is used, so that developers don't need to do anything, but at least this behavior is controllable.

The authentication behavior before #1362 would auto-login users without user interaction. The behavior after #1362 is that my users need to re-enter their username/password and confirm 2FA on their phone. Furthermore my coporate users login to their device with a PIN so most don't remember their password. This has led to a poor experience.

Ideally, I'd like to see the behavior require the user to click the "Sign in with Microsoft" button (or different auth providers if there's multiple like #1362 suggests) to auto-login via SSO. I don't know where this auto-login trigger is coming from and how to remove, so I'm open to suggestions!
![image](https://github.com/user-attachments/assets/f73920c1-8247-4300-b357-2617f9d759ce)


