### PR TITLE
fix: Use await instead of asyncio.create_task

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -18,7 +18,6 @@ from typing import (
 import filetype
 from pydantic import Field
 from pydantic.dataclasses import dataclass
-from syncer import asyncio
 
 from chainlit.context import context
 from chainlit.data import get_data_layer

--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -211,7 +211,7 @@ class Element:
 
         if (data_layer := get_data_layer()) and persist:
             try:
-                asyncio.create_task(data_layer.create_element(self))
+                await data_layer.create_element(self)
             except Exception as e:
                 logger.error(f"Failed to create element: {e!s}")
         if not self.url and (not self.chainlit_key or self.updatable):

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -240,7 +240,7 @@ class ChainlitEmitter(BaseChainlitEmitter):
                 )
             except Exception as e:
                 logger.error(f"Error updating thread: {e}")
-            asyncio.create_task(self.session.flush_method_queue())
+            await self.session.flush_method_queue()
 
     async def init_thread(self, interaction: str):
         await self.flush_thread_queues(interaction)
@@ -263,11 +263,11 @@ class ChainlitEmitter(BaseChainlitEmitter):
         message.created_at = utc_now()
         chat_context.add(message)
 
-        asyncio.create_task(message._create())
-
         if not self.session.has_first_interaction:
             self.session.has_first_interaction = True
-            asyncio.create_task(self.init_thread(message.content))
+            await self.init_thread(message.content)
+
+        await message._create()
 
         if file_refs:
             files = [
@@ -296,7 +296,7 @@ class ChainlitEmitter(BaseChainlitEmitter):
                 for element in message.elements:
                     await element.send(for_id=message.id)
 
-            asyncio.create_task(send_elements())
+            await send_elements()
 
         return message
 

--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -111,7 +111,7 @@ class MessageBase(ABC):
         data_layer = get_data_layer()
         if data_layer:
             try:
-                asyncio.create_task(data_layer.update_step(step_dict))
+                await data_layer.update_step(step_dict)
             except Exception as e:
                 if self.fail_on_persist_error:
                     raise e
@@ -131,7 +131,7 @@ class MessageBase(ABC):
         data_layer = get_data_layer()
         if data_layer:
             try:
-                asyncio.create_task(data_layer.delete_step(step_dict["id"]))
+                await data_layer.delete_step(step_dict["id"])
             except Exception as e:
                 if self.fail_on_persist_error:
                     raise e
@@ -146,7 +146,7 @@ class MessageBase(ABC):
         data_layer = get_data_layer()
         if data_layer and not self.persisted:
             try:
-                asyncio.create_task(data_layer.create_step(step_dict))
+                await data_layer.create_step(step_dict)
                 self.persisted = True
             except Exception as e:
                 if self.fail_on_persist_error:

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1053,7 +1053,7 @@ async def call_action(
     if callback:
         if not context.session.has_first_interaction:
             context.session.has_first_interaction = True
-            asyncio.create_task(context.emitter.init_thread(action.name))
+            await context.emitter.init_thread(action.name)
 
         response = await callback(action)
     else:

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -365,7 +365,7 @@ async def audio_end(sid):
 
         if not session.has_first_interaction:
             session.has_first_interaction = True
-            asyncio.create_task(context.emitter.init_thread("audio"))
+            await context.emitter.init_thread("audio")
 
         if config.code.on_audio_end:
             await config.code.on_audio_end()

--- a/backend/chainlit/step.py
+++ b/backend/chainlit/step.py
@@ -325,7 +325,7 @@ class Step:
 
         if data_layer:
             try:
-                asyncio.create_task(data_layer.update_step(step_dict.copy()))
+                await data_layer.update_step(step_dict.copy())
             except Exception as e:
                 if self.fail_on_persist_error:
                     raise e
@@ -352,7 +352,7 @@ class Step:
 
         if data_layer:
             try:
-                asyncio.create_task(data_layer.delete_step(self.id))
+                await data_layer.delete_step(self.id)
             except Exception as e:
                 if self.fail_on_persist_error:
                     raise e
@@ -378,7 +378,7 @@ class Step:
 
         if data_layer:
             try:
-                asyncio.create_task(data_layer.create_step(step_dict.copy()))
+                await data_layer.create_step(step_dict.copy())
                 self.persisted = True
             except Exception as e:
                 if self.fail_on_persist_error:


### PR DESCRIPTION
For almost all persistence operations, we use `asyncio.create_task` to do async operations. However, `asyncio.create_task` only create a task, it won't wait the operation to complete. It might cause that messages/steps don't persistent in db even if `await msg.send()` returns.