### PR TITLE
Increase Cypress E2E test timeout

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 
   e2e: {
     supportFile: false,
-    defaultCommandTimeout: 15000,
+    defaultCommandTimeout: 30000,
     video: false,
     baseUrl: 'http://127.0.0.1:8000',
     setupNodeEvents(on) {


### PR DESCRIPTION
Intended to increase test robustness on Windows.