### PR TITLE
Configuration feature: Enables Apple home screen touch icon

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -136,6 +136,9 @@ cot = "full"
 # Specify a custom meta image url.
 # custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
 
+# Specify a custom ios home screen bookmark icon url.
+# custom_bookmark_icon = "/public/bookmark.png"
+
 # Specify a custom build directory for the frontend.
 # This can be used to customize the frontend code.
 # Be careful: If this is a relative path, it should not start with a slash.
@@ -266,6 +269,8 @@ class UISettings(DataClassJsonMixin):
     custom_font: Optional[str] = None
     # Optional custom meta tag for image preview
     custom_meta_image_url: Optional[str] = None
+    # Optional custom ios home screen bookmark icon
+    custom_bookmark_icon: Optional[str] = None
     # Optional custom build directory for the frontend
     custom_build: Optional[str] = None
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -316,6 +316,11 @@ def get_html_template():
     if config.ui.custom_font:
         font = f"""<link rel="stylesheet" href="{config.ui.custom_font}">"""
 
+    if config.ui.custom_bookmark_icon:
+        tags += (
+            f"""<link rel="apple-touch-icon" href="{config.ui.custom_bookmark_icon}">"""
+        )
+
     index_html_file_path = os.path.join(build_dir, "index.html")
 
     with open(index_html_file_path, encoding="utf-8") as f:

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -37,6 +37,7 @@ export interface IChainlitConfig {
     custom_js?: string;
     custom_font?: string;
     custom_meta_image_url?: string;
+    custom_bookmark_icon?: string;
   };
   features: {
     spontaneous_file_upload?: {


### PR DESCRIPTION
This additional setting allows chainlit to look better when used as a progressive web app on ios devices. Adds support for apple-touch-icons