### PR TITLE
Fix: Ensure clear_auth_cookie uses the correct secure and samesite settings

### DIFF
--- a/backend/chainlit/auth/cookie.py
+++ b/backend/chainlit/auth/cookie.py
@@ -150,10 +150,7 @@ def set_auth_cookie(request: Request, response: Response, token: str):
     # Delete remaining prior cookies/cookie chunks
     for k in existing_cookies:
         response.delete_cookie(
-            key=k,
-            path="/",
-            secure=_cookie_secure,
-            samesite=_cookie_samesite
+            key=k, path="/", secure=_cookie_secure, samesite=_cookie_samesite
         )
 
 
@@ -168,10 +165,7 @@ def clear_auth_cookie(request: Request, response: Response):
 
     for k in existing_cookies:
         response.delete_cookie(
-            key=k,
-            path="/",
-            secure=_cookie_secure,
-            samesite=_cookie_samesite
+            key=k, path="/", secure=_cookie_secure, samesite=_cookie_samesite
         )
 
 

--- a/backend/chainlit/auth/cookie.py
+++ b/backend/chainlit/auth/cookie.py
@@ -149,7 +149,12 @@ def set_auth_cookie(request: Request, response: Response, token: str):
 
     # Delete remaining prior cookies/cookie chunks
     for k in existing_cookies:
-        response.delete_cookie(key=k, path="/")
+        response.delete_cookie(
+            key=k,
+            path="/",
+            secure=_cookie_secure,
+            samesite=_cookie_samesite
+        )
 
 
 def clear_auth_cookie(request: Request, response: Response):
@@ -162,7 +167,12 @@ def clear_auth_cookie(request: Request, response: Response):
     }
 
     for k in existing_cookies:
-        response.delete_cookie(key=k, path="/")
+        response.delete_cookie(
+            key=k,
+            path="/",
+            secure=_cookie_secure,
+            samesite=_cookie_samesite
+        )
 
 
 def set_oauth_state_cookie(response: Response, token: str):


### PR DESCRIPTION
This pull request fixes an issue where `clear_auth_cookie` did not explicitly specify the `secure` and `samesite` attributes when deleting authentication cookies.  

### Issue:  
- The `set_auth_cookie` function correctly sets cookies using the `_cookie_secure` and `_cookie_samesite` values.  
- These values are derived from the environment variable `CHAINLIT_COOKIE_SAMESITE`.  
  - If `CHAINLIT_COOKIE_SAMESITE` is `"none"`, then `_cookie_secure` is set to `True`, ensuring the cookie is only sent over HTTPS.  
  - Otherwise, `_cookie_secure` is `False`.  
- However, `clear_auth_cookie` did not apply these settings when deleting cookies.  
- If a user had customized `CHAINLIT_COOKIE_SAMESITE` to a value other than the default (`"lax"`), the logout process could fail because the browser might not clear the cookie correctly.  

### Fix:  
- `clear_auth_cookie` now ensures that cookies are deleted using the same `secure` and `samesite` settings as `set_auth_cookie`.  
- This ensures that logout behaves correctly regardless of custom cookie settings.  

This change improves consistency and ensures proper authentication cleanup across different deployment environments.  