### PR TITLE
fix: issue #2084 fetching steps feedbacks in get_thread

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -14,12 +14,12 @@ from chainlit.logger import logger
 from chainlit.step import StepDict
 from chainlit.types import (
     Feedback,
+    FeedbackDict,
     PageInfo,
     PaginatedResponse,
     Pagination,
     ThreadDict,
     ThreadFilter,
-    FeedbackDict
 )
 from chainlit.user import PersistedUser, User
 
@@ -569,14 +569,14 @@ class ChainlitDataLayer(BaseDataLayer):
         """
 
         await self.execute_query(query, {str(i + 1): v for i, v in enumerate(values)})
-        
+
     def _extract_feedback_dict_from_step_row(self, row: Dict) -> FeedbackDict:
-        if row['feedback_id'] is not None:
+        if row["feedback_id"] is not None:
             return FeedbackDict(
                 forId=row["id"],
                 id=row["feedback_id"],
-                value=row['feedback_value'],
-                comment=row['feedback_comment']
+                value=row["feedback_value"],
+                comment=row["feedback_comment"],
             )
         return None
 

--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -19,6 +19,7 @@ from chainlit.types import (
     Pagination,
     ThreadDict,
     ThreadFilter,
+    FeedbackDict
 )
 from chainlit.user import PersistedUser, User
 
@@ -483,10 +484,14 @@ class ChainlitDataLayer(BaseDataLayer):
 
         thread = results[0]
 
-        # Get steps
+        # Get steps and related feedback
         steps_query = """
-        SELECT * FROM "Step" 
-        WHERE "threadId" = $1 
+        SELECT  s.*, 
+                f.id feedback_id, 
+                f.value feedback_value, 
+                f."comment" feedback_comment
+        FROM "Step" s left join "Feedback" f on s.id = f."stepId"
+        WHERE s."threadId" = $1
         ORDER BY "startTime"
         """
         steps_results = await self.execute_query(steps_query, {"thread_id": thread_id})
@@ -564,6 +569,16 @@ class ChainlitDataLayer(BaseDataLayer):
         """
 
         await self.execute_query(query, {str(i + 1): v for i, v in enumerate(values)})
+        
+    def _extract_feedback_dict_from_step_row(self, row: Dict) -> FeedbackDict:
+        if row['feedback_id'] is not None:
+            return FeedbackDict(
+                forId=row["id"],
+                id=row["feedback_id"],
+                value=row['feedback_value'],
+                comment=row['feedback_comment']
+            )
+        return None
 
     def _convert_step_row_to_dict(self, row: Dict) -> StepDict:
         return StepDict(
@@ -580,6 +595,7 @@ class ChainlitDataLayer(BaseDataLayer):
             showInput=row.get("showInput"),
             isError=row.get("isError"),
             end=row["endTime"].isoformat() if row.get("endTime") else None,
+            feedback=self._extract_feedback_dict_from_step_row(row),
         )
 
     def _convert_element_row_to_dict(self, row: Dict) -> ElementDict:

--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -570,7 +570,7 @@ class ChainlitDataLayer(BaseDataLayer):
 
         await self.execute_query(query, {str(i + 1): v for i, v in enumerate(values)})
 
-    def _extract_feedback_dict_from_step_row(self, row: Dict) -> FeedbackDict:
+    def _extract_feedback_dict_from_step_row(self, row: Dict) -> Optional[FeedbackDict]:
         if row["feedback_id"] is not None:
             return FeedbackDict(
                 forId=row["id"],


### PR DESCRIPTION
### Description  
This pull request addresses a bug in the `ChainlitDataLayer` class, specifically in the `get_thread` method. As pointed out in #2084, when resuming a thread, previous feedback entries were not being loaded from the database.

### Problem  
The `Feedback` table was not being queried at all.

### Solution  
The query used to retrieve steps from the database has been updated to also fetch related entries from the `Feedback` table. The method responsible for creating steps to be included in the thread has been updated accordingly. Now, when reloading a thread, previous feedback for each step is displayed correctly.
