### PR TITLE
Add refresh token support for Azure AD OAuth provider

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -207,10 +207,12 @@ class AzureADOAuthProvider(OAuthProvider):
             json = response.json()
 
             token = json["access_token"]
+            refresh_token = json.get("refresh_token")
             if not token:
                 raise HTTPException(
                     status_code=400, detail="Failed to get the access token"
                 )
+            self._refresh_token = refresh_token
             return token
 
     async def get_user_info(self, token: str):
@@ -239,7 +241,7 @@ class AzureADOAuthProvider(OAuthProvider):
 
             user = User(
                 identifier=azure_user["userPrincipalName"],
-                metadata={"image": azure_user.get("image"), "provider": "azure-ad"},
+                metadata={"image": azure_user.get("image"), "provider": "azure-ad", "refresh_token": getattr(self, "_refresh_token", None)},
             )
             return (azure_user, user)
 

--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -183,7 +183,7 @@ class AzureADOAuthProvider(OAuthProvider):
         self.authorize_params = {
             "tenant": os.environ.get("OAUTH_AZURE_AD_TENANT_ID"),
             "response_type": "code",
-            "scope": "https://graph.microsoft.com/User.Read",
+            "scope": "https://graph.microsoft.com/User.Read offline_access",
             "response_mode": "query",
         }
 


### PR DESCRIPTION
## Description
This PR adds support for handling refresh tokens in the Azure AD OAuth provider. This enables applications to maintain long-term access to Azure AD resources without requiring users to re-authenticate.

## Changes
- Added refresh token retrieval in `get_token` method
- Store refresh token in provider instance
- Include refresh token in user metadata
- Added `offline_access` scope to enable refresh token support

## Testing
I have tested these changes by:
- Authenticating with Azure AD
- Verifying refresh token is properly retrieved
- Confirming refresh token is accessible in user metadata