### PR TITLE
Added commands to starters

### DIFF
--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -256,6 +256,7 @@ class Starter(DataClassJsonMixin):
 
     label: str
     message: str
+    command: Optional[str] = None
     icon: Optional[str] = None
 
 

--- a/frontend/src/components/chat/Starter.tsx
+++ b/frontend/src/components/chat/Starter.tsx
@@ -32,7 +32,7 @@ export default function Starter({ starter }: StarterProps) {
     const message: IStep = {
       threadId: '',
       id: uuidv4(),
-      command: selectedCommand?.id,
+      command: starter.command ?? selectedCommand?.id,
       name: user?.identifier || 'User',
       type: 'user_message',
       output: starter.message,

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -2,6 +2,7 @@ export interface IStarter {
   label: string;
   message: string;
   icon?: string;
+  command?: string;
 }
 
 export interface ChatProfile {


### PR DESCRIPTION
As discussed with @willydouhard previously (Saint-Gobain), It would really be nice to be able to add a command to a starter. This pull request aims to do that.

If a starter has a command, the selected command will be ignored.

```python
@cl.set_starters
async def set_starters():
    return [
        cl.Starter(
            label="Morning routine ideation",
            message="...",
            icon="/public/idea.svg",
            command="morning_routine", # New command attribute
        ),
    ]
```