### PR TITLE
feat: Allow HTML for markdown_description in Welcome Screen

### DIFF
--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -31,6 +31,9 @@ export default function WelcomeScreen(props: Props) {
 
   const chatProfiles = config?.chatProfiles;
 
+  const allowHtml = config?.features?.unsafe_allow_html;
+  const latex = config?.features?.latex;
+
   useEffect(() => {
     setIsVisible(true);
   }, []);
@@ -52,7 +55,9 @@ export default function WelcomeScreen(props: Props) {
               }
             />
             {currentChatProfile?.markdown_description ? (
-              <Markdown>{currentChatProfile.markdown_description}</Markdown>
+              <Markdown allowHtml={allowHtml} latex={latex}>
+                {currentChatProfile.markdown_description}
+              </Markdown>
             ) : null}
           </div>
         );


### PR DESCRIPTION
This pull request includes changes to the `WelcomeScreen` component to add support for allowing HTML and LaTeX in markdown descriptions. This code was copied from [ChatProfiles.tsx](https://github.com/Chainlit/chainlit/blob/main/frontend/src/components/header/ChatProfiles.tsx) where it's used for the over/popover.

Enhancements to markdown rendering:

* [`frontend/src/components/chat/WelcomeScreen.tsx`](diffhunk://#diff-16a9d38c0b482fad7d0a31014364eba7dfe107d5ec300041961a83ff1df8b07dR34-R36): Introduced new configuration options `allowHtml` and `latex` to control the rendering of HTML and LaTeX in markdown descriptions.
* [`frontend/src/components/chat/WelcomeScreen.tsx`](diffhunk://#diff-16a9d38c0b482fad7d0a31014364eba7dfe107d5ec300041961a83ff1df8b07dL55-R60): Updated the `Markdown` component to utilize the new `allowHtml` and `latex` properties for rendering the markdown description.