### PR TITLE
fix: Fix display_name in header links

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -272,9 +272,9 @@ class FeaturesSettings(DataClassJsonMixin):
 @dataclass
 class HeaderLink(DataClassJsonMixin):
     name: str
-    display_name: Optional[str]
     icon_url: str
     url: str
+    display_name: Optional[str] = None
 
 
 @dataclass()


### PR DESCRIPTION
Fixes an issue in #2059 where display_name throws pydantic validation errors when omitted. Setting default to None and move to the end fixes this.