### PR TITLE
fix: Fix Element mime type by fixing from_dict()

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -150,7 +150,7 @@ class Element:
         object_key = e_dict.get("objectKey")
         chainlit_key = e_dict.get("chainlitKey")
         display = e_dict.get("display", "inline")
-        mime_type = e_dict.get("type", "")
+        mime_type = e_dict.get("mime", "")
 
         # Common parameters for all element types
         common_params = {


### PR DESCRIPTION
Fixes #1831 

Element type "file" was being used for both `type` and `mime`
![image](https://github.com/user-attachments/assets/ebf9fa51-85c2-4e74-83cc-b73479af212e)

After changing mime to "mime" we get the intended results
![image](https://github.com/user-attachments/assets/f5a7df5d-b89b-42a1-9528-a75e2a4a609d)
