### PR TITLE
fix(react-client): Chat settings won't be resumed when resuming thread

### DIFF
--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -62,6 +62,7 @@ const useChatSession = () => {
   const setIsAiSpeaking = useSetRecoilState(isAiSpeakingState);
   const setAudioConnection = useSetRecoilState(audioConnectionState);
   const resetChatSettingsValue = useResetRecoilState(chatSettingsValueState);
+  const setChatSettingsValue = useSetRecoilState(chatSettingsValueState);
   const setFirstUserInteraction = useSetRecoilState(firstUserInteraction);
   const setLoading = useSetRecoilState(loadingState);
   const wavStreamPlayer = useRecoilValue(wavStreamPlayerState);
@@ -189,6 +190,9 @@ const useChatSession = () => {
         }
         if (thread.metadata?.chat_profile) {
           setChatProfile(thread.metadata?.chat_profile);
+        }
+        if (thread.metadata?.chat_settings) {
+          setChatSettingsValue(thread.metadata?.chat_settings);
         }
         setMessages(messages);
         const elements = thread.elements || [];


### PR DESCRIPTION
When resuming thread, the backend has already sent the chat setting values to the frontend. However,
the frontend doesn't resume the values. As a result, the setting button will be disappeared after resuming
the thread.

This PR will resume the setting values in the frontend when resuming the thread to fix the problem.