### PR TITLE
fix : Select highlighting is cut of (#1905)

### DIFF
--- a/frontend/src/components/ChatSettings/InputStateHandler.tsx
+++ b/frontend/src/components/ChatSettings/InputStateHandler.tsx
@@ -65,7 +65,7 @@ const InputStateHandler = ({
           ) : null}
         </label>
       )}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 p-2">
         {children}
         {description && (
           <div className="text-sm text-muted-foreground">{description}</div>


### PR DESCRIPTION
@willydouhard @dokterbob @hexart 
Solved the issue by adding an additional class to the relevant react template.

Did not change anything else therefore the failure of the `pnpm test` is directly from main branch (perhaps you should look into that).

Pytest:
```PowerShell
============================================================================================= test session starts ==============================================================================================
platform win32 -- Python 3.10.11, pytest-8.3.4, pluggy-1.5.0
rootdir: C:\Users\bob.vanonzen\projects\chainlit\backend
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.8.0, asyncio-0.23.8, cov-5.0.0, typeguard-4.4.1
asyncio: mode=auto
collected 130 items

tests\auth\test_cookie.py .....                                                                                                                                                                           [  3%]
tests\data\storage_clients\test_s3.py .                                                                                                                                                                   [  4%]
tests\data\test_get_data_layer.py .                                                                                                                                                                       [  5%]
tests\data\test_literalai.py ...................................                                                                                                                                          [ 32%]
tests\data\test_sql_alchemy.py ........                                                                                                                                                                   [ 38%]
tests\llama_index\test_callbacks.py ....                                                                                                                                                                  [ 41%]
tests\test_callbacks.py ..............                                                                                                                                                                    [ 52%]
tests\test_context.py .....                                                                                                                                                                               [ 56%]
tests\test_emitter.py ...............                                                                                                                                                                     [ 67%]
tests\test_server.py .........................................                                                                                                                                            [ 99%]
tests\test_user_session.py .                                                                                                                                                                              [100%]

=============================================================================================== warnings summary ===============================================================================================
tests/data/storage_clients/test_s3.py::test_upload_file
  C:\Users\bob.vanonzen\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\LocalCache\Local\pypoetry\Cache\virtualenvs\chainlit-NhWIowe7-py3.10\lib\site-packages\asyncer\_main.py:365: DeprecationWarning: The `cancellable=` keyword argument to `anyio.to_thread.run_sync` is deprecated since AnyIO 4.1.0; use `abandon_on_cancel=` instead
    return await anyio.to_thread.run_sync(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 130 passed, 1 warning in 132.95s (0:02:12) ==================================================================================
```

 pnpm test:
 ```PowerShell
 > @ test C:\Users\bob.vanonzen\projects\chainlit
> pnpm exec ts-node ./cypress/support/e2e.ts

Process on port 8000 killed
stdout: 2025-02-21 16:43:14 - Running in CI mode

stderr: Usage: chainlit.cmd run [OPTIONS] TARGET
Try 'chainlit.cmd run --help' for help.


stderr: Error: Invalid value: File does not exist: main.py

child process exited with code 2
Error: Command failed: pnpm exec ts-node ./cypress/support/run.ts action
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:882:11)
    at execSync (node:child_process:954:15)
    at runCommand (C:\Users\bob.vanonzen\projects\chainlit\cypress\support\utils.ts:29:18)
    at C:\Users\bob.vanonzen\projects\chainlit\cypress\support\utils.ts:17:3
    at step (C:\Users\bob.vanonzen\projects\chainlit\cypress\support\utils.ts:33:23)
    at Object.next (C:\Users\bob.vanonzen\projects\chainlit\cypress\support\utils.ts:14:53)
    at C:\Users\bob.vanonzen\projects\chainlit\cypress\support\utils.ts:8:71
    at new Promise (<anonymous>) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 6492,
  stdout: null,
  stderr: null
}
 ELIFECYCLE  Test failed. See above for more details.
 ```