### PR TITLE
fix: only make the body of chat settings modal scroll

### DIFF
--- a/frontend/src/components/ChatSettings/index.tsx
+++ b/frontend/src/components/ChatSettings/index.tsx
@@ -64,24 +64,26 @@ export default function ChatSettingsModal() {
     <Dialog open={chatSettingsOpen} onOpenChange={handleClose}>
       <DialogContent
         id="chat-settings"
-        className="min-w-[20vw] max-h-[85vh] overflow-y-auto flex flex-col gap-6"
+        className="min-w-[20vw] max-h-[85vh] flex flex-col gap-6"
       >
         <DialogHeader>
           <DialogTitle>
             <Translator path="components.organisms.chat.settings.settingsPanel" />
           </DialogTitle>
         </DialogHeader>
-        {chatSettingsInputs.map((input: any) => (
-          <FormInput
-            key={input.id}
-            element={{
-              ...input,
-              value: values[input.id],
-              onChange: handleChange,
-              setField: setFieldValue
-            }}
-          />
-        ))}
+        <div className="flex flex-col flex-grow overflow-y-auto gap-6">
+          {chatSettingsInputs.map((input: any) => (
+            <FormInput
+              key={input.id}
+              element={{
+                ...input,
+                value: values[input.id],
+                onChange: handleChange,
+                setField: setFieldValue
+              }}
+            />
+          ))}
+        </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleReset}>
             <Translator path="components.organisms.chat.settings.reset" />

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -2,6 +2,7 @@ import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
+import { useTranslation } from '@/components/i18n/Translator';
 import { Button } from '@/components/ui/button';
 import {
   Tooltip,
@@ -9,7 +10,6 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@/components/ui/tooltip';
-import { useTranslation } from '@/components/i18n/Translator';
 
 interface Props {
   content: unknown;
@@ -57,7 +57,13 @@ const CopyButton = ({ content, className }: Props) => {
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>{copied ? t('components.organisms.chat.Messages.copyButton.copied') : t('components.organisms.chat.Messages.copyButton.copyToClipboard')}</p>
+          <p>
+            {copied
+              ? t('components.organisms.chat.Messages.copyButton.copied')
+              : t(
+                  'components.organisms.chat.Messages.copyButton.copyToClipboard'
+                )}
+          </p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>


### PR DESCRIPTION
Fixing https://github.com/Chainlit/chainlit/issues/1712 and https://github.com/Chainlit/chainlit/issues/1713