### PR TITLE
fix: GCS private key was in incorrect format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ Start by running `backend/hello.py` as an example.
 
 ```sh
 cd backend
+poetry self add poetry-plugin-shell
 poetry shell
 chainlit run chainlit/hello.py
 ```
@@ -99,10 +100,10 @@ Then, start the UI.
 
 ```sh
 cd frontend
-pnpm run dev --port 5174
+pnpm run dev --port 5174 --host
 ```
 
-If you visit `http://127.0.0.1:5174/`, it should connect to your local server. If the local server is not running, it should say that it can't connect to the server.
+If you visit `http://localhost:5174/`, it should connect to your local server. If the local server is not running, it should say that it can't connect to the server.
 
 ## Run the tests
 

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -65,7 +65,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 logger.info("SQLAlchemyDataLayer storage client initialized")
         else:
             self.storage_provider = None
-            logger.warn(
+            logger.warning(
                 "SQLAlchemyDataLayer storage client is not initialized and elements will not be persisted!"
             )
 
@@ -93,11 +93,11 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                     return result.rowcount
             except SQLAlchemyError as e:
                 await session.rollback()
-                logger.warn(f"An error occurred: {e}")
+                logger.warning(f"An error occurred: {e}")
                 return None
             except Exception as e:
                 await session.rollback()
-                logger.warn(f"An unexpected error occurred: {e}")
+                logger.warning(f"An unexpected error occurred: {e}")
                 return None
 
     async def get_current_timestamp(self) -> str:
@@ -468,7 +468,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
             logger.info(f"SQLAlchemy: create_element, element_id = {element.id}")
 
         if not self.storage_provider:
-            logger.warn(
+            logger.warning(
                 "SQLAlchemy: create_element error. No blob_storage_client is configured!"
             )
             return

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -58,7 +58,7 @@ class GCSStorageClient(BaseStorageClient):
 
             return {
                 "object_key": object_key,
-                "url": f"gs://{self.bucket.name}/{object_key}",
+                "url": f"https://storage.googleapis.com/{self.bucket.name}/{object_key}",
             }
 
         except Exception as e:

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -14,9 +14,6 @@ class GCSStorageClient(BaseStorageClient):
         self, project_id: str, client_email: str, private_key: str, bucket_name: str
     ):
         # Go to IAM & Admin, click on Service Accounts, and generate a new JSON key
-        private_key = base64.b64encode(private_key.encode("utf-8")).decode("utf-8")
-        private_key = base64.b64decode(private_key).decode("utf-8")
-
         credentials = service_account.Credentials.from_service_account_info(
             {
                 "type": "service_account",

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -13,6 +13,8 @@ class GCSStorageClient(BaseStorageClient):
     def __init__(
         self, project_id: str, client_email: str, private_key: str, bucket_name: str
     ):
+        # Go to IAM & Admin, click on Service Accounts, and generate a new JSON key
+        private_key = base64.b64encode(private_key.encode("utf-8")).decode("utf-8")
         private_key = base64.b64decode(private_key).decode("utf-8")
 
         credentials = service_account.Credentials.from_service_account_info(


### PR DESCRIPTION
1. GCP creates service account keys in IAM through a JSON file. Currently, the private key is a string in the format of `-----BEGIN PRIVATE KEY-----`. However, when using this private key with the `GCS_PRIVATE_KEY` environment variable, the following error occurs:

```
storage_client = GCSStorageClient(
                     ^^^^^^^^^^^^^^^^^
  File "/Library/Python/3.11/lib/python/site-packages/chainlit/data/storage_clients/gcs.py", line 16, in __init__
    private_key = base64.b64decode(private_key).decode("utf-8")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/base64.py", line 88, in b64decode
    return binascii.a2b_base64(s, strict_mode=validate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
binascii.Error: Incorrect padding
```

The GCP authentication issue was caused by unnecessary encoding of the private key. This PR removes the unnecessary key encoding.


2. When using `display="side"` for elements in the side panel, the following error occurs when trying to retrieve persisted data elements:

`
Fetch API cannot load gs://{BUCKET}. URL scheme "gs" is not supported.
`

The Fetch API in browsers doesn't support the `gs://` URL natively as it expects HTTPS URLs. This ticket changes the URL from `gs://` to `https://storage.googleapis.com`.