### PR TITLE
Import `Field` from `pydantic` instead of `pydantic.dataclasses`

### DIFF
--- a/backend/chainlit/action.py
+++ b/backend/chainlit/action.py
@@ -2,7 +2,8 @@ import uuid
 from typing import Optional
 
 from dataclasses_json import DataClassJsonMixin
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 from chainlit.context import context
 from chainlit.telemetry import trace_event

--- a/backend/chainlit/chat_settings.py
+++ b/backend/chainlit/chat_settings.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 from chainlit.context import context
 from chainlit.input_widget import InputWidget

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -18,7 +18,8 @@ from typing import (
 
 import tomli
 from dataclasses_json import DataClassJsonMixin
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 from starlette.datastructures import Headers
 
 from chainlit.data.base import BaseDataLayer

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -16,7 +16,8 @@ from typing import (
 )
 
 import filetype
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 from syncer import asyncio
 
 from chainlit.context import context

--- a/backend/chainlit/input_widget.py
+++ b/backend/chainlit/input_widget.py
@@ -2,7 +2,8 @@ from abc import abstractmethod
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 from chainlit.types import InputWidgetType
 

--- a/backend/chainlit/user.py
+++ b/backend/chainlit/user.py
@@ -1,7 +1,8 @@
 from typing import Dict, Literal, Optional, TypedDict
 
 from dataclasses_json import DataClassJsonMixin
-from pydantic.dataclasses import Field, dataclass
+from pydantic import Field
+from pydantic.dataclasses import dataclass
 
 Provider = Literal[
     "credentials",


### PR DESCRIPTION
`Field` just so happens to be imported internally by the `pydantic.dataclasses` module, but this can change at any time.