### PR TITLE
fix: oauth redirection with root path = '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Pasting text/images into Chainlit Copilot should now work
+- OAuth redirection should work when submounting Chainlit with root path `/`
 
 ### Removed
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -430,6 +430,7 @@ def _get_auth_response(access_token: str, redirect_to_callback: bool) -> Respons
 
     if redirect_to_callback:
         root_path = os.environ.get("CHAINLIT_ROOT_PATH", "")
+        root_path = "" if root_path == "/" else root_path
         redirect_url = (
             f"{root_path}/login/callback?{urllib.parse.urlencode(response_dict)}"
         )


### PR DESCRIPTION
Fixing https://github.com/Chainlit/chainlit/issues/1986