### PR TITLE
feat(backend/mcp): Support set env vars from command line

### DIFF
--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -64,5 +64,13 @@ def validate_mcp_command(command_string: str):
 
     # Return 'npx' as the executable and everything after it as args
     args_list = parts[executable_index + 1 :]
+    env_list = parts[:executable_index]
+    env = {}
+    for env_var in env_list:
+        if "=" in env_var:
+            key, value = env_var.split("=", 1)
+            env[key] = value
+        else:
+            raise ValueError(f"Invalid environment variable format: {env_var}")
 
-    return executable, args_list
+    return env, executable, args_list

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1072,7 +1072,11 @@ async def connect_mcp(
 ):
     from mcp import ClientSession
     from mcp.client.sse import sse_client
-    from mcp.client.stdio import StdioServerParameters, stdio_client
+    from mcp.client.stdio import (
+        StdioServerParameters,
+        get_default_environment,
+        stdio_client,
+    )
 
     from chainlit.context import init_ws_context
     from chainlit.mcp import SseMcpConnection, StdioMcpConnection, validate_mcp_command
@@ -1111,16 +1115,18 @@ async def connect_mcp(
                     sse_client(url=mcp_connection.url)
                 )
             elif payload.clientType == "stdio":
-                command, args = validate_mcp_command(payload.fullCommand)
+                env_from_cmd, command, args = validate_mcp_command(payload.fullCommand)
                 mcp_connection = StdioMcpConnection(  # type: ignore[no-redef]
                     command=command, args=args, name=payload.name
                 )  # type: StdioMcpConnection
 
+                env = get_default_environment()
+                env.update(env_from_cmd)
                 # Create the server parameters
                 server_params = StdioServerParameters(
                     command=command,
                     args=args,
-                    env=None,
+                    env=env,
                 )
 
                 transport = await exit_stack.enter_async_context(


### PR DESCRIPTION
Some MCP servers need env vars to set API keys, configure, etc. This commit will add support to set env vars from command line.