### PR TITLE
fix: add conflict strategy to create_element

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -194,6 +194,8 @@ class ChainlitDataLayer(BaseDataLayer):
         ) VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14
         )
+        ON CONFLICT (id) DO UPDATE SET
+            props = EXCLUDED.props
         """
         params = {
             "id": element.id,

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -240,7 +240,7 @@ class Element:
     async def remove(self):
         trace_event(f"remove {self.__class__.__name__}")
         data_layer = get_data_layer()
-        if data_layer and self.persisted:
+        if data_layer:
             await data_layer.delete_element(self.id, self.thread_id)
         await context.emitter.emit("remove_element", {"id": self.id})
 

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -219,7 +219,7 @@ class Element:
         if self.persisted and not self.updatable:
             return True
 
-        if data_layer := get_data_layer() and persist:
+        if (data_layer := get_data_layer()) and persist:
             try:
                 asyncio.create_task(data_layer.create_element(self))
             except Exception as e:


### PR DESCRIPTION
@yves03 reported https://github.com/Chainlit/chainlit/issues/1792

### Changes:
- override `props` in `create_element` with on conflict strategy
- remove persisted condition on deletion -> need to check why `self.persisted` is false upon element removal :/

### To test:
- set up data layer with https://github.com/Chainlit/chainlit-datalayer/
- use the counter example from https://docs.chainlit.io/api-reference/elements/custom linked to above data layer
- validate that counter increments do show on `props` (count key incremented in DB)
- validate that clicking "Remove" deletes the `Element` record from DB
- add the `callAction` as described in issue above and validate the print works (no errors)