### PR TITLE
feat: add http_cookie to WebsocketSession and UserSession

### DIFF
--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -64,6 +64,8 @@ class BaseSession:
         chat_profile: Optional[str] = None,
         # Origin of the request
         http_referer: Optional[str] = None,
+        # Cookie
+        http_cookie: Optional[str] = None,
     ):
         if thread_id:
             self.thread_id_to_resume = thread_id
@@ -75,6 +77,7 @@ class BaseSession:
         self.user_env = user_env or {}
         self.chat_profile = chat_profile
         self.http_referer = http_referer
+        self.http_cookie = http_cookie
 
         self.files: Dict[str, FileDict] = {}
 
@@ -167,6 +170,8 @@ class HTTPSession(BaseSession):
         user_env: Optional[Dict[str, str]] = None,
         # Origin of the request
         http_referer: Optional[str] = None,
+        # Cookie
+        http_cookie: Optional[str] = None,
     ):
         super().__init__(
             id=id,
@@ -176,6 +181,7 @@ class HTTPSession(BaseSession):
             client_type=client_type,
             user_env=user_env,
             http_referer=http_referer,
+            http_cookie=http_cookie,
         )
 
     def delete(self):
@@ -226,6 +232,8 @@ class WebsocketSession(BaseSession):
         languages: Optional[str] = None,
         # Origin of the request
         http_referer: Optional[str] = None,
+        # Cookie
+        http_cookie: Optional[str] = None,
     ):
         super().__init__(
             id=id,
@@ -236,6 +244,7 @@ class WebsocketSession(BaseSession):
             client_type=client_type,
             chat_profile=chat_profile,
             http_referer=http_referer,
+            http_cookie=http_cookie,
         )
 
         self.socket_id = socket_id

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -136,6 +136,7 @@ async def connect(sid, environ, auth):
 
     client_type = auth.get("clientType")
     http_referer = environ.get("HTTP_REFERER")
+    http_cookie = environ.get("HTTP_COOKIE")
     url_encoded_chat_profile = auth.get("chatProfile")
     chat_profile = (
         unquote(url_encoded_chat_profile) if url_encoded_chat_profile else None
@@ -154,6 +155,7 @@ async def connect(sid, environ, auth):
         thread_id=auth.get("threadId"),
         languages=environ.get("HTTP_ACCEPT_LANGUAGE"),
         http_referer=http_referer,
+        http_cookie=http_cookie,
     )
 
     trace_event("connection_successful")

--- a/backend/chainlit/user_session.py
+++ b/backend/chainlit/user_session.py
@@ -29,6 +29,7 @@ class UserSession:
         user_session["chat_profile"] = context.session.chat_profile
         user_session["http_referer"] = context.session.http_referer
         user_session["client_type"] = context.session.client_type
+        user_session["http_cookie"] = context.session.http_cookie
 
         if isinstance(context.session, WebsocketSession):
             user_session["languages"] = context.session.languages

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,7 @@ def mock_session_factory(persisted_test_user: PersistedUser) -> Callable[..., Mo
         mock.chat_settings = kwargs.get("chat_settings", {})
         mock.chat_profile = kwargs.get("chat_profile", None)
         mock.http_referer = kwargs.get("http_referer", None)
+        mock.http_cookie = kwargs.get("http_cookie", None)
         mock.client_type = kwargs.get("client_type", "webapp")
         mock.languages = kwargs.get("languages", ["en"])
         mock.thread_id = kwargs.get("thread_id", "test_thread_id")

--- a/backend/tests/test_user_session.py
+++ b/backend/tests/test_user_session.py
@@ -13,3 +13,4 @@ async def test_user_session_set_get(mock_chainlit_context, user_session):
         assert user_session.get("id") == context.session.id
         assert user_session.get("env") == context.session.user_env
         assert user_session.get("languages") == context.session.languages
+        assert user_session.get("http_cookie") == context.session.http_cookie


### PR DESCRIPTION
This is a partial solution to this issue. https://github.com/Chainlit/chainlit/issues/1213

Adding access to `http_cookie` to `WebSocketSession` and `UserSession` facilitates the use of chainlit in enterprise applications that deploy multiple services under the same domain.

## Pull Request Summary

This pull request introduces support for handling HTTP cookies in the `backend/chainlit` module. The changes primarily involve adding a new `http_cookie` parameter to various methods and ensuring that this parameter is properly propagated throughout the session handling and testing code.

### Session handling updates:

* [`backend/chainlit/session.py`](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R67-R68): Added `http_cookie` parameter to the `__init__` method of several classes to handle HTTP cookies. [[1]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R67-R68) [[2]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R80) [[3]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R173-R174) [[4]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R184) [[5]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R235-R236) [[6]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R247)
* [`backend/chainlit/socket.py`](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R139): Added `http_cookie` extraction from the environment and passed it to the session initialization. [[1]](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R139) [[2]](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R158)
* [`backend/chainlit/user_session.py`](diffhunk://#diff-f147b9aeed6d2490967c79bf10034b4b7ada1b9e6f66cd308657318573de2f3cR32): Updated `get` method to include `http_cookie` in the user session dictionary.

### Testing updates:

* [`backend/tests/conftest.py`](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR38): Updated `create_mock_session` to include the `http_cookie` parameter.
* [`backend/tests/test_user_session.py`](diffhunk://#diff-cec4c2a07ee087d892424c58c36644b847f70e8b75fcfc213ab2e0257e14cb11R16): Added assertion to check `http_cookie` in the `test_user_session_set_get` test case.