### PR TITLE
Fix File Icons

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Attachment.tsx
+++ b/frontend/src/components/chat/MessageComposer/Attachment.tsx
@@ -15,10 +15,9 @@ interface AttachmentProps {
   children?: React.ReactNode;
 }
 
-const Attachment: React.FC<AttachmentProps> = ({ name, mime, children }) => {
-  const extension = (
-    mime ? mime.split('/').pop() : 'txt'
-  ) as DefaultExtensionType;
+const Attachment: React.FC<AttachmentProps> = ({ name, children }) => {
+  const extensionFromName = name.includes('.') ? name.split('.').pop()!.toLowerCase() : 'txt';
+  const extension = extensionFromName as DefaultExtensionType;
 
   return (
     <TooltipProvider delayDuration={100}>

--- a/frontend/src/components/chat/MessageComposer/Attachment.tsx
+++ b/frontend/src/components/chat/MessageComposer/Attachment.tsx
@@ -15,9 +15,13 @@ interface AttachmentProps {
   children?: React.ReactNode;
 }
 
-const Attachment: React.FC<AttachmentProps> = ({ name, children }) => {
-  const extensionFromName = name.includes('.') ? name.split('.').pop()!.toLowerCase() : 'txt';
-  const extension = extensionFromName as DefaultExtensionType;
+const Attachment: React.FC<AttachmentProps> = ({ name, mime, children }) => {
+  let extension: DefaultExtensionType;
+  if (name.includes('.')) {
+    extension = name.split('.').pop()!.toLowerCase() as DefaultExtensionType;
+  } else {
+    extension = mime ? (mime.split('/').pop() || 'txt') as DefaultExtensionType : 'txt' as DefaultExtensionType;
+  }
 
   return (
     <TooltipProvider delayDuration={100}>


### PR DESCRIPTION
Fixes #2031 and #1072 

The problem is that `react-file-icon` works by using the file extension to make the right icon (.txt, .xlsx, .pptx, etc.). This code was inferring the extension by taking what's after the `/` so mimes like application/txt becomes `txt` and application/pdf becomes `pdf`. This works fine. The problem is that for Microsoft Office files in particular (although there are others) the mimes are these:

```
application/vnd.openxmlformats-officedocument.spreadsheetml.sheet #Excel
application/vnd.ms-excel # Excel
application/vnd.openxmlformats-officedocument.wordprocessingml.document  # Word
application/vnd.openxmlformats-officedocument.presentationml.presentation Powerpoint
```

The code was returning `vnd.ms-excel ` as the extension for example and since that's not `xlsx` we get the weird icedocument placeholders.

This PR changes this logic to instead first look at the file_name like `Test.docx` and chops off what's after the `.` to return the correct extension, and moves existing logic as a fallback, so that file icons for all files now.