### PR TITLE
fix: add key prop to ButtonLink components in header

### DIFF
--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -63,8 +63,9 @@ const Header = memo(() => {
         <ReadmeButton />
         <ApiKeys />
         {links &&
-          links.map((link) => (
+          links.map((link, index) => (
             <ButtonLink
+              key={`${link.name}-${link.url}-${index}`}
               name={link.name}
               iconUrl={link.icon_url}
               url={link.url}


### PR DESCRIPTION
## Description
Fix React warning about missing key prop in ButtonLink components rendered in header.

## Screenshots
<img width="651" alt="2025-02-17 18 11 16" src="https://github.com/user-attachments/assets/d789e34a-0607-4c78-968e-63fabc55a037" />

## Changes
- Added unique key prop to ButtonLink components in header/index.tsx
- Key is generated using combination of link name, URL and index to ensure uniqueness

## Testing
- [x] Verified warning no longer appears in console
- [x] Confirmed links still function correctly
- [x] Tested with multiple header links to ensure proper rendering