### PR TITLE
fix: file extensions are now checked in lowercase for uploads

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1152,7 +1152,9 @@ def validate_file_mime_type(file: UploadFile):
                 if len(extensions) == 0:
                     return
                 for extension in extensions:
-                    if file.filename is not None and file.filename.endswith(extension):
+                    if file.filename is not None and file.filename.lower().endswith(
+                        extension.lower()
+                    ):
                         return
     raise ValueError("File type not allowed")
 


### PR DESCRIPTION
When we add specific file extensions in the spontaneous_file_upload.accept like this : 

```toml
[features.spontaneous_file_upload]
    enabled = true
    accept = { "application/octet-stream" = [".xyz", ".pdb", ".aac"] }
```

If the endpoint receive a file with an extension in upper case an error is reported. We have many os, some are case sensitive some not. In case sensitive os'es extensions like .MP3, .mp3, Mp3 or event mP3 is interpreted as the same extension.

This change allow those os'es to send files whatever the extension's case.