### PR TITLE
Remove numpy depdendency

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -5722,4 +5722,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "2964359572fb5dc66ff4428b72b89b9154b71f8192a4783887c1073faee7085e"
+content-hash = "4a07f193228d414016f6b0c2be79c7f2d80a440b2978dfe9846e68c7fc06601e"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,7 +62,6 @@ lazify = "^0.4.0"
 packaging = "^23.1"
 python-multipart = "^0.0.9"
 pyjwt = "^2.8.0"
-numpy = "^1.26"
 
 [tool.poetry.group.tests]
 optional = true


### PR DESCRIPTION
I can't find where we're explicitly installing numpy, so propose to remove it as a (bulky!) dependency.