### PR TITLE
Allow running commit hooks outside of poetry/venv.

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,6 +2,10 @@
 module.exports = {
   '**/*.{js,jsx,ts,tsx}': ['npx prettier --write', 'npx eslint --fix'],
   '**/*.{ts,tsx}': [() => 'tsc --skipLibCheck --noEmit'],
-  '**/*.py': ['ruff check --fix', 'ruff format', () => 'pnpm run lintPython'],
+  '**/*.py': [
+    'cd backend && poetry run ruff check --fix',
+    'cd backend && poetry run ruff format',
+    () => 'pnpm run lintPython'
+  ],
   '.github/{workflows,actions}/**': ['actionlint']
 };


### PR DESCRIPTION
The new commit hooks were assuming we were inside a poetry venv. This PR fixes that.