### PR TITLE
Remove space in license string.

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 description = "Build Conversational AI."
 authors = ["Willy Douhard", "Dan Andre Constantini"]
-license = " Apache-2.0"
+license = "Apache-2.0"
 homepage = "https://chainlit.io/"
 documentation = "https://docs.chainlit.io/"
 classifiers = [


### PR DESCRIPTION
There was a prepending space in the license string... 
<img width="289" alt="image" src="https://github.com/user-attachments/assets/182478ac-0b0e-4c2d-a1e5-cb987b71283d">
