### PR TITLE
OAuth prompt configurable through environment

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -16,7 +16,7 @@ class OAuthProvider:
     client_secret: str
     authorize_url: str
     authorize_params: Dict[str, str]
-    default_prompt: Optional[str]
+    default_prompt: Optional[str] = None
 
     def is_configured(self):
         return all([os.environ.get(env) for env in self.env])

--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -16,6 +16,7 @@ class OAuthProvider:
     client_secret: str
     authorize_url: str
     authorize_params: Dict[str, str]
+    default_prompt: Optional[str]
 
     def is_configured(self):
         return all([os.environ.get(env) for env in self.env])
@@ -25,6 +26,21 @@ class OAuthProvider:
 
     async def get_user_info(self, token: str) -> Tuple[Dict[str, str], User]:
         raise NotImplementedError()
+
+    def get_env_prefix(self) -> str:
+        """Return environment prefix, like AZURE_AD."""
+
+        return self.id.replace("-", "_").upper()
+
+    def get_prompt(self) -> Optional[str]:
+        """Return OAuth prompt param."""
+        if prompt := os.environ.get(f"OAUTH_{self.get_env_prefix()}_PROMPT"):
+            return prompt
+
+        if prompt := os.environ.get("OAUTH_PROMPT"):
+            return prompt
+
+        return self.default_prompt
 
 
 class GithubOAuthProvider(OAuthProvider):
@@ -37,8 +53,10 @@ class GithubOAuthProvider(OAuthProvider):
         self.client_secret = os.environ.get("OAUTH_GITHUB_CLIENT_SECRET")
         self.authorize_params = {
             "scope": "user:email",
-            "prompt": "consent",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -96,8 +114,10 @@ class GoogleOAuthProvider(OAuthProvider):
             "scope": "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
             "response_type": "code",
             "access_type": "offline",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -164,8 +184,10 @@ class AzureADOAuthProvider(OAuthProvider):
             "response_type": "code",
             "scope": "https://graph.microsoft.com/User.Read",
             "response_mode": "query",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -249,8 +271,10 @@ class AzureADHybridOAuthProvider(OAuthProvider):
             "scope": "https://graph.microsoft.com/User.Read https://graph.microsoft.com/openid",
             "response_mode": "form_post",
             "nonce": nonce,
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -329,8 +353,10 @@ class OktaOAuthProvider(OAuthProvider):
             "response_type": "code",
             "scope": "openid profile email",
             "response_mode": "query",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     def get_authorization_server_path(self):
         if not self.authorization_server_id:
@@ -401,8 +427,10 @@ class Auth0OAuthProvider(OAuthProvider):
             "response_type": "code",
             "scope": "openid profile email",
             "audience": f"{self.original_domain}/userinfo",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -459,8 +487,10 @@ class DescopeOAuthProvider(OAuthProvider):
             "response_type": "code",
             "scope": "openid profile email",
             "audience": f"{self.domain}/userinfo",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -518,8 +548,10 @@ class AWSCognitoOAuthProvider(OAuthProvider):
             "response_type": "code",
             "client_id": self.client_id,
             "scope": "openid profile email",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {
@@ -587,8 +619,10 @@ class GitlabOAuthProvider(OAuthProvider):
         self.authorize_params = {
             "scope": "openid profile email",
             "response_type": "code",
-            "prompt": "login",
         }
+
+        if prompt := self.get_prompt():
+            self.authorize_params["prompt"] = prompt
 
     async def get_token(self, code: str, url: str):
         payload = {


### PR DESCRIPTION
Use `OAUTH_<PROVIDER>_PROMPT` or `OAUTH_PROMPT` to override behaviour.
E.g. `OAUTH_PROMPT=login` to always require login, allowing for re-login after logout, even when only a single oauth provider is configured, without breaking prior user expecations.

Supersedes #1419 and #1362, requires documentation. 

Would be great to get this into 1.3.0 as shipping as-is would break some SSO users and require release of `1.4.0` (e.g. another breaking change) to fix it.