### PR TITLE
revert PREFIX of fastapi server.

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -74,8 +74,6 @@ from ._utils import is_path_inside
 mimetypes.add_type("application/javascript", ".js")
 mimetypes.add_type("text/css", ".css")
 
-PREFIX = os.environ.get("CHAINLIT_ROOT_PATH", "")
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Context manager to handle app start and shutdown."""
@@ -201,7 +199,7 @@ asgi_app = socketio.ASGIApp(
     socketio_path="",
 )
 
-app.mount(f"{PREFIX}/ws/socket.io", asgi_app)
+app.mount(f"{config.run.root_path}/ws/socket.io", asgi_app)
 
 app.add_middleware(
     CORSMiddleware,
@@ -211,7 +209,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-router = APIRouter(prefix=PREFIX)
+router = APIRouter(prefix=config.run.root_path)
 
 
 @router.get("/public/{filename:path}")

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -74,6 +74,7 @@ from ._utils import is_path_inside
 mimetypes.add_type("application/javascript", ".js")
 mimetypes.add_type("text/css", ".css")
 
+PREFIX = os.environ.get("CHAINLIT_ROOT_PATH", "")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -200,7 +201,7 @@ asgi_app = socketio.ASGIApp(
     socketio_path="",
 )
 
-app.mount("/ws/socket.io", asgi_app)
+app.mount(f"{PREFIX}/ws/socket.io", asgi_app)
 
 app.add_middleware(
     CORSMiddleware,
@@ -210,7 +211,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-router = APIRouter()
+router = APIRouter(prefix=PREFIX)
 
 
 @router.get("/public/{filename:path}")


### PR DESCRIPTION
After the changes introduced in [this pull request](https://github.com/Chainlit/chainlit/pull/1723/files), issue [#1904](https://github.com/Chainlit/chainlit/issues/1904) occurred, leading to a rollback of the changes.

I tested running the following script locally using the command:

```
chainlit run demo.py -w --root-path /app
```

demo.py

```python
import chainlit as cl


@cl.step(type="tool")
async def tool():
    # Fake tool
    await cl.sleep(2)
    return "Response from the tool!"


@cl.on_message  # this function will be called every time a user inputs a message in the UI
async def main(message: cl.Message):
    """
    This function is called every time a user inputs a message in the UI.
    It sends back an intermediate response from the tool, followed by the final answer.

    Args:
        message: The user's message.

    Returns:
        None.
    """


    # Call the tool
    tool_res = await tool()

    await cl.Message(content=tool_res).send()

```

The script runs without any issues in this setup. However, I have not yet investigated any potential side effects. I would appreciate it if you could review this further.