### PR TITLE
[Add] Implement Slack Socket Mode support

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -131,6 +131,13 @@ async def lifespan(app: FastAPI):
 
         discord_task = asyncio.create_task(client.start(discord_bot_token))
 
+    slack_task = None
+
+    # Slack Socket Handler if env variable SLACK_APP_TOKEN is set
+    if os.environ.get("SLACK_BOT_TOKEN") and os.environ.get("SLACK_WEBSOCKET_TOKEN"):
+        from chainlit.slack.app import start_socket_mode
+        slack_task = asyncio.create_task(start_socket_mode())
+
     try:
         yield
     finally:
@@ -143,6 +150,10 @@ async def lifespan(app: FastAPI):
             if discord_task:
                 discord_task.cancel()
                 await discord_task
+
+            if slack_task:
+                slack_task.cancel()
+                await slack_task
         except asyncio.exceptions.CancelledError:
             pass
 
@@ -230,10 +241,10 @@ app.mount(
 
 
 # -------------------------------------------------------------------------------
-#                               SLACK HANDLER
+#                               SLACK HTTP HANDLER
 # -------------------------------------------------------------------------------
 
-if os.environ.get("SLACK_BOT_TOKEN") and os.environ.get("SLACK_SIGNING_SECRET"):
+if os.environ.get("SLACK_BOT_TOKEN") and os.environ.get("SLACK_SIGNING_SECRET") and not os.environ.get("SLACK_WEBSOCKET_TOKEN"):
     from chainlit.slack.app import slack_app_handler
 
     @router.post("/slack/events")

--- a/backend/chainlit/slack/app.py
+++ b/backend/chainlit/slack/app.py
@@ -19,6 +19,7 @@ from chainlit.types import Feedback
 from chainlit.user import PersistedUser, User
 from chainlit.user_session import user_session
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
+from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
 
 
@@ -124,6 +125,16 @@ slack_app = AsyncApp(
     token=os.environ.get("SLACK_BOT_TOKEN"),
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
 )
+
+
+async def start_socket_mode():
+    """
+    Initializes and starts the Slack app in Socket Mode asynchronously.
+
+    Uses the SLACK_APP_TOKEN from environment variables to authenticate.
+    """
+    handler = AsyncSocketModeHandler(slack_app, os.environ.get("SLACK_WEBSOCKET_TOKEN"))
+    await handler.start_async()
 
 
 @trace

--- a/backend/chainlit/slack_websocket_test.py
+++ b/backend/chainlit/slack_websocket_test.py
@@ -1,0 +1,18 @@
+# This is a simple example to test the slack websocket handler.
+# To initiate the websocket dont forget to set the variables:
+#   - SLACK_BOT_TOKEN
+#   - SLACK_SIGNING_SECRET
+#   - SLACK_WEBSOCKET_TOKEN <- this one dictates if websocket or http handler
+
+from chainlit import Message, on_message, user_session
+
+
+@on_message
+async def main(message: Message):
+    client_type = user_session.get("client_type")
+    if client_type == "slack":
+        user_email = user_session.get("user").metadata.get("email")
+        print(f"Received a message from: {user_email}")
+        await Message(
+            content=f"Hi {user_email}, I have received the following message:\n{message.content}",
+        ).send()


### PR DESCRIPTION
## Description
This PR introduces support for Slack Socket Mode, enabling real-time message processing using websockets. This feature enhances the Slack integration by allowing for more efficient and responsive communication, and a way to bypass ingress restrictive networks.

## Changes
- Added Slack Socket Mode handler in `server.py`
- Created `start_socket_mode` function in `slack/app.py`
- Implemented conditional logic to use Socket Mode when `SLACK_WEBSOCKET_TOKEN` is set
- Added an example script `slack_websocket_test.py` for testing the Slack websocket handler

## How to Test
1. Set the following environment variables:
   - `SLACK_BOT_TOKEN`
   - `SLACK_SIGNING_SECRET`
   - `SLACK_WEBSOCKET_TOKEN`
2. Run the application and verify that the Slack integration connects using Socket Mode
3. Test sending messages through Slack and ensure they are processed correctly

## Additional Notes
- The existing HTTP handler remains active when only `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` are provided
- When `SLACK_WEBSOCKET_TOKEN` is set, the application will prioritize Socket Mode over the HTTP handler