### PR TITLE
fix: Remove unnecessary 'use client' directives to fix sourcemap errors

### DIFF
--- a/frontend/src/components/chat/Messages/Message/Buttons/FeedbackButtons.tsx
+++ b/frontend/src/components/chat/Messages/Message/Buttons/FeedbackButtons.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { MessageContext } from '@/contexts/MessageContext';
 import { MessageCircle, ThumbsDown, ThumbsUp } from 'lucide-react';
 import { useCallback, useContext, useState } from 'react';

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cn } from '@/lib/utils';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { cn } from '@/lib/utils';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { type VariantProps, cva } from 'class-variance-authority';


### PR DESCRIPTION
## Issue Description
When running `poetry install --with tests --with mypy --with dev`, the build process fails with sourcemap errors in three React components. These errors occur during the Vite build process for both `@chainlit/copilot` and `@chainlit/app`:
- Related issue #1764 

```
vite v5.4.14 building for production...
Error when using sourcemap for reporting an error: Can't resolve original location of error.
``` 
The errors consistently appear in three files:
- `src/components/ui/dialog.tsx`
- `src/components/ui/sheet.tsx`
- `src/components/chat/Messages/Message/Buttons/FeedbackButtons.tsx`

## Root Cause
The affected components include the `'use client'` directive, which is specific to Next.js and unnecessary in a Vite project. These components appear to be generated using shadcn/ui CLI tool, which defaults to Next.js templates and automatically adds the 'use client' directive. While this directive is essential in Next.js for declaring client-side components, it's not recognized or needed in our Vite-based build system and interferes with sourcemap generation.

## Changes
This PR removes the `'use client'` directive from:
- `dialog.tsx`
- `sheet.tsx`
- `FeedbackButtons.tsx`

## Testing
To verify this fix:
1. Run `poetry install --with tests --with mypy --with dev`
2. Confirm that the build completes without sourcemap errors

## Impact
This change:
- Fixes the sourcemap generation errors
- Removes unnecessary code
- Has no functional impact on the components
- Does not require any configuration changes
- Introducing PR `#1888` - a lucky number in Chinese culture that represents prosperity! 🎉