### PR TITLE
fix: keep icon style when no display is set

### DIFF
--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -30,6 +30,7 @@ export default function ButtonLink({
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
+            size={displayName ? 'default' : 'icon'}
             className="text-muted-foreground hover:text-muted-foreground"
           >
             <a


### PR DESCRIPTION
The PR #2059 introduced an optional display name, however if no display name is provided the style gets a bit bat with too much spacing between icons.

This PR preserves the original style when no display is specified and keeping the proposed style when display is set

Currently after #2059
![image](https://github.com/user-attachments/assets/f9ed20f5-0352-4073-894f-1451c94a9ad1)

Original before #2059 and after this PR
![image](https://github.com/user-attachments/assets/677e66de-2802-4900-bf22-6aa5617964aa)
