### PR TITLE
fix: AskFileButton can now upload file with proper checking and it's own limits

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -61,6 +61,7 @@ from chainlit.markdown import get_markdown_str
 from chainlit.oauth_providers import get_oauth_provider
 from chainlit.secret import random_secret
 from chainlit.types import (
+    AskFileSpec,
     CallActionRequest,
     ConnectMCPRequest,
     DeleteFeedbackRequest,
@@ -1348,6 +1349,7 @@ async def upload_file(
     current_user: UserParam,
     session_id: str,
     file: UploadFile,
+    ask_parent_id: Optional[str] = None,
 ):
     """Upload a file to the session files directory."""
 
@@ -1376,8 +1378,15 @@ async def upload_file(
         assert file.filename, "No filename for uploaded file"
         assert file.content_type, "No content type for uploaded file"
 
+        spec: AskFileSpec = session.files_spec.get(ask_parent_id, None)
+        if not spec and ask_parent_id:
+            raise HTTPException(
+                status_code=404,
+                detail="Parent message not found",
+            )
+
         try:
-            validate_file_upload(file)
+            validate_file_upload(file, spec=spec)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
@@ -1390,27 +1399,28 @@ async def upload_file(
         await file.close()
 
 
-def validate_file_upload(file: UploadFile):
-    """Validate the file upload as configured in config.features.spontaneous_file_upload.
+def validate_file_upload(file: UploadFile, spec: Optional[AskFileSpec] = None):
+    """Validate the file upload as configured in config.features.spontaneous_file_upload or by AskFileSpec
+    for a specific message.
+
     Args:
         file (UploadFile): The file to validate.
+        spec (AskFileSpec): The file spec to validate against if any.
     Raises:
         ValueError: If the file is not allowed.
     """
-    # TODO: This logic/endpoint is shared across spontaneous uploads and the AskFileMessage API.
-    # Commenting this check until we find a better solution
+    if not spec and config.features.spontaneous_file_upload is None:
+        """Default for a missing config is to allow the fileupload without any restrictions"""
+        return
 
-    # if config.features.spontaneous_file_upload is None:
-    #     """Default for a missing config is to allow the fileupload without any restrictions"""
-    #     return
-    # if not config.features.spontaneous_file_upload.enabled:
-    #     raise ValueError("File upload is not enabled")
+    if not spec and not config.features.spontaneous_file_upload.enabled:
+        raise ValueError("File upload is not enabled")
 
-    validate_file_mime_type(file)
-    validate_file_size(file)
+    validate_file_mime_type(file, spec)
+    validate_file_size(file, spec)
 
 
-def validate_file_mime_type(file: UploadFile):
+def validate_file_mime_type(file: UploadFile, spec: Optional[AskFileSpec]):
     """Validate the file mime type as configured in config.features.spontaneous_file_upload.
     Args:
         file (UploadFile): The file to validate.
@@ -1418,14 +1428,14 @@ def validate_file_mime_type(file: UploadFile):
         ValueError: If the file type is not allowed.
     """
 
-    if (
+    if not spec and (
         config.features.spontaneous_file_upload is None
         or config.features.spontaneous_file_upload.accept is None
     ):
         "Accept is not configured, allowing all file types"
         return
 
-    accept = config.features.spontaneous_file_upload.accept
+    accept = config.features.spontaneous_file_upload.accept if not spec else spec.accept
 
     assert isinstance(accept, List) or isinstance(accept, dict), (
         "Invalid configuration for spontaneous_file_upload, accept must be a list or a dict"
@@ -1433,11 +1443,11 @@ def validate_file_mime_type(file: UploadFile):
 
     if isinstance(accept, List):
         for pattern in accept:
-            if fnmatch.fnmatch(file.content_type, pattern):
+            if fnmatch.fnmatch(str(file.content_type), pattern):
                 return
     elif isinstance(accept, dict):
         for pattern, extensions in accept.items():
-            if fnmatch.fnmatch(file.content_type, pattern):
+            if fnmatch.fnmatch(str(file.content_type), pattern):
                 if len(extensions) == 0:
                     return
                 for extension in extensions:
@@ -1448,24 +1458,25 @@ def validate_file_mime_type(file: UploadFile):
     raise ValueError("File type not allowed")
 
 
-def validate_file_size(file: UploadFile):
+def validate_file_size(file: UploadFile, spec: Optional[AskFileSpec]):
     """Validate the file size as configured in config.features.spontaneous_file_upload.
     Args:
         file (UploadFile): The file to validate.
     Raises:
         ValueError: If the file size is too large.
     """
-    if (
+    if not spec and (
         config.features.spontaneous_file_upload is None
         or config.features.spontaneous_file_upload.max_size_mb is None
     ):
         return
 
-    if (
-        file.size is not None
-        and file.size
-        > config.features.spontaneous_file_upload.max_size_mb * 1024 * 1024
-    ):
+    max_size_mb = (
+        config.features.spontaneous_file_upload.max_size_mb
+        if not spec
+        else spec.max_size_mb
+    )
+    if file.size is not None and file.size > max_size_mb * 1024 * 1024:
         raise ValueError("File size too large")
 
 

--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Literal, Optional,
 import aiofiles
 
 from chainlit.logger import logger
-from chainlit.types import FileReference
+from chainlit.types import AskFileSpec, FileReference
 
 if TYPE_CHECKING:
     from mcp import ClientSession
@@ -80,6 +80,7 @@ class BaseSession:
         self.chat_profile = chat_profile
 
         self.files: Dict[str, FileDict] = {}
+        self.files_spec: Dict[str, AskFileSpec] = {}
 
         self.id = id
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,6 +40,7 @@ def mock_session_factory(persisted_test_user: PersistedUser) -> Callable[..., Mo
         mock.emit = AsyncMock()
         mock.has_first_interaction = kwargs.get("has_first_interaction", True)
         mock.files = kwargs.get("files", {})
+        mock.files_spec = kwargs.get("files_spec", {})
 
         return mock
 

--- a/cypress/e2e/ask_file/main.py
+++ b/cypress/e2e/ask_file/main.py
@@ -17,7 +17,14 @@ async def start():
         ).send()
 
     files = await cl.AskFileMessage(
-        content="Please upload a python file to begin!", accept={"text/plain": [".py"]}
+        content="Please upload a python file to begin!",
+        accept={
+            "text/plain": [".py", ".txt"],
+            # Some browser / os report it as text/plain but some as text/x-python when doing drag&drop
+            "text/x-python": [".py"],
+            # Or even as application/octet-stream when using the select file dialog
+            "application/octet-stream": [".py"],
+        },
     ).send()
     py_file = files[0]
 

--- a/cypress/e2e/ask_multiple_files/main.py
+++ b/cypress/e2e/ask_multiple_files/main.py
@@ -6,7 +6,13 @@ async def start():
     files = await cl.AskFileMessage(
         content="Please upload from one to two python files to begin!",
         max_files=2,
-        accept={"text/plain": [".py"]},
+        accept={
+            "text/plain": [".py", ".txt"],
+            # Some browser / os report it as text/plain but some as text/x-python when doing drag&drop
+            "text/x-python": [".py"],
+            # Or even as application/octet-stream when using the select file dialog
+            "application/octet-stream": [".py"],
+        },
     ).send()
 
     file_names = [file.name for file in files]

--- a/frontend/src/components/chat/Messages/Message/AskFileButton.tsx
+++ b/frontend/src/components/chat/Messages/Message/AskFileButton.tsx
@@ -20,9 +20,11 @@ interface UploadState {
 
 interface _AskFileButtonProps {
   askUser: IAsk;
+  parentId?: string;
   uploadFile: (
     file: File,
-    onProgress: (progress: number) => void
+    onProgress: (progress: number) => void,
+    parentId?: string
   ) => {
     xhr: XMLHttpRequest;
     promise: Promise<IFileRef>;
@@ -93,16 +95,20 @@ const _AskFileButton = ({
     const promises: Promise<IFileRef>[] = [];
 
     const newUploads = files.map((file, index) => {
-      const { xhr, promise } = uploadFile(file, (progress) => {
-        setUploads((prev) =>
-          prev.map((upload, i) => {
-            if (i === index) {
-              return { ...upload, progress };
-            }
-            return upload;
-          })
-        );
-      });
+      const { xhr, promise } = uploadFile(
+        file,
+        (progress) => {
+          setUploads((prev) =>
+            prev.map((upload, i) => {
+              if (i === index) {
+                return { ...upload, progress };
+              }
+              return upload;
+            })
+          );
+        },
+        askUser?.parentId
+      );
       promises.push(promise);
       return { progress: 0, uploaded: false, cancel: () => xhr.abort() };
     });

--- a/frontend/src/components/chat/MessagesContainer/index.tsx
+++ b/frontend/src/components/chat/MessagesContainer/index.tsx
@@ -36,8 +36,8 @@ const MessagesContainer = ({ navigate }: Props) => {
   const { t } = useTranslation();
 
   const uploadFile = useCallback(
-    (file: File, onProgress: (progress: number) => void) => {
-      return _uploadFile(file, onProgress);
+    (file: File, onProgress: (progress: number) => void, parentId?: string) => {
+      return _uploadFile(file, onProgress, parentId);
     },
     [_uploadFile]
   );

--- a/libs/react-client/src/api/index.tsx
+++ b/libs/react-client/src/api/index.tsx
@@ -245,7 +245,8 @@ export class ChainlitAPI extends APIBase {
   uploadFile(
     file: File,
     onProgress: (progress: number) => void,
-    sessionId: string
+    sessionId: string,
+    parentId?: string
   ) {
     const xhr = new XMLHttpRequest();
     xhr.withCredentials = true;
@@ -254,9 +255,12 @@ export class ChainlitAPI extends APIBase {
       const formData = new FormData();
       formData.append('file', file);
 
+      const ask_parent_id = parentId ? `&ask_parent_id=${parentId}` : '';
       xhr.open(
         'POST',
-        this.buildEndpoint(`/project/file?session_id=${sessionId}`),
+        this.buildEndpoint(
+          `/project/file?session_id=${sessionId}${ask_parent_id}`
+        ),
         true
       );
 

--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -152,8 +152,8 @@ const useChatInteract = () => {
   }, [session?.socket]);
 
   const uploadFile = useCallback(
-    (file: File, onProgress: (progress: number) => void) => {
-      return client.uploadFile(file, onProgress, sessionId);
+    (file: File, onProgress: (progress: number) => void, parentId?: string) => {
+      return client.uploadFile(file, onProgress, sessionId, parentId);
     },
     [sessionId]
   );


### PR DESCRIPTION
This a follow up of https://github.com/Chainlit/chainlit/issues/1658.

This PR solve :
- the validate_file_upload() that prevented uploading file with AskFileMessage when spontaneous_file_upload was set to False
- the POST /project/file will now validate the upload against the AskFileMessage limit/accept instead of the spontaneous upload limit/accept (fallback to spontaneous limits if not provided)