### PR TITLE
fix: limit thread name

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -530,13 +530,15 @@ class ChainlitDataLayer(BaseDataLayer):
         if self.show_logger:
             logger.info(f"asyncpg: update_thread, thread_id={thread_id}")
 
+        thread_name = truncate(
+            name
+            if name is not None
+            else (metadata.get("name") if metadata and "name" in metadata else None)
+        )
+
         data = {
             "id": thread_id,
-            "name": (
-                name
-                if name is not None
-                else (metadata.get("name") if metadata and "name" in metadata else None)
-            ),
+            "name": thread_name,
             "userId": user_id,
             "tags": tags,
             "metadata": json.dumps(metadata or {}),
@@ -606,3 +608,7 @@ class ChainlitDataLayer(BaseDataLayer):
         """Cleanup database connections"""
         if self.pool:
             await self.pool.close()
+
+
+def truncate(text: Optional[str], max_length: int = 255) -> Optional[str]:
+    return None if text is None else text[:max_length]


### PR DESCRIPTION
Fix for bug reported in [this issue](https://github.com/Chainlit/chainlit-datalayer/issues/4#issue-2791603282). 
No need to limit var length on Prisma schema itself. 

To test, start a thread with a text exceeding 255 characters, make sure you don't get the error below and you can still search through your threads efficiently. 

Error that should not appear anymore:
```
2025-01-17 13:11:19 - Database error: index row requires 204672 bytes, maximum size is 8191
2025-01-17 13:11:19 - Error updating thread: index row requires 204672 bytes, maximum size is 8191
```