### PR TITLE
feat: support additionalQueryParamsForAPI setting in copilot

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -25,6 +25,7 @@ const onError = (error: ClientError) => {
 export const apiClient = new ChainlitAPI(
   httpEndpoint,
   'webapp',
+  {}, // Optional - additionalQueryParams property.
   on401,
   onError
 );

--- a/libs/copilot/src/api.ts
+++ b/libs/copilot/src/api.ts
@@ -2,7 +2,10 @@ import { toast } from 'sonner';
 
 import { ChainlitAPI, ClientError } from '@chainlit/react-client';
 
-export function makeApiClient(chainlitServer: string) {
+export function makeApiClient(
+  chainlitServer: string,
+  additionalQueryParams: Record<string, string>
+) {
   const httpEndpoint = chainlitServer;
 
   const on401 = () => {
@@ -13,5 +16,11 @@ export function makeApiClient(chainlitServer: string) {
     toast.error(error.toString());
   };
 
-  return new ChainlitAPI(httpEndpoint, 'copilot', on401, onError);
+  return new ChainlitAPI(
+    httpEndpoint,
+    'copilot',
+    additionalQueryParams,
+    on401,
+    onError
+  );
 }

--- a/libs/copilot/src/appWrapper.tsx
+++ b/libs/copilot/src/appWrapper.tsx
@@ -14,7 +14,11 @@ interface Props {
 }
 
 export default function AppWrapper({ widgetConfig }: Props) {
-  const apiClient = makeApiClient(widgetConfig.chainlitServer);
+  const additionalQueryParams = widgetConfig?.additionalQueryParamsForAPI;
+  const apiClient = makeApiClient(
+    widgetConfig.chainlitServer,
+    additionalQueryParams || {}
+  );
   const [customThemeLoaded, setCustomThemeLoaded] = useState(false);
 
   function completeInitialization() {

--- a/libs/copilot/src/types.ts
+++ b/libs/copilot/src/types.ts
@@ -9,4 +9,5 @@ export interface IWidgetConfig {
     className?: string;
   };
   customCssUrl?: string;
+  additionalQueryParamsForAPI?: Record<string, string>;
 }

--- a/libs/react-client/src/api/index.tsx
+++ b/libs/react-client/src/api/index.tsx
@@ -46,17 +46,28 @@ export class APIBase {
   constructor(
     public httpEndpoint: string,
     public type: 'webapp' | 'copilot' | 'teams' | 'slack' | 'discord',
+    public additionalQueryParams?: Record<string, string>,
     public on401?: () => void,
     public onError?: (error: ClientError) => void
   ) {}
 
   buildEndpoint(path: string) {
+    let fullUrl = `${this.httpEndpoint}${path}`;
     if (this.httpEndpoint.endsWith('/')) {
       // remove trailing slash on httpEndpoint
-      return `${this.httpEndpoint.slice(0, -1)}${path}`;
-    } else {
-      return `${this.httpEndpoint}${path}`;
+      fullUrl = `${this.httpEndpoint.slice(0, -1)}${path}`;
     }
+
+    const url = new URL(fullUrl);
+
+    // Add additionalQueryParams for all API calls
+    if (this.additionalQueryParams) {
+      const params = new URLSearchParams(this.additionalQueryParams);
+      const separator = url.search ? '&' : '?';
+      url.search = url.search + `${separator}${params.toString()}`;
+    }
+
+    return url.toString();
   }
 
   private async getDetailFromErrorResponse(


### PR DESCRIPTION
This PR introduces a new configuration option: `additionalQueryParamsForAPI` in Copilot settings. This allows passing extra query parameters in API requests to the Chainlit server.

### ✨ What's New?
- 🆕 **New copilot setting:** `additionalQueryParamsForAPI`, which accepts key-value pairs.
- 🔗 **Automatic query param injection:** When configured, all API requests from the Copilot client will include these parameters.
- 📌 **Example:** If set as `{ "version": "v3", "region": "europe" }`, API calls will be formatted as:
`/auth/config?version=v3&region=europe`
`/project/settings?version=v3&region=europe`

### Why This Matters?
- When Chainlit backend server is behind the API Gateway which enforce some strict API versioning rules, then this configurable option is savior.
- Improves request tracking and API monitoring. For example, if multiple websites embed Chainlit’s Copilot while using a single Chainlit backend, this feature allows better tracking of requests from individual sites, offering more flexibility.

### Implementation changes:
- Added `additionalQueryParamsForAPI` option in Copilot settings to accept key-value pairs.
- Updated `buildEndpoint` method in `APIBase` (React client) to append these parameters to the API URL.