### PR TITLE
HOT FIX - Fixes Elements by reverting bug in #1441

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -881,7 +881,7 @@ async def upload_file(
 async def get_file(
     file_id: str,
     session_id: str,
-    current_user: Annotated[Union[User, PersistedUser], Depends(get_current_user)],
+    # current_user: Annotated[Union[User, PersistedUser], Depends(get_current_user)], #TODO: Causes 401 error. See https://github.com/Chainlit/chainlit/issues/1472
 ):
     """Get a file from the session files directory."""
 
@@ -895,12 +895,13 @@ async def get_file(
             detail="Unauthorized",
         )
 
-    if current_user:
-        if not session.user or session.user.identifier != current_user.identifier:
-            raise HTTPException(
-                status_code=401,
-                detail="You are not authorized to download files from this session",
-            )
+     #TODO: Causes 401 error. See https://github.com/Chainlit/chainlit/issues/1472
+    # if current_user:
+    #     if not session.user or session.user.identifier != current_user.identifier:
+    #         raise HTTPException(
+    #             status_code=401,
+    #             detail="You are not authorized to download files from this session",
+    #         )
 
     if file_id in session.files:
         file = session.files[file_id]


### PR DESCRIPTION
The `project/file/{file_id}` endpoint always returns 401 HTTP error. This prevent any Element from being displayed. Fixes https://github.com/Chainlit/chainlit/issues/1472

> [!IMPORTANT]  
> Users should not upgrade to versions 1.3.0 or 2.0.dev1

This comments out the problematic code and adds TODOs. This reopens #1101 and #1438 .