### PR TITLE
chore: remove github config not used

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -127,9 +127,6 @@ name = "Assistant"
 # Chain of Thought (CoT) display mode. Can be "hidden", "tool_call" or "full".
 cot = "full"
 
-# Link to your github repo. This will add a github button in the UI's header.
-# github = ""
-
 # Specify a CSS file that can be used to customize the user interface.
 # The CSS file can be served from the public directory or via an external link.
 # custom_css = "/public/test.css"

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -333,7 +333,6 @@ def get_html_template(root_path):
     default_meta_image_url = (
         "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
     )
-    url = config.ui.github or default_url
     meta_image_url = config.ui.custom_meta_image_url or default_meta_image_url
     favicon_path = "/favicon"
 
@@ -344,7 +343,7 @@ def get_html_template(root_path):
     <meta property="og:title" content="{config.ui.name}">
     <meta property="og:description" content="{config.ui.description}">
     <meta property="og:image" content="{meta_image_url}">
-    <meta property="og:url" content="{url}">
+    <meta property="og:url" content="{default_url}">
     <meta property="og:root_path" content="{root_path}">"""
 
     js = f"""<script>


### PR DESCRIPTION
the github button in the UI wasn't really working, however this could now be achieved using `UI.header_links` from https://github.com/Chainlit/chainlit/pull/1836