### PR TITLE
Dont show placeholder and disable typing

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -24,6 +24,7 @@ interface Props {
   autoFocus?: boolean;
   placeholder?: string;
   selectedCommand?: ICommand;
+  disabled?: boolean;
   setSelectedCommand: (command: ICommand | undefined) => void;
   onChange: (value: string) => void;
   onPaste?: (event: any) => void;
@@ -41,6 +42,7 @@ const Input = forwardRef<InputMethods, Props>(
       id,
       className,
       autoFocus,
+      disabled,
       selectedCommand,
       setSelectedCommand,
       onChange,
@@ -338,8 +340,8 @@ const Input = forwardRef<InputMethods, Props>(
           id={id}
           autoFocus={autoFocus}
           ref={contentEditableRef}
-          contentEditable
-          data-placeholder={placeholder}
+          contentEditable={!disabled}
+          data-placeholder={disabled ? : '' : placeholder}
           className={cn(
             'min-h-10 max-h-[250px] overflow-y-auto w-full focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0 empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground',
             className

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -149,6 +149,7 @@ export default function MessageComposer({
         onPaste={onPaste}
         onEnter={submit}
         placeholder={t('chat.input.placeholder')}
+        disabled={disabled}
       />
       <div className="flex items-center justify-between">
         <div className="flex items-center -ml-1.5">


### PR DESCRIPTION
Hey,

Small modification that I think is could prevent confusion of end-users. When a `AskUser*` component is sent, the ability to send messages is disabled (the send button, the settings and so on), yet the "text-area" is not, and the placeholder still shows "_Type your message here..._" even if we can't.

This PR aims to fix this. 

Note: I've also though of creating a new translation `chat.input.disabled` instead of it being empty, so LMK.

Before: 
![image](https://github.com/user-attachments/assets/63054706-8944-4470-b9b5-d60a5fb0eec5)

After:
![image](https://github.com/user-attachments/assets/ff90db38-f43e-4d74-af5b-c2d505d2e366)
