### PR TITLE
feature: allow set attributes for the tags of the custom_js or custom_css file

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -287,7 +287,7 @@ class UISettings(DataClassJsonMixin):
     github: Optional[str] = None
     # Optional custom CSS file that allows you to customize the UI
     custom_css: Optional[str] = None
-    custom_css_attributes: Optional[str] = None
+    custom_css_attributes: Optional[str] = ""
     # Optional custom JS file that allows you to customize the UI
     custom_js: Optional[str] = None
     custom_js_attributes: Optional[str] = "defer"

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -146,9 +146,15 @@ cot = "full"
 # The CSS file can be served from the public directory or via an external link.
 # custom_css = "/public/test.css"
 
+# Specify additional attributes for a custom CSS file
+# custom_css_attributes = "media=\\\"print\\\""
+
 # Specify a JavaScript file that can be used to customize the user interface.
 # The JavaScript file can be served from the public directory.
 # custom_js = "/public/test.js"
+
+# Specify additional attributes for custom JS file
+# custom_js_attributes = "async type = \\\"module\\\""
 
 # Custom login page image, relative to public directory or external URL
 # login_page_image = "/public/custom-background.jpg"
@@ -281,7 +287,10 @@ class UISettings(DataClassJsonMixin):
     github: Optional[str] = None
     # Optional custom CSS file that allows you to customize the UI
     custom_css: Optional[str] = None
+    custom_css_attributes: Optional[str] = None
+    # Optional custom JS file that allows you to customize the UI
     custom_js: Optional[str] = None
+    custom_js_attributes: Optional[str] = "defer"
     # Optional custom background image for login page
     login_page_image: Optional[str] = None
     login_page_image_filter: Optional[str] = None

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -363,9 +363,7 @@ def get_html_template(root_path):
 
     css = None
     if config.ui.custom_css:
-        css = (
-            f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}" {config.ui.custom_css_attributes}>"""
-        )
+        css = f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}" {config.ui.custom_css_attributes}>"""
 
     if config.ui.custom_js:
         js += f"""<script src="{config.ui.custom_js}" {config.ui.custom_js_attributes}></script>"""

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -364,11 +364,11 @@ def get_html_template(root_path):
     css = None
     if config.ui.custom_css:
         css = (
-            f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}">"""
+            f"""<link rel="stylesheet" type="text/css" href="{config.ui.custom_css}" {config.ui.custom_css_attributes}>"""
         )
 
     if config.ui.custom_js:
-        js += f"""<script src="{config.ui.custom_js}" defer></script>"""
+        js += f"""<script src="{config.ui.custom_js}" {config.ui.custom_js_attributes}></script>"""
 
     font = None
     if custom_theme and custom_theme.get("custom_fonts"):


### PR DESCRIPTION
Case: I'm building `custom_js` used for chainlit in our project using `vite` and due to certain conditions I can produce only native ECMAScript (JS) module (`<script type="module">`) build. But currently only non-modular scripts can be used in `custom_js`

Solution: allow set attributes for the tags of the `custom_js` or `custom_css` file