### PR TITLE
feat: expose expiry time as environment variable

### DIFF
--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Union
 
 from azure.storage.blob import BlobSasPermissions, ContentSettings, generate_blob_sas
 from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
+
 from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
 from chainlit.logger import logger
 

--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -3,8 +3,7 @@ from typing import Any, Dict, Union
 
 from azure.storage.blob import BlobSasPermissions, ContentSettings, generate_blob_sas
 from azure.storage.blob.aio import BlobServiceClient as AsyncBlobServiceClient
-
-from chainlit.data.storage_clients.base import EXPIRY_TIME, BaseStorageClient
+from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
 from chainlit.logger import logger
 
 
@@ -33,7 +32,7 @@ class AzureBlobStorageClient(BaseStorageClient):
 
         sas_permissions = BlobSasPermissions(read=True)
         start_time = datetime.now(tz=timezone.utc)
-        expiry_time = start_time + timedelta(seconds=EXPIRY_TIME)
+        expiry_time = start_time + timedelta(seconds=storage_expiry_time)
 
         sas_token = generate_blob_sas(
             account_name=self.storage_account,

--- a/backend/chainlit/data/storage_clients/base.py
+++ b/backend/chainlit/data/storage_clients/base.py
@@ -1,7 +1,8 @@
+import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Union
 
-EXPIRY_TIME = 3600
+storage_expiry_time = int(os.getenv("STORAGE_EXPIRY_TIME", 3600))
 
 
 class BaseStorageClient(ABC):

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, Union
 
-from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
-from chainlit.logger import logger
 from google.cloud import storage  # type: ignore
 from google.oauth2 import service_account
 
 from chainlit import make_async
+from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
+from chainlit.logger import logger
 
 
 class GCSStorageClient(BaseStorageClient):

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, Union
 
+from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
+from chainlit.logger import logger
 from google.cloud import storage  # type: ignore
 from google.oauth2 import service_account
 
 from chainlit import make_async
-from chainlit.data.storage_clients.base import EXPIRY_TIME, BaseStorageClient
-from chainlit.logger import logger
 
 
 class GCSStorageClient(BaseStorageClient):
@@ -29,7 +29,7 @@ class GCSStorageClient(BaseStorageClient):
 
     def sync_get_read_url(self, object_key: str) -> str:
         return self.bucket.blob(object_key).generate_signed_url(
-            version="v4", expiration=EXPIRY_TIME, method="GET"
+            version="v4", expiration=storage_expiry_time, method="GET"
         )
 
     async def get_read_url(self, object_key: str) -> str:

--- a/backend/chainlit/data/storage_clients/s3.py
+++ b/backend/chainlit/data/storage_clients/s3.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Union
 
 import boto3  # type: ignore
+from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
+from chainlit.logger import logger
 
 from chainlit import make_async
-from chainlit.data.storage_clients.base import EXPIRY_TIME, BaseStorageClient
-from chainlit.logger import logger
 
 
 class S3StorageClient(BaseStorageClient):
@@ -25,7 +25,7 @@ class S3StorageClient(BaseStorageClient):
             url = self.client.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": self.bucket, "Key": object_key},
-                ExpiresIn=EXPIRY_TIME,
+                ExpiresIn=storage_expiry_time,
             )
             return url
         except Exception as e:

--- a/backend/chainlit/data/storage_clients/s3.py
+++ b/backend/chainlit/data/storage_clients/s3.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Union
 
 import boto3  # type: ignore
-from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
-from chainlit.logger import logger
 
 from chainlit import make_async
+from chainlit.data.storage_clients.base import BaseStorageClient, storage_expiry_time
+from chainlit.logger import logger
 
 
 class S3StorageClient(BaseStorageClient):


### PR DESCRIPTION
The 1-hour expiry time for read-only URLs of elements in a chat leads to unusable URLs. 

Some developers want a way to configure the `EXPIRY_TIME`, see https://discord.com/channels/1088038867602526210/1360221598279536800/1363216725641920825

Initially I thought it'd be a Chainlit config, but I thought it best to have it an environment variable, same as all the storage configurations. 

- [ ] Write a test
- [ ] Test the change