### PR TITLE
fix: threadId assignment to first user message

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -345,6 +345,9 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Steps ######
     @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
+
+        await self.update_thread(step_dict["threadId"])  
+
         if self.show_logger:
             logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")
 

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -345,8 +345,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
     ###### Steps ######
     @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
-
-        await self.update_thread(step_dict["threadId"])  
+        await self.update_thread(step_dict["threadId"])
 
         if self.show_logger:
             logger.info(f"SQLAlchemy: create_step, step_id={step_dict.get('id')}")


### PR DESCRIPTION
**Describe the bug**
In SQLAlchemy data layer, create_step is executed before update_thread which prevents first user message from being saved in the database with a threadId assigned resulting in cutting it out when on_chat_resume is triggered.

Here's what happened when I send the first message to the UI: 

An error occurred: (sqlalchemy.dialects.postgresql.asyncpg.IntegrityError) <class 'asyncpg.exceptions.ForeignKeyViolationError'>: insert or update on table "steps" violates foreign key constraint "steps_threadId_fkey"
DETAIL:  Key (threadId)=(7bfc3437-cf41-417f-8fbb-642fa25b420d) is not present in table "threads".

**How I fixed it**
I added this line of code at the beginning of 'create_step' function:

`await self.update_thread(step_dict["threadId"])`

forcing update_thread to be executed first. 

