### PR TITLE
fix: flickering on app start

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils';
 import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -7,6 +8,7 @@ import { useAuth, useChatSession, useConfig } from '@chainlit/react-client';
 
 import ChatSettingsModal from './components/ChatSettings';
 import { ThemeProvider } from './components/ThemeProvider';
+import { Loader } from '@/components/Loader';
 import { Toaster } from '@/components/ui/sonner';
 
 import { userEnvState } from 'state/user';
@@ -80,6 +82,15 @@ function App() {
 
       <ChatSettingsModal />
       <RouterProvider router={router} />
+
+      <div
+        className={cn(
+          'bg-[hsl(var(--background))] flex items-center justify-center fixed size-full p-2 top-0',
+          isReady && 'hidden'
+        )}
+      >
+        <Loader className="!size-6" />
+      </div>
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/chat/Messages/index.tsx
+++ b/frontend/src/components/chat/Messages/index.tsx
@@ -72,7 +72,8 @@ const Messages = memo(
                     scorableRun={scorableRun}
                   />
                 ) : null}
-                {showToolCoTLoader || showHiddenCoTLoader ? (
+                {(showToolCoTLoader || showHiddenCoTLoader) &&
+                m.name !== 'on_chat_start' ? (
                   <BlinkingCursor />
                 ) : null}
               </React.Fragment>


### PR DESCRIPTION
This PR:
- Adds a loader that is used until authentication information is ready. This prevents flickering on app load when the initial UI (for an unauthenticated user) is displayed first and then replaced with the authenticated user's version.
- Removes the blinking cursor on the `on_chat_start` message loading (the large black dot below the chat input).

Before:
https://github.com/user-attachments/assets/f4cd157a-0620-400e-94d1-08703d328373

After:
https://github.com/user-attachments/assets/16108af1-5aa9-44b8-b304-8f54e151fce6