### PR TITLE
feat(mcp): Support custom cmd allow list for mcp server

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -116,6 +116,11 @@ edit_message = true
     # Sample rate of the audio
     sample_rate = 24000
 
+[features.mcp]
+    # Only the executables in the allow list can be used for MCP stdio server.
+    # Only need the base name of the executable, e.g. "npx", not "/usr/bin/npx".
+    stdio_executable_allow_list = [ "npx", "uvx" ]
+
 [UI]
 # Name of the assistant.
 name = "Assistant"
@@ -213,11 +218,17 @@ class AudioFeature(DataClassJsonMixin):
     enabled: bool = False
 
 
+@dataclass
+class MCPFeature(DataClassJsonMixin):
+    enabled: bool = False
+    stdio_executable_allow_list: Optional[list[str]] = None
+
+
 @dataclass()
 class FeaturesSettings(DataClassJsonMixin):
     spontaneous_file_upload: Optional[SpontaneousFileUploadFeature] = None
     audio: Optional[AudioFeature] = Field(default_factory=AudioFeature)
-    mcp: bool = False
+    mcp: MCPFeature = Field(default_factory=MCPFeature)
     latex: bool = False
     user_message_autoscroll: bool = True
     unsafe_allow_html: bool = False

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -117,9 +117,17 @@ edit_message = true
     sample_rate = 24000
 
 [features.mcp]
+    enabled = false
+
+[features.mcp.sse]
+    enabled = true
+
+[features.mcp.stdio]
+    enabled = true
     # Only the executables in the allow list can be used for MCP stdio server.
     # Only need the base name of the executable, e.g. "npx", not "/usr/bin/npx".
-    stdio_executable_allow_list = [ "npx", "uvx" ]
+    # Please don't comment this line for now, we need it to parse the executable name.
+    allowed_executables = [ "npx", "uvx" ]
 
 [UI]
 # Name of the assistant.
@@ -219,16 +227,28 @@ class AudioFeature(DataClassJsonMixin):
 
 
 @dataclass
-class MCPFeature(DataClassJsonMixin):
+class McpSseFeature(DataClassJsonMixin):
+    enabled: bool = True
+
+
+@dataclass
+class McpStdioFeature(DataClassJsonMixin):
+    enabled: bool = True
+    allowed_executables: Optional[list[str]] = None
+
+
+@dataclass
+class McpFeature(DataClassJsonMixin):
     enabled: bool = False
-    stdio_executable_allow_list: Optional[list[str]] = None
+    sse: McpSseFeature = Field(default_factory=McpSseFeature)
+    stdio: McpStdioFeature = Field(default_factory=McpStdioFeature)
 
 
 @dataclass()
 class FeaturesSettings(DataClassJsonMixin):
     spontaneous_file_upload: Optional[SpontaneousFileUploadFeature] = None
     audio: Optional[AudioFeature] = Field(default_factory=AudioFeature)
-    mcp: MCPFeature = Field(default_factory=MCPFeature)
+    mcp: McpFeature = Field(default_factory=McpFeature)
     latex: bool = False
     user_message_autoscroll: bool = True
     unsafe_allow_html: bool = False

--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -50,14 +50,11 @@ def validate_mcp_command(command_string: str):
     # Look for the actual executable in the command
     executable = None
     executable_index = None
-    allowed_executables = config.features.mcp.stdio_executable_allow_list or [
-        "npx",
-        "uvx",
-    ]
+    allowed_executables = config.features.mcp.stdio.allowed_executables
     for i, part in enumerate(parts):
         # Remove any path components to get the base executable name
         base_exec = part.split("/")[-1].split("\\")[-1]
-        if base_exec in allowed_executables:
+        if allowed_executables is None or base_exec in allowed_executables:
             executable = part
             executable_index = i
             break
@@ -65,6 +62,8 @@ def validate_mcp_command(command_string: str):
     if executable is None or executable_index is None:
         raise ValueError(
             f"Only commands in ({', '.join(allowed_executables)}) are allowed"
+            if allowed_executables
+            else "No allowed executables found"
         )
 
     # Return `executable` as the executable and everything after it as args

--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -2,6 +2,8 @@ from typing import Literal, Union
 
 from pydantic import BaseModel
 
+from chainlit.config import config
+
 
 class StdioMcpConnection(BaseModel):
     name: str
@@ -21,22 +23,23 @@ McpConnection = Union[StdioMcpConnection, SseMcpConnection]
 
 def validate_mcp_command(command_string: str):
     """
-    Validates that a command string uses 'npx' or 'uvx as the executable and returns
+    Validates that a command string uses command in the allowed list as the executable and returns
     the executable and list of arguments suitable for subprocess calls.
 
     This function handles potential command prefixes, flags, and options
-    to ensure only npx commands are allowed.
+    to ensure only commands in allowed list are allowed.
 
     Args:
         command_string (str): The full command string to validate
 
     Returns:
-        tuple: (executable, args_list) where:
-            - executable (str): Always 'npx' or 'uvx' if valid
+        tuple: (env, executable, args_list) where:
+            - env (dict): Environment variables as a dictionary
+            - executable (str): The executable name or path
             - args_list (list): List of command arguments
 
     Raises:
-        ValueError: If the command doesn't use 'npx' or 'uvx' as the executable
+        ValueError: If the command doesn't use an allowed executable
     """
     # Split the command string into parts
     parts = command_string.strip().split()
@@ -47,22 +50,24 @@ def validate_mcp_command(command_string: str):
     # Look for the actual executable in the command
     executable = None
     executable_index = None
+    allowed_executables = config.features.mcp.stdio_executable_allow_list or [
+        "npx",
+        "uvx",
+    ]
     for i, part in enumerate(parts):
         # Remove any path components to get the base executable name
         base_exec = part.split("/")[-1].split("\\")[-1]
-        if base_exec == "npx":
-            executable = "npx"
-            executable_index = i
-            break
-        if base_exec == "uvx":
-            executable = "uvx"
+        if base_exec in allowed_executables:
+            executable = part
             executable_index = i
             break
 
     if executable is None or executable_index is None:
-        raise ValueError("Only 'npx' or 'uvx' commands are allowed")
+        raise ValueError(
+            f"Only commands in ({', '.join(allowed_executables)}) are allowed"
+        )
 
-    # Return 'npx' as the executable and everything after it as args
+    # Return `executable` as the executable and everything after it as args
     args_list = parts[executable_index + 1 :]
     env_list = parts[:executable_index]
     env = {}

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1091,8 +1091,8 @@ async def connect_mcp(
                 status_code=401,
             )
 
-    on_mcp_connect = config.code.on_mcp_connect
-    if on_mcp_connect:
+    mcp_enabled = config.features.mcp.enabled and config.code.on_mcp_connect is not None
+    if mcp_enabled:
         if payload.name in session.mcp_sessions:
             old_client_session, old_exit_stack = session.mcp_sessions[payload.name]
             if on_mcp_disconnect := config.code.on_mcp_disconnect:
@@ -1157,7 +1157,7 @@ async def connect_mcp(
             session.mcp_sessions[mcp_connection.name] = (mcp_session, exit_stack)
 
             # Call the callback
-            await on_mcp_connect(mcp_connection, mcp_session)
+            await config.code.on_mcp_connect(mcp_connection, mcp_session)
 
         except Exception as e:
             raise HTTPException(

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -762,7 +762,7 @@ async def project_settings(
         config.features.audio.enabled = True
 
     if config.code.on_mcp_connect:
-        config.features.mcp = True
+        config.features.mcp.enabled = True
 
     debug_url = None
     data_layer = get_data_layer()


### PR DESCRIPTION
Some mcp servers are implemented using compiled language (such as go), and can't run via `npx` or `uvx`. This PR supports to custom allow list for the commands to run mcp servers.