### PR TITLE
fix: Include element `props` in SQLAlchemyDataLayer query for elements

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -519,7 +519,12 @@ class SQLAlchemyDataLayer(BaseDataLayer):
 
         columns = ", ".join(f'"{column}"' for column in element_dict_cleaned.keys())
         placeholders = ", ".join(f":{column}" for column in element_dict_cleaned.keys())
-        query = f"INSERT INTO elements ({columns}) VALUES ({placeholders})"
+        updates = ", ".join(
+            f'"{column}" = :{column}'
+            for column in element_dict_cleaned.keys()
+            if column != "id"
+        )
+        query = f"INSERT INTO elements ({columns}) VALUES ({placeholders}) ON CONFLICT (id) DO UPDATE SET {updates};"
         await self.execute_sql(query=query, parameters=element_dict_cleaned)
 
     @queue_until_user_message()
@@ -627,7 +632,8 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 e."language" AS element_language,
                 e."page" AS element_page,
                 e."forId" AS element_forid,
-                e."mime" AS element_mime
+                e."mime" AS element_mime,
+                e."props" AS props
             FROM elements e
             WHERE e."threadId" IN {thread_ids}
         """
@@ -712,7 +718,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                         autoPlay=element.get("element_autoPlay"),
                         playerConfig=element.get("element_playerconfig"),
                         page=element.get("element_page"),
-                        props=json.loads(element.get("props", "{}")),
+                        props=element.get("props", "{}"),
                         forId=element.get("element_forid"),
                         mime=element.get("element_mime"),
                     )


### PR DESCRIPTION
# Description
Fixes an issue arising with `SQLAlchemyDataLayer` in which a custom element's state would not be properly reloaded after resuming a chat thread due to a null value for the element's `props`. https://github.com/Chainlit/chainlit/issues/1799 documents the issue in more detail, including a fix.

# Problem
In `sql_alchemy.py`, the SQL query contained in `elements_query` is missing the `props`. Since this is missing, any reloaded custom element will have an empty value for `props` thereby ignoring its latest state.

Also, there was an error on insertion of new elements into the database in an identical fashion to https://github.com/Chainlit/chainlit/pull/1794 which fixes the same error in the default Postgres data layer. This PR includes the same fix for the SQLAlchemyDataLayer which also blocked a successful element refresh workflow.

# Steps to Reproduce
- Create an application with a custom Element
- Use the SQLAlchemyDataLayer for persistence
- Create a Chainlit app instantiating the custom Element
- Update the state of the element
- Refresh the page or create a new conversation, then switch back to the original one

# Solution and Changes
Add the `props` field to the query and use `props=element.get("props", "{}")` instead of `props=json.loads(element.get("props", "{}"))`

# Testing
- Ran `pytest` from `backend/` with no failures or errors and all tests finishing.
- Successfully tested with my application which uses the S3 storage client and SQLAlchemyDataLayer with Azure PostgreSQL (flexible server). I created two new chat threads, triggered the custom element creation, and created a third chat. I then switched back to the two earlier chat threads and verified that the elements' props were loaded and the element state was properly set.