### PR TITLE
chore: allow chainlit to be built as dependencies

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],


### PR DESCRIPTION
Signed-off-by: San Nguyen <vinhsannguyen91@gmail.com>

Adding composite: true so that chainlit can built incrementally when referenced in another projects.
This is to support monorepo cloning chainlit and build . This should not be an issue with current chainlit project.