### PR TITLE
Fix: Images disappear after page reload when using AzureBlobStorageClient

### DIFF
--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -70,6 +70,8 @@ class AzureBlobStorageClient(BaseStorageClient):
 
             return {
                 "path": object_key,
+                "object_key": object_key,
+                "url": self.get_read_url(object_key),
                 "size": properties.size,
                 "last_modified": properties.last_modified,
                 "etag": properties.etag,

--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -71,7 +71,7 @@ class AzureBlobStorageClient(BaseStorageClient):
             return {
                 "path": object_key,
                 "object_key": object_key,
-                "url": self.get_read_url(object_key),
+                "url": await self.get_read_url(object_key),
                 "size": properties.size,
                 "last_modified": properties.last_modified,
                 "etag": properties.etag,


### PR DESCRIPTION
fix https://github.com/Chainlit/chainlit/issues/1756


## What
This PR updates the Azure Blob Storage implementation of `upload_file` to return a consistent response format that includes both `object_key` and `url` keys, aligning with other storage providers like S3 and GCS.

The current implementation returns:
```python
{
    "path": object_key,
    "size": properties.size,
    # other properties but no url or object_key
}
```

While the S3 implementation returns:
```python
{
    "object_key": object_key,
    "url": url
}
```

## Why
Currently, when using `SQLAlchemyDataLayer` with Azure Blob Storage, uploaded images disappear after page reload. This is because:

1. The Element data model expects either a `url` or `chainlit_key` to display media
2. Frontend components check for `element.url` first when rendering elements
3. When saving to the database, `SQLAlchemyDataLayer` tries to get the URL from `uploaded_file.get("url")`, which is `None` for Azure Blob Storage

This inconsistency causes files to appear initially (using temporary URLs) but disappear after reload since the persisted element lacks a valid URL.

Note: As mentioned in the related issue, in future releases it might be better to further improve this by generating temporary read-only URLs that expire after a certain period rather than storing long-lived URLs directly.