### PR TITLE
fix: data layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Errors in thread resume (like thread not found) now properly redirects to the the home page
 - Elements like Dataframe, Plotly or text should now load correctly from cloud storages
 - AskFileMessage is now usable even if spontaneous uploads are disabled
+- Remove element objects from cloud storage on thread removal (Official & SQLAlchemy data layers)
+- Fix custom element `props` storage for SQL Alchemy data layer
 
 ## [2.0.1] - 2025-01-09
 

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -262,6 +262,14 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def delete_thread(self, thread_id: str):
         if self.show_logger:
             logger.info(f"SQLAlchemy: delete_thread, thread_id={thread_id}")
+
+        elements_query = """SELECT * FROM elements WHERE "threadId" = :id"""
+        elements = await self.execute_sql(elements_query, {"id": thread_id})
+
+        if self.storage_provider is not None and isinstance(elements, list):
+            for elem in filter(lambda x: x["objectKey"], elements):
+                await self.storage_provider.delete_file(object_key=elem["objectKey"])
+
         # Delete feedbacks/elements/steps/thread
         feedbacks_query = """DELETE FROM feedbacks WHERE "forId" IN (SELECT "id" FROM steps WHERE "threadId" = :id)"""
         elements_query = """DELETE FROM elements WHERE "threadId" = :id"""
@@ -439,7 +447,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 url=element_dict.get("url"),
                 objectKey=element_dict.get("objectKey"),
                 name=element_dict["name"],
-                props=element_dict.get("props"),
+                props=json.loads(element_dict.get("props", "{}")),
                 display=element_dict["display"],
                 size=element_dict.get("size"),
                 language=element_dict.get("language"),
@@ -504,7 +512,10 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
         element_dict["url"] = uploaded_file.get("url")
         element_dict["objectKey"] = uploaded_file.get("object_key")
+
         element_dict_cleaned = {k: v for k, v in element_dict.items() if v is not None}
+        if "props" in element_dict_cleaned:
+            element_dict_cleaned["props"] = json.dumps(element_dict_cleaned["props"])
 
         columns = ", ".join(f'"{column}"' for column in element_dict_cleaned.keys())
         placeholders = ", ".join(f":{column}" for column in element_dict_cleaned.keys())
@@ -515,8 +526,21 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     async def delete_element(self, element_id: str, thread_id: Optional[str] = None):
         if self.show_logger:
             logger.info(f"SQLAlchemy: delete_element, element_id={element_id}")
+
+        query = """SELECT * FROM elements WHERE "id" = :id"""
+        elements = await self.execute_sql(query, {"id": element_id})
+
+        if (
+            self.storage_provider is not None
+            and isinstance(elements, list)
+            and len(elements) > 0
+            and elements[0]["objectKey"]
+        ):
+            await self.storage_provider.delete_file(object_key=elements[0]["objectKey"])
+
         query = """DELETE FROM elements WHERE "id" = :id"""
         parameters = {"id": element_id}
+
         await self.execute_sql(query=query, parameters=parameters)
 
     async def get_all_user_threads(
@@ -688,7 +712,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         autoPlay=element.get("element_autoPlay"),
                         playerConfig=element.get("element_playerconfig"),
                         page=element.get("element_page"),
-                        props=element.get("element_props"),
+                        props=json.loads(element.get("props", "{}")),
                         forId=element.get("element_forid"),
                         mime=element.get("element_mime"),
                     )

--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -22,6 +22,9 @@ class AzureBlobStorageClient(BaseStorageClient):
         self.service_client = AsyncBlobServiceClient.from_connection_string(
             connection_string
         )
+        self.container_client = self.service_client.get_container_client(
+            self.container_name
+        )
         logger.info("AzureBlobStorageClient initialized")
 
     async def get_read_url(self, object_key: str) -> str:
@@ -52,10 +55,7 @@ class AzureBlobStorageClient(BaseStorageClient):
         overwrite: bool = True,
     ) -> Dict[str, Any]:
         try:
-            container_client = self.service_client.get_container_client(
-                self.container_name
-            )
-            blob_client = container_client.get_blob_client(object_key)
+            blob_client = self.container_client.get_blob_client(object_key)
 
             if isinstance(data, str):
                 data = data.encode("utf-8")
@@ -78,3 +78,12 @@ class AzureBlobStorageClient(BaseStorageClient):
 
         except Exception as e:
             raise Exception(f"Failed to upload file to Azure Blob Storage: {e!s}")
+
+    async def delete_file(self, object_key: str) -> bool:
+        try:
+            blob_client = self.container_client.get_blob_client(blob=object_key)
+            await blob_client.delete_blob()
+            return True
+        except Exception as e:
+            logger.warn(f"AzureBlobStorageClient, delete_file error: {e}")
+            return False

--- a/backend/chainlit/data/storage_clients/base.py
+++ b/backend/chainlit/data/storage_clients/base.py
@@ -18,5 +18,9 @@ class BaseStorageClient(ABC):
         pass
 
     @abstractmethod
+    async def delete_file(self, object_key: str) -> bool:
+        pass
+
+    @abstractmethod
     async def get_read_url(self, object_key: str) -> str:
         pass

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -26,7 +26,6 @@ class GCSStorageClient(BaseStorageClient):
         )
 
         self.client = storage.Client(project=project_id, credentials=credentials)
-        self.bucket_name = bucket_name
         self.bucket = self.client.bucket(bucket_name)
         logger.info("GCSStorageClient initialized")
 
@@ -60,7 +59,7 @@ class GCSStorageClient(BaseStorageClient):
 
             return {
                 "object_key": object_key,
-                "url": f"gs://{self.bucket_name}/{object_key}",
+                "url": f"gs://{self.bucket.name}/{object_key}",
             }
 
         except Exception as e:
@@ -76,3 +75,14 @@ class GCSStorageClient(BaseStorageClient):
         return await make_async(self.sync_upload_file)(
             object_key, data, mime, overwrite
         )
+
+    def sync_delete_file(self, object_key: str) -> bool:
+        try:
+            self.bucket.blob(object_key).delete()
+            return True
+        except Exception as e:
+            logger.warn(f"GCSStorageClient, delete_file error: {e}")
+            return False
+
+    async def delete_file(self, object_key: str) -> bool:
+        return await make_async(self.sync_delete_file)(object_key)


### PR DESCRIPTION
To test:
- [x] S3 deletion
- [x] GCS deletion
- [x] Azure deletion
- [x] SQLAlchemy DL element deletion
- [x] custom element `props` with SQLAlchemy DL

Fixes for:
- https://github.com/Chainlit/chainlit/issues/1546
- https://github.com/Chainlit/chainlit/issues/1649

### Changes:
- deleting a thread removes objects on cloud storage for official + SQLAlchemy data layers (GCS/Azure/S3)
- store `props` as JSON in SQLAlchemy data layer
- cleanup + async wrappers for S3

### To test:
- for both official & SQLAlchemy data layers
  - connect to GCS/Azure/S3 storage
    - start thread with image attachment -> get element URL from cloud storage
    - delete thread
    - check on cloud storage that object isn't there anymoer
- specific to SQLAlchemy data layer:
  - start thread with custom element & check `props` properly written to DB