### PR TITLE
Fix/disable input on ask

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -21,6 +21,7 @@ import {
 interface Props {
   id?: string;
   className?: string;
+  disabled?: boolean;
   autoFocus?: boolean;
   placeholder?: string;
   selectedCommand?: ICommand;
@@ -51,6 +52,7 @@ const Input = forwardRef<InputMethods, Props>(
       className,
       autoFocus,
       selectedCommand,
+      disabled,
       setSelectedCommand,
       onChange,
       onEnter,
@@ -349,7 +351,7 @@ const Input = forwardRef<InputMethods, Props>(
           id={id}
           autoFocus={autoFocus}
           ref={contentEditableRef}
-          contentEditable
+          contentEditable={!disabled}
           data-placeholder={placeholder}
           className={cn(
             'min-h-10 max-h-[250px] overflow-y-auto w-full focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0 empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground',

--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -352,7 +352,7 @@ const Input = forwardRef<InputMethods, Props>(
           autoFocus={autoFocus}
           ref={contentEditableRef}
           contentEditable={!disabled}
-          data-placeholder={placeholder}
+          data-placeholder={disabled ? '' : placeholder}
           className={cn(
             'min-h-10 max-h-[250px] overflow-y-auto w-full focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0 empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground',
             className

--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -351,7 +351,7 @@ const Input = forwardRef<InputMethods, Props>(
           id={id}
           autoFocus={autoFocus}
           ref={contentEditableRef}
-          contentEditable={!disabled}
+          {...(!disabled && { contentEditable: true })}          
           data-placeholder={disabled ? '' : placeholder}
           className={cn(
             'min-h-10 max-h-[250px] overflow-y-auto w-full focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 focus-visible:ring-offset-0 empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground',

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -151,6 +151,7 @@ export default function MessageComposer({
         onPaste={onPaste}
         onEnter={submit}
         placeholder={t('chat.input.placeholder')}
+        disabled={disabled}
       />
       <div className="flex items-center justify-between">
         <div className="flex items-center -ml-1.5">

--- a/frontend/src/components/chat/Messages/Message/index.tsx
+++ b/frontend/src/components/chat/Messages/Message/index.tsx
@@ -129,7 +129,7 @@ const Message = memo(
                         allowHtml={allowHtml}
                         latex={latex}
                       />
-                      {!isRunning && isAsk && (
+                      {!isRunning && isAsk ? (
                         <>
                           <AskFileButton onError={onError} />
                           <AskActionButtons
@@ -137,7 +137,7 @@ const Message = memo(
                             messageId={message.id}
                           />
                         </>
-                      )}
+                      ) : null}
                       <MessageButtons
                         message={message}
                         actions={actions}


### PR DESCRIPTION
Hey,

Small modification that I think is could prevent confusion of end-users. When a `AskUser*` component is sent, the ability to send messages is disabled (the send button, the settings and so on), yet the "text-area" is not, and the placeholder still shows "_Type your message here..._" even if we can't.

This PR aims to fix this. 

Note: I've also though of creating a new translation `chat.input.disabled` instead of it being empty, so LMK.

Before: 
![image](https://github.com/user-attachments/assets/63054706-8944-4470-b9b5-d60a5fb0eec5)

After:
![image](https://github.com/user-attachments/assets/ff90db38-f43e-4d74-af5b-c2d505d2e366)

PS. Sorry for the double PR, selected wrong branch.