### PR TITLE
fix: disable submit button when input is empty

### DIFF
--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -179,7 +179,10 @@ export default function MessageComposer({
           <VoiceButton disabled={disabled} />
         </div>
         <div className="flex items-center gap-1">
-          <SubmitButton onSubmit={submit} disabled={disabled || !value} />
+          <SubmitButton
+            onSubmit={submit}
+            disabled={disabled || !value.trim()}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

when I type something then delete to empty string in the input, the actual value is `\n`, so the button was not disabled.