### PR TITLE
Fix: prevent showing 0's on resumed thread if AskAction/File was used

### DIFF
--- a/frontend/src/components/chat/Messages/Message/index.tsx
+++ b/frontend/src/components/chat/Messages/Message/index.tsx
@@ -129,7 +129,7 @@ const Message = memo(
                         allowHtml={allowHtml}
                         latex={latex}
                       />
-                      {!isRunning && isAsk && (
+                      {!isRunning && isAsk ? (
                         <>
                           <AskFileButton onError={onError} />
                           <AskActionButtons
@@ -137,7 +137,7 @@ const Message = memo(
                             messageId={message.id}
                           />
                         </>
-                      )}
+                      ) : null}
                       <MessageButtons
                         message={message}
                         actions={actions}


### PR DESCRIPTION
Hello, the redesign of Chainlit on V2 introduced back an issue (https://github.com/Chainlit/chainlit/issues/1548) where the assistant messages would display "0" in some case when thread contains a AskActionMessage or AskFileMessage element.

This simply applies back the same fix as the PR https://github.com/Chainlit/chainlit/pull/1617 to change the logic on the frontend.

---
Before : 
<img width="804" alt="image" src="https://github.com/user-attachments/assets/0b561f95-4ea2-4624-b5e3-529715b0e274" />

After:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/d8012bab-813f-4c8e-8816-6e4c98187593" />
