### PR TITLE
fix: store show input as string

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -350,7 +350,7 @@ class ChainlitDataLayer(BaseDataLayer):
             "type": step_dict["type"],
             "start_time": timestamp,
             "end_time": timestamp,
-            "show_input": step_dict.get("showInput", "json"),
+            "show_input": str(step_dict.get("showInput", "json")),
             "is_error": step_dict.get("isError", False),
         }
         await self.execute_query(query, params)


### PR DESCRIPTION
Countedragon reported [this issue](https://discord.com/channels/1088038867602526210/1329247912093286400/1329247912093286400) where boolean values for `showInput` make step ingestion on official data layer fail. 

Corresponding column on `Step` is TEXT in `schema.prisma` of `chainlit-datalayer`. Therefore, string cast is required prior to insert. 