### PR TITLE
[Feature] Add Azure AD Group Memberships to User Metadata

### DIFF
--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -1,8 +1,14 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Union
 
-from azure.storage.blob import BlobSasPermissions, ContentSettings, generate_blob_sas
-from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
+from azure.storage.blob import (  # type: ignore
+    BlobSasPermissions,
+    ContentSettings,
+    generate_blob_sas,
+)
+from azure.storage.blob.aio import (  # type: ignore
+    BlobServiceClient as AsyncBlobServiceClient,
+)
 
 from chainlit.data.storage_clients.base import EXPIRY_TIME, BaseStorageClient
 from chainlit.logger import logger

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -2,7 +2,7 @@ import base64
 from typing import Any, Dict, Union
 
 from google.cloud import storage  # type: ignore
-from google.oauth2 import service_account
+from google.oauth2 import service_account  # type: ignore
 
 from chainlit import make_async
 from chainlit.data.storage_clients.base import EXPIRY_TIME, BaseStorageClient

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "pnpm run lintUi && pnpm run lintPython",
     "lintUi": "pnpm run --parallel lint",
     "formatUi": "pnpm run --parallel format",
-    "lintPython": "cd backend && poetry run dmypy run --timeout 600 -- chainlit/ tests/",
+    "lintPython": "cd backend && poetry run dmypy run -- chainlit/ tests/",
     "formatPython": "black `git ls-files | grep '.py$'` && isort --profile=black .",
     "buildUi": "cd libs/react-client && pnpm run build && cd ../copilot && pnpm run build && cd ../../frontend && pnpm run build"
   },


### PR DESCRIPTION
This PR updates the oauth_providers.py file to include Azure Active Directory (Azure AD) group memberships in the user metadata. 

The following changes were made:

1. Fetch Group Memberships: Added logic to retrieve group memberships using the Microsoft Graph API.
2. Error Handling: Implemented a try-except block to gracefully handle any errors during the group membership fetch process.
3. User Metadata Update: Updated the User object to include the fetched group memberships under the groups key in the metadata.

**Testing:**
- Verified that group memberships are correctly fetched and added to the user metadata.
- Tested error handling to ensure the application continues to function if the group membership fetch fails.

**Dependencies:**

- No new dependencies were added.

**Notes:**

- This change ensures that user group memberships are available for downstream processes that rely on user metadata.
- Backward compatibility is maintained as errors during group membership fetch are ignored.