### PR TITLE
feat: source maps

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    sourcemap: true
+  },
   plugins: [react(), tsconfigPaths(), svgr()],
   resolve: {
     alias: {

--- a/libs/copilot/tsconfig.json
+++ b/libs/copilot/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,

--- a/libs/react-client/tsconfig.json
+++ b/libs/react-client/tsconfig.json
@@ -23,7 +23,7 @@
     "preserveConstEnums": true,
     "removeComments": true,
     "skipLibCheck": true,
-    "sourceMap": false,
+    "sourceMap": true,
     "strictNullChecks": true,
     "target": "es5",
     "types": ["node", "react"],


### PR DESCRIPTION
This PR adds source map support to the Chainlit frontend and the react-client library.

Source maps make debugging easier, particularly in production environments. They allow you to debug pre-compiled code without needing to deploy a debug version or run Chainlit from the source code.

This PR enables source map generation as separate files, ensuring it does not affect the resulting bundle, package, or wheel size, except for a single line added at the end of each file to reference the corresponding source map file.

You can learn more about source maps [here](https://web.dev/articles/source-maps) and the settings used [here](https://v3.vitejs.dev/config/build-options.html#build-sourcemap) and [here](https://www.typescriptlang.org/tsconfig/#sourceMap).

After this PR, the build system may generate numerous warnings about missing source maps and incorrectly (though this doesn't seem to have much impact) add the source map link to files twice, with the wrong file name the first time (`out.js.map` instead of `index.js.map`).

The first issue can be resolved by upgrading to `vite-plugin-react-swc` version 3.7.1 or later, and the second by upgrading `tsup` to version 8.1.2 or later.

Unfortunately, I wasn't able to get source maps working for `libs/*` when they are included in the `frontend` app compiled in production mode. This seems to be an issue with Vite/React/SWC, as it affects all dependencies, not just `libs/*`. However, source maps for `libs/*` are generated correctly and can be used in other apps that depend on these libraries.

Feel free to edit this PR if needed as I allowed edits by maintainers.