### PR TITLE
fix #1230 Incorrect message ordering in UI

### DIFF
--- a/libs/react-client/src/types/file.ts
+++ b/libs/react-client/src/types/file.ts
@@ -22,4 +22,5 @@ export interface IAsk {
     timeout: number;
   } & FileSpec &
     ActionSpec;
+  parentId?: string;
 }

--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -118,6 +118,7 @@ const useChatInteract = () => {
   const replyMessage = useCallback(
     (message: IStep) => {
       if (askUser) {
+        if (askUser.parentId) message.parentId = askUser.parentId;
         setMessages((oldMessages) => addMessage(oldMessages, message));
         askUser.callback(message);
       }

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -277,7 +277,7 @@ const useChatSession = () => {
       );
 
       socket.on('ask', ({ msg, spec }, callback) => {
-        setAskUser({ spec, callback });
+        setAskUser({ spec, callback, parentId: msg.parentId });
         setMessages((oldMessages) => addMessage(oldMessages, msg));
 
         setLoading(false);


### PR DESCRIPTION
AskUserMessage answer was added in frontend message memory without parentId resulting in wrongly ordered messages.

Detail in #1230