### PR TITLE
fix: set defaultSize equal to minSize in ResizablePanel to avoid warning

### DIFF
--- a/frontend/src/pages/Page.tsx
+++ b/frontend/src/pages/Page.tsx
@@ -38,7 +38,7 @@ const Page = ({ children }: Props) => {
         <ResizablePanel
           className="flex flex-col h-full w-full"
           minSize={60}
-          defaultSize={50}
+          defaultSize={60}
         >
           <div className="flex flex-row flex-grow overflow-auto">
             {children}


### PR DESCRIPTION
## Description
When using the application, there are warnings in the browser console about ResizablePanel configuration:
```
[Warning] Panel ":[id]:" has an invalid configuration: default size should not be less than min size
``` 
The warning occurs because the defaultSize (50) is less than minSize (60) in the main ResizablePanel of `Page.tsx`.

### Changes
- Modified `defaultSize` from `50` to `60` to match `minSize` in the main `ResizablePanel` of `Page.tsx`

### Testing
- Verified the warning no longer appears in the browser console when:
  - Opening the application
  - Navigating between different chat threads
- Verified the layout and resizing functionality remain unchanged