### PR TITLE
Include current URL in the message payload

### DIFF
--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -59,7 +59,7 @@ class MessageBase(ABC):
     @classmethod
     def from_dict(self, _dict: StepDict):
         type = _dict.get("type", "assistant_message")
-        message = Message(
+        return Message(
             id=_dict["id"],
             parent_id=_dict.get("parentId"),
             created_at=_dict["createdAt"],
@@ -67,9 +67,8 @@ class MessageBase(ABC):
             author=_dict.get("name", config.ui.name),
             type=type,  # type: ignore
             language=_dict.get("language"),
+            metadata=_dict.get("metadata", {}),
         )
-
-        return message
 
     def to_dict(self) -> StepDict:
         _dict: StepDict = {

--- a/libs/copilot/src/components/InputBox.tsx
+++ b/libs/copilot/src/components/InputBox.tsx
@@ -45,7 +45,8 @@ const InputBox = memo(
           name: user?.identifier || 'User',
           type: 'user_message',
           output: msg,
-          createdAt: new Date().toISOString()
+          createdAt: new Date().toISOString(),
+          metadata: {location: window.location.href},
         };
 
         setInputHistory((old) => {

--- a/libs/react-client/src/types/step.ts
+++ b/libs/react-client/src/types/step.ts
@@ -30,6 +30,7 @@ export interface IStep {
   language?: string;
   streaming?: boolean;
   steps?: IStep[];
+  metadata?: Record<string, any>;
   //legacy
   indent?: number;
 }


### PR DESCRIPTION
Backport https://github.com/Chainlit/chainlit/pull/1403 already merged from main/development branch 2.X into releases/1.3

---

When using chainlit in copilot mode it is pretty useful to have the context of the current location/URL where the user is. This context may be helpful to be used for further processing the question/message by including it in the prompt

With this PR the URL is included in the metadata of the message for further processing in `on_message(message: cl.Message)` call