### PR TITLE
Auto-fit cl.Dataframe() to content

### DIFF
--- a/frontend/src/components/atoms/elements/InlinedDataframeList.tsx
+++ b/frontend/src/components/atoms/elements/InlinedDataframeList.tsx
@@ -16,7 +16,7 @@ const InlinedDataframeList = ({ items }: Props) => (
           key={i}
           style={{
             height: 450,
-            maxWidth: '650px'
+            maxWidth: 'fit-content'
           }}
         >
           <DataframeElement element={element} />


### PR DESCRIPTION
Changes Dataframe width to fit-content instead of hardcoded 650px to better handle different sized dataframes and fill out the UI.

Before:
![image](https://github.com/user-attachments/assets/100fd592-8af9-4156-89b8-4ed22f51cdac)

After:
![image](https://github.com/user-attachments/assets/e05cf75e-7d04-4820-9b96-d6defb67e0c0)


Builds on #1373 . Awesome job getting this going @desertproject ! Streamlit's implementation is envious (export to csv, copy/paste, full screen, etc.) but after digging into their code it looks completely manual and complex! It's a bit suprising there's not a library for displaying Pandas dataframes out there with these features!
