### PR TITLE
Fix: Resolve WebSocket connection error when deleting chat history

### DIFF
--- a/frontend/src/components/LeftSidebar/ThreadList.tsx
+++ b/frontend/src/components/LeftSidebar/ThreadList.tsx
@@ -117,13 +117,14 @@ export function ThreadList({
     );
   }
 
-  const handleDeleteThread = () => {
+  const handleDeleteThread = async () => {
     if (!threadIdToDelete) return;
     if (
       threadIdToDelete === idToResume ||
       threadIdToDelete === currentThreadId
     ) {
       clear();
+      await new Promise((resolve) => setTimeout(resolve, 300));
     }
 
     toast.promise(apiClient.deleteThread(threadIdToDelete), {


### PR DESCRIPTION
## Issue
When deleting a chat history session from the sidebar, a WebSocket error occurs:
"WebSocket is closed before the connection is established."

## Solution
Added a short delay (300ms) after clearing the current session before proceeding with the delete operation. This gives the WebSocket enough time to properly reconnect before continuing with the session deletion process.