### PR TITLE
Fix Broken Translation Paths in Left Sidebar in 2.0.4

### DIFF
--- a/frontend/src/components/LeftSidebar/ThreadList.tsx
+++ b/frontend/src/components/LeftSidebar/ThreadList.tsx
@@ -92,7 +92,7 @@ export function ThreadList({
   if (!threadHistory || size(threadHistory?.timeGroupedThreads) === 0) {
     return (
       <Alert variant="info" className="m-3">
-        <Translator path="components.organisms.threadHistory.threadList.noThreads" />
+        <Translator path="components.organisms.threadHistory.sidebar.ThreadList.noThreads" />
       </Alert>
     );
   }
@@ -137,7 +137,7 @@ export function ThreadList({
 
     toast.promise(apiClient.renameThread(threadIdToRename, threadNewName), {
       loading: (
-        <Translator path="components.organisms.threadHistory.threadList.RenameThreadButton.renamingThread" />
+        <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameThreadButton.renamingThread" />
       ),
       success: () => {
         setThreadNewName(undefined);
@@ -160,7 +160,7 @@ export function ThreadList({
           return next;
         });
         return <div>
-          <Translator path="components.organisms.threadHistory.threadList.RenameThreadButton.threadRenamed" />
+          <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameThreadButton.threadRenamed" />
         </div>;
       },
       error: (err) => {
@@ -192,18 +192,18 @@ export function ThreadList({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              <Translator path="components.organisms.threadHistory.threadList.DeleteDialog.title" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.DeleteDialog.title" />
             </AlertDialogTitle>
             <AlertDialogDescription>
-              <Translator path="components.organisms.threadHistory.threadList.DeleteDialog.description" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.DeleteDialog.description" />
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-row gap-2 sm:gap-0">
             <AlertDialogCancel className="mt-0">
-              <Translator path="components.organisms.threadHistory.threadList.DeleteDialog.cancel" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.DeleteDialog.cancel" />
             </AlertDialogCancel>
             <AlertDialogAction onClick={handleDeleteThread}>
-              <Translator path="components.organisms.threadHistory.threadList.DeleteDialog.confirm" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.DeleteDialog.confirm" />
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -215,15 +215,15 @@ export function ThreadList({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              <Translator path="components.organisms.threadHistory.threadList.RenameDialog.title" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameDialog.title" />
             </DialogTitle>
             <DialogDescription>
-              <Translator path="components.organisms.threadHistory.threadList.RenameDialog.description" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameDialog.description" />
             </DialogDescription>
           </DialogHeader>
           <div className="my-6">
             <Label htmlFor="name" className="text-right">
-              <Translator path="components.organisms.threadHistory.threadList.RenameDialog.nameLabel" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameDialog.nameLabel" />
             </Label>
             <Input
               id="name"
@@ -242,10 +242,10 @@ export function ThreadList({
               variant="outline"
               onClick={() => setThreadIdToRename(undefined)}
             >
-              <Translator path="components.organisms.threadHistory.threadList.RenameDialog.cancel" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameDialog.cancel" />
             </Button>
             <Button type="button" onClick={handleRenameThread}>
-              <Translator path="components.organisms.threadHistory.threadList.RenameDialog.confirm" />
+              <Translator path="components.organisms.threadHistory.sidebar.ThreadList.RenameDialog.confirm" />
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -267,7 +267,7 @@ export function ThreadList({
                         isActive={isSelected}
                         className="relative truncate h-9 group/thread"
                       >
-                        {thread.name || (<Translator path="components.organisms.threadHistory.threadList.untitledConversation" />)}
+                        {thread.name || (<Translator path="components.organisms.threadHistory.sidebar.ThreadList.untitledConversation" />)}
                         <div
                           className={cn(
                             'absolute w-10 bottom-0 top-0 right-0 bg-gradient-to-l from-[hsl(var(--sidebar-background))] to-transparent'


### PR DESCRIPTION
The translation additions in #1729 broke text from appearing for some interactions in the left sidebar due to the incorrect path being used in [ThreadList.tsx](https://github.com/Chainlit/chainlit/blob/32d7fd821fdb74a8be74fda46aeb75cdc410d921/frontend/src/components/LeftSidebar/ThreadList.tsx), so this fixes the paths to match the [en-US translation file](https://github.com/Chainlit/chainlit/blob/32d7fd821fdb74a8be74fda46aeb75cdc410d921/backend/chainlit/translations/en-US.json).

Currently in Chainlit 2.0.4, some panels have dialogue missing:

#### Renaming and deleting a thread before the fix:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/5c2daea5-ff60-496e-893a-50399c7666e4" />
<img width="399" alt="image" src="https://github.com/user-attachments/assets/9e2d9176-8619-408f-83d9-b6f66dedefc9" />

#### Renaming and deleting a thread after this fix:
<img width="399" alt="image" src="https://github.com/user-attachments/assets/29eeb7ba-cc30-4f9c-8e70-2a9e777dd205" />
<img width="395" alt="image" src="https://github.com/user-attachments/assets/254b4b8f-89f2-4d28-86a0-afbea1bc97db" />
