### PR TITLE
feat: add support for HTTP User-Agent in user sessions

### DIFF
--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -69,6 +69,8 @@ class BaseSession:
         http_referer: Optional[str] = None,
         # Cookie
         http_cookie: Optional[str] = None,
+        # User-Agent
+        http_user_agent: Optional[str] = None,
     ):
         if thread_id:
             self.thread_id_to_resume = thread_id
@@ -81,6 +83,7 @@ class BaseSession:
         self.chat_profile = chat_profile
         self.http_referer = http_referer
         self.http_cookie = http_cookie
+        self.http_user_agent = http_user_agent
 
         self.files: Dict[str, FileDict] = {}
 
@@ -175,6 +178,8 @@ class HTTPSession(BaseSession):
         http_referer: Optional[str] = None,
         # Cookie
         http_cookie: Optional[str] = None,
+        # User-Agent
+        http_user_agent: Optional[str] = None,
     ):
         super().__init__(
             id=id,
@@ -185,6 +190,7 @@ class HTTPSession(BaseSession):
             user_env=user_env,
             http_referer=http_referer,
             http_cookie=http_cookie,
+            http_user_agent=http_user_agent,
         )
 
     async def delete(self):
@@ -239,6 +245,8 @@ class WebsocketSession(BaseSession):
         http_referer: Optional[str] = None,
         # Cookie
         http_cookie: Optional[str] = None,
+        # User-Agent
+        http_user_agent: Optional[str] = None,
     ):
         super().__init__(
             id=id,
@@ -250,6 +258,7 @@ class WebsocketSession(BaseSession):
             chat_profile=chat_profile,
             http_referer=http_referer,
             http_cookie=http_cookie,
+            http_user_agent=http_user_agent,
         )
 
         self.socket_id = socket_id

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -143,6 +143,8 @@ async def connect(sid, environ, auth):
     client_type = auth.get("clientType")
     http_referer = environ.get("HTTP_REFERER")
     http_cookie = environ.get("HTTP_COOKIE")
+    http_user_agent = environ.get("HTTP_USER_AGENT")
+
     url_encoded_chat_profile = auth.get("chatProfile")
     chat_profile = (
         unquote(url_encoded_chat_profile) if url_encoded_chat_profile else None
@@ -162,6 +164,7 @@ async def connect(sid, environ, auth):
         languages=environ.get("HTTP_ACCEPT_LANGUAGE"),
         http_referer=http_referer,
         http_cookie=http_cookie,
+        http_user_agent=http_user_agent,
     )
 
     trace_event("connection_successful")

--- a/backend/chainlit/user_session.py
+++ b/backend/chainlit/user_session.py
@@ -30,6 +30,7 @@ class UserSession:
         user_session["http_referer"] = context.session.http_referer
         user_session["client_type"] = context.session.client_type
         user_session["http_cookie"] = context.session.http_cookie
+        user_session["http_user_agent"] = context.session.http_user_agent
 
         if isinstance(context.session, WebsocketSession):
             user_session["languages"] = context.session.languages

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,6 +36,7 @@ def mock_session_factory(persisted_test_user: PersistedUser) -> Callable[..., Mo
         mock.chat_profile = kwargs.get("chat_profile", None)
         mock.http_referer = kwargs.get("http_referer", None)
         mock.http_cookie = kwargs.get("http_cookie", None)
+        mock.http_user_agent = kwargs.get("http_user_agent", None)
         mock.client_type = kwargs.get("client_type", "webapp")
         mock.languages = kwargs.get("languages", ["en"])
         mock.thread_id = kwargs.get("thread_id", "test_thread_id")

--- a/backend/tests/test_user_session.py
+++ b/backend/tests/test_user_session.py
@@ -14,3 +14,4 @@ async def test_user_session_set_get(mock_chainlit_context, user_session):
         assert user_session.get("env") == context.session.user_env
         assert user_session.get("languages") == context.session.languages
         assert user_session.get("http_cookie") == context.session.http_cookie
+        assert user_session.get("http_user_agent") == context.session.http_user_agent


### PR DESCRIPTION
- Servers can use User-Agent information to provide the most optimized response for the device or browser from which the request originates.
- By using the User-Agent, it becomes easier to identify the environment of the access source (such as the OS, browser, version, etc.), which helps in troubleshooting.
- Analyzing the device trends and browser share of visitors can be useful for improving UX.

## Pull Request Summary

This pull request includes changes to the `backend/chainlit` module to add support for tracking the `User-Agent` HTTP header in user sessions. The most important changes involve modifications to the session initialization and the handling of HTTP headers.

### Session Initialization Enhancements:

* [`backend/chainlit/session.py`](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R72-R73): Added `http_user_agent` parameter to the `__init__` method of several classes to store the User-Agent header. [[1]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R72-R73) [[2]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R86) [[3]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R181-R182) [[4]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R193) [[5]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R248-R249) [[6]](diffhunk://#diff-fbe9680de98b84f5b8bfb9643a3f9039c29e438592f42305e4acc9f6caaef2b2R261)

### HTTP Header Handling:

* [`backend/chainlit/socket.py`](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R146-R147): Updated `emit_call_fn` function to capture and pass the `http_user_agent` header from the environment. [[1]](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R146-R147) [[2]](diffhunk://#diff-c7887db793bc2a7e33c3bccced3790bbf04dd85b35cd63d20d12f3c8017dab30R167)

### User Session Management:

* [`backend/chainlit/user_session.py`](diffhunk://#diff-f147b9aeed6d2490967c79bf10034b4b7ada1b9e6f66cd308657318573de2f3cR33): Modified `get` method to include `http_user_agent` in the user session data.

### Testing Enhancements:

* [`backend/tests/conftest.py`](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR39): Updated `create_mock_session` function to support `http_user_agent` for testing purposes.
* [`backend/tests/test_user_session.py`](diffhunk://#diff-cec4c2a07ee087d892424c58c36644b847f70e8b75fcfc213ab2e0257e14cb11R17): Added test assertion to verify `http_user_agent` is correctly set and retrieved in user sessions.