### PR TITLE
Add HeaderLink display_name

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -256,7 +256,7 @@ class FeaturesSettings(DataClassJsonMixin):
 @dataclass
 class HeaderLink(DataClassJsonMixin):
     name: str
-    icon_url: str
+    icon_url: Optional[str] = None
     url: str
 
 

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -159,6 +159,7 @@ cot = "full"
 # Specify optional one or more custom links in the header.
 # [[UI.header_links]]
 #     name = "Issues"
+#     display_name = "Report Issue"
 #     icon_url = "https://avatars.githubusercontent.com/u/128686189?s=200&v=4"
 #     url = "https://github.com/Chainlit/chainlit/issues"
 
@@ -256,7 +257,8 @@ class FeaturesSettings(DataClassJsonMixin):
 @dataclass
 class HeaderLink(DataClassJsonMixin):
     name: str
-    icon_url: Optional[str] = None
+    display_name: Optional[str]
+    icon_url: str
     url: str
 
 

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -17,7 +17,12 @@ export interface ButtonLinkProps {
   url: string;
 }
 
-export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
+export default function ButtonLink({
+  name,
+  displayName,
+  iconUrl,
+  url
+}: ButtonLinkProps) {
   const apiClient = useContext(ChainlitContext);
   return (
     <TooltipProvider>
@@ -27,7 +32,11 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
             variant="ghost"
             className="text-muted-foreground hover:text-muted-foreground"
           >
-            <a href={url} target="_blank" className="inline-flex items-center gap-1">
+            <a
+              href={url}
+              target="_blank"
+              className="inline-flex items-center gap-1"
+            >
               <img
                 src={
                   iconUrl?.startsWith('/public')
@@ -37,7 +46,7 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
                 className={'h-6 w-6'}
                 alt={name}
               />
-              {displayName}
+              {displayName && <span>{displayName}</span>}
             </a>
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -12,6 +12,7 @@ import {
 
 export interface ButtonLinkProps {
   name?: string;
+  displayName?: string;
   iconUrl?: string;
   url: string;
 }
@@ -36,7 +37,7 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
                 className={'h-6 w-6'}
                 alt={name}
               />
-              {name}
+              {displayName}
             </a>
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -25,7 +25,7 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
           <Button
             variant="ghost"
             size="icon"
-            className="text-muted-foreground hover:text-muted-foreground"
+            className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
           >
             <a href={url} target="_blank">
               {iconUrl ? (

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -28,15 +28,19 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
             className="text-muted-foreground hover:text-muted-foreground"
           >
             <a href={url} target="_blank">
-              <img
-                src={
-                  iconUrl?.startsWith('/public')
-                    ? apiClient.buildEndpoint(iconUrl)
-                    : iconUrl
-                }
-                className={'h-6 w-6'}
-                alt={name}
-              />
+              {iconUrl ? (
+                <img
+                  src={
+                    iconUrl.startsWith('/public')
+                      ? apiClient.buildEndpoint(iconUrl)
+                      : iconUrl
+                  }
+                  className={'h-6 w-6'}
+                  alt={name}
+                />
+              ) : (
+                <span>{name}</span>
+              )}
             </a>
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -24,23 +24,19 @@ export default function ButtonLink({ name, iconUrl, url }: ButtonLinkProps) {
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
-            size="icon"
-            className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
+            className="text-muted-foreground hover:text-muted-foreground"
           >
-            <a href={url} target="_blank">
-              {iconUrl ? (
-                <img
-                  src={
-                    iconUrl.startsWith('/public')
-                      ? apiClient.buildEndpoint(iconUrl)
-                      : iconUrl
-                  }
-                  className={'h-6 w-6'}
-                  alt={name}
-                />
-              ) : (
-                <span>{name}</span>
-              )}
+            <a href={url} target="_blank" className="inline-flex items-center gap-1">
+              <img
+                src={
+                  iconUrl?.startsWith('/public')
+                    ? apiClient.buildEndpoint(iconUrl)
+                    : iconUrl
+                }
+                className={'h-6 w-6'}
+                alt={name}
+              />
+              {name}
             </a>
           </Button>
         </TooltipTrigger>

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -67,6 +67,7 @@ const Header = memo(() => {
             <ButtonLink
               key={`${link.name}-${link.url}-${index}`}
               name={link.name}
+              displayName={link.display_name}
               iconUrl={link.icon_url}
               url={link.url}
             />

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -39,7 +39,7 @@ export interface IChainlitConfig {
     custom_js?: string;
     custom_font?: string;
     custom_meta_image_url?: string;
-    header_links?: { name: string; icon_url: string; url: string }[];
+    header_links?: { name: string; display_name: string; icon_url: string; url: string }[];
   };
   features: {
     spontaneous_file_upload?: {


### PR DESCRIPTION
Builds on #1836 by adding `display_name` optional. I didn't want to re-use `name` so that this isn't a breaking change. @willydouhard I'm no tailwinds expert so I copied the rendered className from the ReadMe over to ButtonLink. This works, but maybe isn't ideal so feel free to update this PR. Thanks!

**Without display_name (current state)**
```toml
[[UI.header_links]]
    name = "Confluence"
    icon_url = "https://www.atlassian.com/favicon.ico"
    url = "https://www.atlassian.com"

[[UI.header_links]]
    name = "Issues"
    icon_url = "https://mintlify.s3-us-west-1.amazonaws.com/chainlit-43/_generated/favicon/favicon.ico?v=3"
    url = "https://github.com/Chainlit/chainlit/issues"
```
![image](https://github.com/user-attachments/assets/0dea4b60-4878-4634-a234-ca58bcd1967f)

**With display_name**
```toml
[[UI.header_links]]
    name = "Confluence"
    display_name = "Confluence"
    icon_url = "https://www.atlassian.com/favicon.ico"
    url = "https://www.atlassian.com"

[[UI.header_links]]
    name = "Issues"
    display_name = "Report Issue"
    icon_url = "https://mintlify.s3-us-west-1.amazonaws.com/chainlit-43/_generated/favicon/favicon.ico?v=3"
    url = "https://github.com/Chainlit/chainlit/issues"
```
![image](https://github.com/user-attachments/assets/10f1308d-447b-430c-ade8-33f3dc7be58c)


