### PR TITLE
fix: markdown alert syntax support with unsafe_allow_html = true

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -28,6 +28,7 @@ import BlinkingCursor from './BlinkingCursor';
 import CodeSnippet from './CodeSnippet';
 import { ElementRef } from './Elements/ElementRef';
 import {
+  type AlertProps,
   type AlertVariant,
   MarkdownAlert,
   alertComponents

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -27,7 +27,11 @@ import {
 import BlinkingCursor from './BlinkingCursor';
 import CodeSnippet from './CodeSnippet';
 import { ElementRef } from './Elements/ElementRef';
-import { MarkdownAlert, alertComponents } from './MarkdownAlert';
+import {
+  type AlertVariant,
+  MarkdownAlert,
+  alertComponents
+} from './MarkdownAlert';
 
 interface Props {
   allowHtml?: boolean;
@@ -269,6 +273,16 @@ const Markdown = ({
           return <TableBody {...(props as any)}>{children}</TableBody>;
         },
         // @ts-expect-error custom plugin
+        alert: ({
+          type,
+          children,
+          ...props
+        }: AlertProps & { type?: AlertVariant }) => {
+          const alertType = type
+            ? normalizeAlertType(type)
+            : normalizeAlertType((props.variant as string) || 'info');
+          return alertComponents.Alert({ variant: alertType, children });
+        },
         blinkingCursor: () => <BlinkingCursor whitespace />
       }}
     >
@@ -276,5 +290,8 @@ const Markdown = ({
     </ReactMarkdown>
   );
 };
-
+const normalizeAlertType = (type: string): AlertVariant => {
+  const normalized = type.toLowerCase().replace(/[-_\s]/g, '-');
+  return normalized as AlertVariant;
+};
 export default Markdown;

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -274,6 +274,7 @@ const Markdown = ({
           return <TableBody {...(props as any)}>{children}</TableBody>;
         },
         // @ts-expect-error custom plugin
+        blinkingCursor: () => <BlinkingCursor whitespace />,
         alert: ({
           type,
           children,
@@ -281,8 +282,7 @@ const Markdown = ({
         }: AlertProps & { type?: string }) => {
           const alertType = normalizeAlertType(type || props.variant || 'info');
           return alertComponents.Alert({ variant: alertType, children });
-        },
-        blinkingCursor: () => <BlinkingCursor whitespace />
+        }
       }}
     >
       {children}

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -29,9 +29,9 @@ import CodeSnippet from './CodeSnippet';
 import { ElementRef } from './Elements/ElementRef';
 import {
   type AlertProps,
-  type AlertVariant,
   MarkdownAlert,
-  alertComponents
+  alertComponents,
+  normalizeAlertType
 } from './MarkdownAlert';
 
 interface Props {
@@ -278,10 +278,8 @@ const Markdown = ({
           type,
           children,
           ...props
-        }: AlertProps & { type?: AlertVariant }) => {
-          const alertType = type
-            ? normalizeAlertType(type)
-            : normalizeAlertType((props.variant as string) || 'info');
+        }: AlertProps & { type?: string }) => {
+          const alertType = normalizeAlertType(type || props.variant || 'info');
           return alertComponents.Alert({ variant: alertType, children });
         },
         blinkingCursor: () => <BlinkingCursor whitespace />
@@ -291,8 +289,5 @@ const Markdown = ({
     </ReactMarkdown>
   );
 };
-const normalizeAlertType = (type: string): AlertVariant => {
-  const normalized = type.toLowerCase().replace(/[-_\s]/g, '-');
-  return normalized as AlertVariant;
-};
+
 export default Markdown;

--- a/frontend/src/components/MarkdownAlert.tsx
+++ b/frontend/src/components/MarkdownAlert.tsx
@@ -21,7 +21,7 @@ import { visit } from 'unist-util-visit';
 import { useTranslation } from '@/components/i18n/Translator';
 
 // Alert type definition
-type AlertVariant =
+export type AlertVariant =
   | 'info'
   | 'note'
   | 'tip'

--- a/frontend/src/components/MarkdownAlert.tsx
+++ b/frontend/src/components/MarkdownAlert.tsx
@@ -40,7 +40,8 @@ export const AlertTypes = [
   'pending',
   'security',
   'beta',
-  'best-practice' // 'your-new-type';
+  'best-practice'
+  // 'your-new-type';
 ] as const;
 export type AlertVariant = (typeof AlertTypes)[number];
 // Styles and icon configuration

--- a/frontend/src/components/MarkdownAlert.tsx
+++ b/frontend/src/components/MarkdownAlert.tsx
@@ -25,24 +25,24 @@ export interface AlertProps {
   children?: React.ReactNode;
 }
 // Alert type definition
-export type AlertVariant =
-  | 'info'
-  | 'note'
-  | 'tip'
-  | 'important'
-  | 'warning'
-  | 'caution' // Basic alerts
-  | 'debug'
-  | 'example' // Development related
-  | 'success'
-  | 'help'
-  | 'idea' // Functional alerts
-  | 'pending'
-  | 'security'
-  | 'beta'
-  | 'best-practice'; // Status alerts
-// | 'your-new-type'; // we can add new types here later, but remember to update translation.json file under "alerts".
-
+export const AlertTypes = [
+  'info',
+  'note',
+  'tip',
+  'important',
+  'warning',
+  'caution',
+  'debug',
+  'example',
+  'success',
+  'help',
+  'idea',
+  'pending',
+  'security',
+  'beta',
+  'best-practice' // 'your-new-type';
+] as const;
+export type AlertVariant = (typeof AlertTypes)[number];
 // Styles and icon configuration
 const variantStyles = {
   // Basic alerts
@@ -206,12 +206,21 @@ export const MarkdownAlert = () => {
         node.type = 'element';
         node.data = {
           hName: 'Alert',
-          hProperties: { variant: type.toLowerCase() }
+          hProperties: { variant: normalizeAlertType(type) }
         };
         node.children = [{ type: 'text', value: content.trim() }];
       }
     });
   };
+};
+export const normalizeAlertType = (type: string): AlertVariant => {
+  if (!type) return 'info';
+  const normalized = type.toLowerCase().replace(/[-_\s]/g, '-');
+  if (!AlertTypes.includes(normalized as AlertVariant)) {
+    console.warn(`Invalid alert type "${type}", falling back to "info"`);
+    return 'info';
+  }
+  return normalized as AlertVariant;
 };
 
 export const alertComponents = {

--- a/frontend/src/components/MarkdownAlert.tsx
+++ b/frontend/src/components/MarkdownAlert.tsx
@@ -20,6 +20,10 @@ import { visit } from 'unist-util-visit';
 
 import { useTranslation } from '@/components/i18n/Translator';
 
+export interface AlertProps {
+  variant: AlertVariant;
+  children?: React.ReactNode;
+}
 // Alert type definition
 export type AlertVariant =
   | 'info'


### PR DESCRIPTION
## Issue
When `unsafe_allow_html = true`, markdown-alert component has two issues:
1. The ::: syntax fails to parse correctly
2. HTML alert tag is not supported at all

## Solution
1. Fixed alert syntax parsing when `unsafe_allow_html = true`
2. Added HTML tag support for alerts

## Verified
1. With `unsafe_allow_html = true`:
   - Verify both ::: syntax and HTML tag syntax work
   - Check all alert types render correctly
   - Confirm styling and icons are consistent across both syntaxes

2. With `unsafe_allow_html = false`:
   - Verify ::: syntax works as before
   - Confirm HTML tags are escaped and shown as text

## Usage
```python
await cl.Message(content="::: idea\nInnovative idea\n:::\n\n").send()
``` 
```html
<alert type="idea">Innovative idea</alert>
``` 
## Addition
Add type validation in both markdown mode and html tag mode.
If type error, alert will fall back to `info` type.

## Testing code
<details><summary>Details</summary>
<p>

```python
import chainlit as cl

MARKDOWN_DEMO = '''
# Markdown & Alert Demo

## Text Formatting
**Bold text** and *italic text*
~~Strikethrough~~ and `inline code`

## Lists
### Unordered List
- First item
- Second item
 - Nested item
 - Another nested item

### Ordered List
1. First step
2. Second step
  1. Sub-step one
  2. Sub-step two

## Table
| Header 1 | Header 2 |
|----------|----------|
| Cell 1   | Cell 2   |
| Cell 3   | Cell 4   |

## Quote
> This is the quote text.
## Alerts
#### Basic alerts
::: InFo
Information message with a list:
Item 1
Item 2
:::

::: note
Note message
:::

::: tip
Helpful tip with code
:::

::: Important
Critical information!
:::

::: warning
Warning with emphasis
:::

::: caution
Caution message
:::
#### Development related
::: debug
Debug information
:::

::: example
Example usage
:::
#### Functional alerts
::: success
Operation successful
:::

::: help
Help message
:::

::: idea
Innovative idea
:::
#### Status alerts
::: pending
Work in progress
:::

::: security
Security notice
:::

::: beta
Beta feature
:::

::: best-practice
Recommended practice
:::

::: unknown
Unknown type, falling back to info type
:::

## HTML Test
<div style="color: blue;">
  <h3>HTML Content</h3>
  <ul>
    <li>HTML list item 1</li>
    <li>HTML list item 2</li>
  </ul>
</div>

<table border="1">
  <tr>
    <th>HTML Table</th>
    <th>Header 2</th>
  </tr>
  <tr>
    <td>Data 1</td>
    <td>Data 2</td>
  </tr>
</table>
<h3>Basic alerts</h3>
<alert type="Info">Information message</alert>
<alert type="noTe">Note message</alert>
<alert type="TIP">Helpful tip with code</alert>
<alert type="important">Critical information!</alert>
<alert type="warning">Warning with emphasis</alert>
<alert type="caution">Caution message</alert>
<h3>Development related</h3>
<alert type="debug">Debug information</alert>
<alert type="example">Example usage</alert>
<h3>Functional alerts</h3>
<alert type="success">Operation successful</alert>
<alert type="help">Help message</alert>
<alert type="idea">Innovative idea</alert>
<h3>Status alerts</h3>
<alert type="pending">Work in progress</alert>
<alert type="security">Security notice</alert>
<alert type="beta">Beta feature</alert>
<alert type="Best-practice">Recommended practice</alert>
<alert type="unknown">Unknown type, falling back to info type</alert>

## LaTeX Test
Inline math: $E = mc^2$
'''

@cl.on_chat_start
async def send_demo():
    await cl.Message(content=MARKDOWN_DEMO).send()

``` 
> CAUTION:
> This demo will cause a bug of nested scrolling pages with `latex = true`.
</p>
</details> 