### PR TITLE
fix: backward compatible with sqlite+sqlalchemy

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -56,6 +56,8 @@ async def resume_thread(session: WebsocketSession):
 
     if user_is_author:
         metadata = thread.get("metadata") or {}
+        if type(metadata) == str:
+            metadata = json.loads(metadata)
         user_sessions[session.id] = metadata.copy()
         if chat_profile := metadata.get("chat_profile"):
             session.chat_profile = chat_profile


### PR DESCRIPTION
With SQLAlchemy on SQLite, the data type return is str not dict. Check if the metadata field type is string, then convert to dict by json.loads

```
  File "/opt/miniconda3/lib/python3.12/asyncio/tasks.py", line 314, in __step_run_and_handle_result
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/Users/kaija/Desktop/demo/venv/lib/python3.12/site-packages/socketio/async_server.py", line 612, in _handle_event_internal
    r = await server._trigger_event(data[0], namespace, sid, *data[1:])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaija/Desktop/demo/venv/lib/python3.12/site-packages/socketio/async_server.py", line 640, in _trigger_event
    ret = await handler(*args)
          ^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaija/Desktop/demo/venv/lib/python3.12/site-packages/chainlit/socket.py", line 177, in connection_successful
    thread = await resume_thread(context.session)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kaija/Desktop/demo/venv/lib/python3.12/site-packages/chainlit/socket.py", line 55, in resume_thread
    user_sessions[session.id] = metadata.copy()
                                ^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'copy'
```