### PR TITLE
fix: reintroduce including URL location after UI refactor

### DIFF
--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -80,7 +80,8 @@ export default function MessageComposer({
         name: user?.identifier || 'User',
         type: 'user_message',
         output: msg,
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
+        metadata: { location: window.location.href }
       };
 
       const fileReferences = attachments
@@ -101,7 +102,8 @@ export default function MessageComposer({
         name: user?.identifier || 'User',
         type: 'user_message',
         output: msg,
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
+        metadata: { location: window.location.href }
       };
 
       replyMessage(message);

--- a/frontend/src/components/chat/Starter.tsx
+++ b/frontend/src/components/chat/Starter.tsx
@@ -29,7 +29,8 @@ export default function Starter({ starter }: StarterProps) {
       name: user?.identifier || 'User',
       type: 'user_message',
       output: starter.message,
-      createdAt: new Date().toISOString()
+      createdAt: new Date().toISOString(),
+      metadata: { location: window.location.href }
     };
 
     sendMessage(message, []);


### PR DESCRIPTION
Partial code of the feature introduced in https://github.com/Chainlit/chainlit/pull/1403 was removed after the recent UI refactoring.

This PR reintroduces the missing parts to allow including the current location/URL where the user is as part of the message metadata for further processing in `on_message(message: cl.Message)`