### PR TITLE
fix: chat_profiles model description

### DIFF
--- a/frontend/src/components/header/ChatProfiles.tsx
+++ b/frontend/src/components/header/ChatProfiles.tsx
@@ -103,7 +103,7 @@ export default function ChatProfiles({ navigate }: Props) {
               : profile.icon;
 
             return (
-              <HoverCard openDelay={100} closeDelay={0} key={profile.name}>
+              <HoverCard openDelay={0} closeDelay={0} key={profile.name}>
                 <HoverCardTrigger asChild>
                   <SelectItem
                     data-test={`select-item:${profile.name}`}


### PR DESCRIPTION
Fix an issue where model description (in Chat Profiles) does not disappear when quickly hovered

## Screenshot
![Screenshot 2025-03-16 at 2 35 39 PM](https://github.com/user-attachments/assets/eff7b167-cba9-40ac-a54b-ce7acc18dd60)
