### PR TITLE
feat(i18n): Add translations for thread menu options

### DIFF
--- a/backend/chainlit/translations/bn.json
+++ b/backend/chainlit/translations/bn.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "শিরোনামহীন আলোচনা",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "মুছে ফেলা নিশ্চিত করুন",

--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "Untitled Conversation",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "Confirm deletion",

--- a/backend/chainlit/translations/gu.json
+++ b/backend/chainlit/translations/gu.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "શીર્ષક વગરની વાતચીત",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "કાઢી નાખવાની પુષ્ટિ કરો",

--- a/backend/chainlit/translations/he-IL.json
+++ b/backend/chainlit/translations/he-IL.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "שיחה ללא כותרת",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "אשר מחיקה",

--- a/backend/chainlit/translations/hi.json
+++ b/backend/chainlit/translations/hi.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "शीर्षकहीन वार्तालाप",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "हटाने की पुष्टि करें",

--- a/backend/chainlit/translations/ja.json
+++ b/backend/chainlit/translations/ja.json
@@ -133,6 +133,10 @@
       },
       "thread": {
         "untitled": "無題の会話",
+        "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
         "actions": {
           "delete": {
             "title": "削除の確認",

--- a/backend/chainlit/translations/kn.json
+++ b/backend/chainlit/translations/kn.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "ಶೀರ್ಷಿಕೆರಹಿತ ಸಂಭಾಷಣೆ",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "ಅಳಿಸುವಿಕೆಯನ್ನು ದೃಢೀಕರಿಸಿ",

--- a/backend/chainlit/translations/ml.json
+++ b/backend/chainlit/translations/ml.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "പേരില്ലാത്ത സംഭാഷണം",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "ഡിലീറ്റ് സ്ഥിരീകരിക്കുക",

--- a/backend/chainlit/translations/mr.json
+++ b/backend/chainlit/translations/mr.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "शीर्षकविरहित संभाषण",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "हटविण्याची पुष्टी करा",

--- a/backend/chainlit/translations/nl-NL.json
+++ b/backend/chainlit/translations/nl-NL.json
@@ -133,6 +133,10 @@
       },
       "thread": {
         "untitled": "Naamloos gesprek",
+        "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
         "actions": {
           "delete": {
             "title": "Verwijdering bevestigen",

--- a/backend/chainlit/translations/ta.json
+++ b/backend/chainlit/translations/ta.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "தலைப்பிடாத உரையாடல்",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "நீக்குவதை உறுதிப்படுத்து",

--- a/backend/chainlit/translations/te.json
+++ b/backend/chainlit/translations/te.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "పేరు లేని సంభాషణ",
+      "menu": {
+          "rename": "Rename",
+          "delete": "Delete"
+        },
       "actions": {
         "delete": {
           "title": "తొలగింపును నిర్ధారించండి",

--- a/backend/chainlit/translations/zh-CN.json
+++ b/backend/chainlit/translations/zh-CN.json
@@ -133,6 +133,10 @@
     },
     "thread": {
       "untitled": "未命名对话",
+      "menu": {
+          "rename": "重命名",
+          "delete": "删除"
+        },
       "actions": {
         "delete": {
           "title": "确认删除",

--- a/frontend/src/components/LeftSidebar/ThreadOptions.tsx
+++ b/frontend/src/components/LeftSidebar/ThreadOptions.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import { Ellipsis, Trash } from 'lucide-react';
-
+import { Translator } from '../i18n';
 import { Pencil } from '@/components/icons/Pencil';
 import { Button } from '@/components/ui/button';
 import {
@@ -48,7 +48,7 @@ export default function ThreadOptions({
             onRename();
           }}
         >
-          Rename
+          <Translator path="threadHistory.thread.menu.rename" />
           <Pencil className="ml-auto" />
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -59,7 +59,7 @@ export default function ThreadOptions({
           }}
           className="text-red-500 focus:text-red-500"
         >
-          Delete
+          <Translator path="threadHistory.thread.menu.delete" />
           <Trash className="ml-auto" />
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION
## Description
Added missing translations for the thread history menu dropdown options across all supported languages.

## Changes
- Added new translation entries for thread menu options in all language JSON files
- Updated `ThreadOptions` component to use `Translator` with path `threadHistory.thread.menu.*`

## Checklist
- [x] Added translations for all supported languages
- [x] Tested the display of translations in en-US and zh-CN
- [x] No breaking changes introduced

## Screenshots
<img width="155" alt="2025-01-21 09 28 25" src="https://github.com/user-attachments/assets/49fe4d1d-247b-4d9d-8d2f-cdcb0d32e04e" />
<img width="157" alt="2025-01-21 09 28 03" src="https://github.com/user-attachments/assets/31ddeb90-c182-4076-b885-f30b723f5d53" />
