### PR TITLE
feat: support adding custom links on the nav header

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -146,6 +146,12 @@ cot = "full"
 # Be careful: If this is a relative path, it should not start with a slash.
 # custom_build = "./public/build"
 
+# Specify optional one or more custom links in the header.
+# [[UI.header_links]]
+#     name = "Issues"
+#     icon_url = "https://avatars.githubusercontent.com/u/128686189?s=200&v=4"
+#     url = "https://github.com/Chainlit/chainlit/issues"
+
 [meta]
 generated_by = "{__version__}"
 """
@@ -217,6 +223,13 @@ class FeaturesSettings(DataClassJsonMixin):
     edit_message: bool = True
 
 
+@dataclass
+class HeaderLink(DataClassJsonMixin):
+    name: str
+    icon_url: str
+    url: str
+
+
 @dataclass()
 class UISettings(DataClassJsonMixin):
     name: str
@@ -233,6 +246,8 @@ class UISettings(DataClassJsonMixin):
     custom_meta_image_url: Optional[str] = None
     # Optional custom build directory for the frontend
     custom_build: Optional[str] = None
+    # Optional header links
+    header_links: Optional[List[HeaderLink]] = None
 
 
 @dataclass()

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -34,6 +34,7 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
                     ? apiClient.buildEndpoint(iconUrl)
                     : iconUrl
                 }
+                className={'h-6 w-6'}
                 alt={name}
               />
             </a>

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -1,3 +1,7 @@
+import { useContext } from 'react';
+
+import { ChainlitContext } from '@chainlit/react-client';
+
 import { Button } from '@/components/ui/button';
 import {
   Tooltip,
@@ -7,33 +11,36 @@ import {
 } from '@/components/ui/tooltip';
 
 export interface ButtonLinkProps {
-    name?: string;
-    iconUrl?: string;
-    url: string;
+  name?: string;
+  iconUrl?: string;
+  url: string;
 }
 
-export default function ButtonLink({name, iconUrl, url }: ButtonLinkProps) {
+export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
+  const apiClient = useContext(ChainlitContext);
   return (
     <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="text-muted-foreground hover:text-muted-foreground"
-            >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:text-muted-foreground"
+          >
             <a href={url} target="_blank">
               <img
-                src={iconUrl}
+                src={
+                  iconUrl?.startsWith('/public')
+                    ? apiClient.buildEndpoint(iconUrl)
+                    : iconUrl
+                }
                 alt={name}
               />
             </a>
           </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            { name }
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+        </TooltipTrigger>
+        <TooltipContent>{name}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
+
+export interface ButtonLinkProps {
+    name?: string;
+    iconUrl?: string;
+    url: string;
+}
+
+export default function ButtonLink({name, iconUrl, url }: ButtonLinkProps) {
+  return (
+    <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-muted-foreground"
+            >
+            <a href={url} target="_blank">
+              <img
+                src={iconUrl}
+                alt={name}
+              />
+            </a>
+          </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            { name }
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+  );
+}

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAudio, useAuth, useConfig } from '@chainlit/react-client';
 
 import AudioPresence from '@/components/AudioPresence';
+import ButtonLink from '@/components/ButtonLink';
 import { useSidebar } from '@/components/ui/sidebar';
 
 import ApiKeys from './ApiKeys';
@@ -24,6 +25,8 @@ const Header = memo(() => {
   const sidebarOpen = isMobile ? openMobile : open;
 
   const historyEnabled = data?.requireLogin && config?.dataPersistence;
+
+  const links = config?.ui?.header_links || [];
 
   return (
     <div
@@ -59,6 +62,9 @@ const Header = memo(() => {
       <div className="flex items-center gap-1">
         <ReadmeButton />
         <ApiKeys />
+        {links && (
+           links.map(link => <ButtonLink name={link.name} iconUrl={link.icon_url} url={link.url}/>)
+        )}
         <ThemeToggle />
         <UserNav />
       </div>

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -39,6 +39,7 @@ export interface IChainlitConfig {
     custom_js?: string;
     custom_font?: string;
     custom_meta_image_url?: string;
+    header_links?: { name: string; icon_url: string, url: string }[];
   };
   features: {
     spontaneous_file_upload?: {


### PR DESCRIPTION
This PR allows to configure custom links to be added in the menu/navigation header by adding them in the config.toml file

For example:


```
[[UI.header_links]]
    name = "Confluence"
    icon_url = "https://www.atlassian.com/favicon.ico"
    url = "https://www.atlassian.com"

[[UI.header_links]]
    name = "Issues"
    icon_url = "https://mintlify.s3-us-west-1.amazonaws.com/chainlit-43/_generated/favicon/favicon.ico?v=3"
    url = "https://github.com/Chainlit/chainlit/issues"
```

That will result in the following:

![image](https://github.com/user-attachments/assets/f74212e2-a0b9-4cec-96e7-ccf707c1250f)
