### PR TITLE
fix: data layer create_element

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -175,9 +175,9 @@ class ChainlitDataLayer(BaseDataLayer):
             raise ValueError("Element url, path or content must be provided")
 
         if element.thread_id:
-            path = f"threads/{element.thread_id}/files/{element.name}"
+            path = f"threads/{element.thread_id}/files/{element.name}/{element.id}"
         else:
-            path = f"files/{element.name}"
+            path = f"files/{element.name}/{element.id}"
 
         if content is not None:
             await self.storage_client.upload_file(


### PR DESCRIPTION
### Description  
This pull request addresses a bug in the `ChainlitDataLayer` class where the `element_id` was missing when constructing the storage client path for the element in the `create_element` method.  

### Problem  
The missing `element_id` caused all elements to share the same path in the blob storage, leading to overwriting of objects (see screenshot below of two elements in the same thread).

![image](https://github.com/user-attachments/assets/d5b82d83-93a2-4e8e-b49c-8fbdd2695d4f)

### Solution  
The `create_element` method has been updated to include the `element_id` when building the storage client path, ensuring each element has a unique path (see screenshot below of how the path looks after the fix).

![image](https://github.com/user-attachments/assets/399e10ba-6abb-4f10-9474-58720aea9666)   
