### PR TITLE
Feature: Add custom env file loading

### DIFF
--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -4,12 +4,13 @@ from dotenv import load_dotenv
 
 # ruff: noqa: E402
 # Keep this here to ensure imports have environment available.
-env_found = load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
+env_file = os.getenv("CHAINLIT_ENV_FILE", ".env")
+env_found = load_dotenv(dotenv_path=os.path.join(os.getcwd(), env_file))
 
 from chainlit.logger import logger
 
 if env_found:
-    logger.info("Loaded .env file")
+    logger.info(f"Loaded {env_file} file")
 
 import asyncio
 from typing import TYPE_CHECKING, Any, Dict


### PR DESCRIPTION
Hi there,

In trying to use chainlit within our application we realized it will always load `.env` even though we have various `.env` files for our different environments such as `.env.production`. Putting up this small PR so that we can just specify the environment ourselves and hopefully this is an acceptable contribution!