### PR TITLE
fix: Sort thread history groups in fixed order

### DIFF
--- a/frontend/src/components/LeftSidebar/ThreadList.tsx
+++ b/frontend/src/components/LeftSidebar/ThreadList.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import { size } from 'lodash';
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
@@ -74,6 +74,24 @@ export function ThreadList({
   const [threadNewName, setThreadNewName] = useState<string>();
   const setThreadHistory = useSetRecoilState(threadHistoryState);
   const apiClient = useContext(ChainlitContext);
+
+  const sortedTimeGroupKeys = useMemo(() => {
+    if (!threadHistory?.timeGroupedThreads) return [];
+    const fixedOrder = [
+      'Today',
+      'Yesterday',
+      'Previous 7 days',
+      'Previous 30 days'
+    ];
+    return Object.keys(threadHistory.timeGroupedThreads).sort((a, b) => {
+      const aIndex = fixedOrder.indexOf(a);
+      const bIndex = fixedOrder.indexOf(b);
+      if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+      if (aIndex !== -1) return -1;
+      if (bIndex !== -1) return 1;
+      return a.localeCompare(b);
+    });
+  }, [threadHistory?.timeGroupedThreads]);
 
   if (isFetching || (!threadHistory?.timeGroupedThreads && isLoadingMore)) {
     return (
@@ -150,7 +168,6 @@ export function ThreadList({
           const threadIndex = next.threads?.findIndex(
             (t) => t.id === threadIdToRename
           );
-
           if (typeof threadIndex === 'number' && next.threads) {
             next.threads[threadIndex] = {
               ...next.threads[threadIndex],
@@ -237,9 +254,7 @@ export function ThreadList({
               id="name"
               required
               value={threadNewName}
-              onChange={(e) => {
-                setThreadNewName(e.target.value);
-              }}
+              onChange={(e) => setThreadNewName(e.target.value)}
               placeholder={t(
                 'threadHistory.thread.actions.rename.form.name.placeholder'
               )}
@@ -260,73 +275,54 @@ export function ThreadList({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      {Object.keys(threadHistory.timeGroupedThreads ?? {})
-        .sort((a, b) => {
-          const fixedOrder = [
-            'Today',
-            'Yesterday',
-            'Previous 7 days',
-            'Previous 30 days'
-          ];
-          const aIndex = fixedOrder.indexOf(a);
-          const bIndex = fixedOrder.indexOf(b);
-          if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
-          if (aIndex !== -1) return -1;
-          if (bIndex !== -1) return 1;
-          return a.localeCompare(b);
-        })
-        .map((group) => {
-          const items = threadHistory.timeGroupedThreads![group];
-          return (
-            <SidebarGroup key={group}>
-              <SidebarGroupLabel>{getTimeGroupLabel(group)}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {items.map((thread) => {
-                    const isResumed =
-                      idToResume === thread.id &&
-                      !threadHistory.currentThreadId;
-                    const isSelected =
-                      isResumed || threadHistory.currentThreadId === thread.id;
-                    return (
-                      <SidebarMenuItem
-                        key={thread.id}
-                        id={`thread-${thread.id}`}
-                      >
-                        <Link to={isResumed ? '' : `/thread/${thread.id}`}>
-                          <SidebarMenuButton
-                            isActive={isSelected}
-                            className="relative truncate h-9 group/thread"
-                          >
-                            {thread.name || (
-                              <Translator path="threadHistory.thread.untitled" />
+      {sortedTimeGroupKeys.map((group) => {
+        const items = threadHistory!.timeGroupedThreads![group];
+        return (
+          <SidebarGroup key={group}>
+            <SidebarGroupLabel>{getTimeGroupLabel(group)}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {items.map((thread) => {
+                  const isResumed =
+                    idToResume === thread.id && !threadHistory!.currentThreadId;
+                  const isSelected =
+                    isResumed || threadHistory!.currentThreadId === thread.id;
+                  return (
+                    <SidebarMenuItem key={thread.id} id={`thread-${thread.id}`}>
+                      <Link to={isResumed ? '' : `/thread/${thread.id}`}>
+                        <SidebarMenuButton
+                          isActive={isSelected}
+                          className="relative truncate h-9 group/thread"
+                        >
+                          {thread.name || (
+                            <Translator path="threadHistory.thread.untitled" />
+                          )}
+                          <div
+                            className={cn(
+                              'absolute w-10 bottom-0 top-0 right-0 bg-gradient-to-l from-[hsl(var(--sidebar-background))] to-transparent'
                             )}
-                            <div
-                              className={cn(
-                                'absolute w-10 bottom-0 top-0 right-0 bg-gradient-to-l from-[hsl(var(--sidebar-background))] to-transparent'
-                              )}
-                            />
-                            <ThreadOptions
-                              onDelete={() => setThreadIdToDelete(thread.id)}
-                              onRename={() => {
-                                setThreadIdToRename(thread.id);
-                                setThreadNewName(thread.name);
-                              }}
-                              className={cn(
-                                'absolute z-20 bottom-0 top-0 right-0 bg-sidebar-accent hover:bg-sidebar-accent hover:text-primary flex opacity-0 group-hover/thread:opacity-100',
-                                isSelected && 'bg-sidebar-accent opacity-100'
-                              )}
-                            />
-                          </SidebarMenuButton>
-                        </Link>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          );
-        })}
+                          />
+                          <ThreadOptions
+                            onDelete={() => setThreadIdToDelete(thread.id)}
+                            onRename={() => {
+                              setThreadIdToRename(thread.id);
+                              setThreadNewName(thread.name);
+                            }}
+                            className={cn(
+                              'absolute z-20 bottom-0 top-0 right-0 bg-sidebar-accent hover:bg-sidebar-accent hover:text-primary flex opacity-0 group-hover/thread:opacity-100',
+                              isSelected && 'bg-sidebar-accent opacity-100'
+                            )}
+                          />
+                        </SidebarMenuButton>
+                      </Link>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        );
+      })}
       {isLoadingMore ? (
         <div className="flex items-center justify-center p-2">
           <Loader />


### PR DESCRIPTION
This PR fixes the inconsistent order of thread history groups in the left sidebar. The groups (Today, Yesterday, Previous 7 days, Previous 30 days) were stored as object keys, and JavaScript does not guarantee their order. I added explicit sorting using a fixed order array so that the groups always appear in the intended order.