### PR TITLE
fix: crlf on paste

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -242,7 +242,10 @@ const Input = forwardRef<InputMethods, Props>(
 
         const textData = event.clipboardData?.getData('text/plain');
         if (textData) {
-          const escapedText = escapeHtml(textData);
+          const normalizedText = textData
+            .replace(/\r\n/g, '\n')
+            .replace(/\r/g, '\n');
+          const escapedText = escapeHtml(normalizedText);
 
           const htmlToInsert = escapedText.replace(/\n/g, '<br>');
 


### PR DESCRIPTION
On Windows pasting multiple lines with CRLF inserts an additional new lines, [discord comment](https://discord.com/channels/1088038867602526210/1088038868344914056/1368940293835198526). 

I don't have a Windows to test, but replace full CRLF would fix the issue.