### PR TITLE
feat: add support for custom CSS styles in copilot

### DIFF
--- a/libs/copilot/src/appWrapper.tsx
+++ b/libs/copilot/src/appWrapper.tsx
@@ -17,6 +17,16 @@ export default function AppWrapper({ widgetConfig }: Props) {
   const apiClient = makeApiClient(widgetConfig.chainlitServer);
   const [customThemeLoaded, setCustomThemeLoaded] = useState(false);
 
+  function completeInitialization() {
+    if (widgetConfig.customCssUrl) {
+      const linkEl = document.createElement('link');
+      linkEl.rel = 'stylesheet';
+      linkEl.href = widgetConfig.customCssUrl;
+      window.cl_shadowRootElement.getRootNode().appendChild(linkEl);
+    }
+    setCustomThemeLoaded(true);
+  }
+
   useEffect(() => {
     let fontLoaded = false;
 
@@ -46,10 +56,10 @@ export default function AppWrapper({ widgetConfig }: Props) {
               'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap';
             window.cl_shadowRootElement.getRootNode().appendChild(linkEl);
           }
-          setCustomThemeLoaded(true);
+          completeInitialization();
         }
       })
-      .catch(() => setCustomThemeLoaded(true));
+      .catch(() => completeInitialization());
   }, []);
 
   if (!customThemeLoaded) return null;

--- a/libs/copilot/src/types.ts
+++ b/libs/copilot/src/types.ts
@@ -8,4 +8,5 @@ export interface IWidgetConfig {
     imageUrl?: string;
     className?: string;
   };
+  customCssUrl?: string;
 }

--- a/libs/copilot/src/widget.tsx
+++ b/libs/copilot/src/widget.tsx
@@ -89,7 +89,10 @@ const Widget = ({ config, error }: Props) => {
           'shadow-lg',
           'z-50',
           'animate-in fade-in-0 zoom-in-95',
-          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95'
+          'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+          expanded
+            ? 'copilot-container-expanded'
+            : 'copilot-container-collapsed'
         )}
       >
         <div id="chainlit-copilot" className="flex flex-col h-full w-full">


### PR DESCRIPTION
This pull request allows for customization of copilot styles and allows for customization of styles of the copilot container in expanded or collapse mode.

for example:

```js
window.mountChainlitWidget({
        chainlitServer: url,
        customCssUrl: '/public/copilot.css',
    }
```

and copilot.css:
```css
#cl-shadow-root .copilot-container-expanded {
    height: min(900px,calc(100vh - 150px));
}

#cl-shadow-root .copilot-container-collapsed {
    width: min(600px,80vw);
}
```

other classes could be overwritten or customized as needed
