### PR TITLE
feat: Add element_name to CustomElement to allow for distinct CustomElements

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -118,6 +118,7 @@ class Element:
                 "display": self.display,
                 "objectKey": getattr(self, "object_key", None),
                 "size": getattr(self, "size", None),
+                "element_name": getattr(self, "element_name", None),
                 "props": getattr(self, "props", None),
                 "page": getattr(self, "page", None),
                 "autoPlay": getattr(self, "auto_play", None),
@@ -182,7 +183,8 @@ class Element:
             return Plotly(size=e_dict.get("size", "medium"), **common_params)  # type: ignore[arg-type]
 
         elif type == "custom":
-            return CustomElement(props=e_dict.get("props", {}), **common_params)  # type: ignore[arg-type]
+            # For backwards compatibility, the name is used as the element_name
+            return CustomElement(element_name=e_dict.get("element_name", name), props=e_dict.get("props", {}), **common_params)  # type: ignore[arg-type]
         else:
             # Default to File for any other type
             return File(**common_params)  # type: ignore[arg-type]
@@ -447,9 +449,13 @@ class CustomElement(Element):
 
     type: ClassVar[ElementType] = "custom"
     mime: str = "application/json"
+    element_name: str = Field(default=None)
     props: Dict = Field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        # Backwards compatibility
+        if self.element_name is None:
+            self.element_name = self.name
         self.content = json.dumps(self.props)
         super().__post_init__()
         self.updatable = True

--- a/frontend/src/components/Elements/CustomElement/index.tsx
+++ b/frontend/src/components/Elements/CustomElement/index.tsx
@@ -36,7 +36,7 @@ const CustomElement = memo(function ({ element }: { element: ICustomElement }) {
 
   useEffect(() => {
     apiClient
-      .get(`/public/elements/${element.name}.jsx`)
+      .get(`/public/elements/${element.element_name}.jsx`)
       .then(async (res) => setSourceCode(await res.text()))
       .catch((err) => setError(String(err)));
   }, [element.name, apiClient]);

--- a/libs/react-client/src/types/element.ts
+++ b/libs/react-client/src/types/element.ts
@@ -77,5 +77,6 @@ export type ITasklistElement = TElement<'tasklist'>;
 export type IDataframeElement = TMessageElement<'dataframe'>;
 
 export interface ICustomElement extends TMessageElement<'custom'> {
+  element_name: string;
   props: Record<string, unknown>;
 }


### PR DESCRIPTION
Introduce the `element_name` attribute to the `CustomElement` class, allowing for distinct identification of custom elements. Update relevant methods and interfaces to ensure compatibility with this new attribute. For backwards compatibility the element_name equals the name of custom element if not defined.

This solves the issue: https://github.com/Chainlit/chainlit/issues/1841

I'll add the following example to the docs if you like this feature.

hello.py
```
import chainlit as cl
from chainlit import Message, on_chat_start


@on_chat_start
async def main():

    await cl.Message(
        content="Lorem Ipsum, ... source: source_1",
        author="AI Search",
        elements=[
            cl.CustomElement(
                element_name="IFrame",
                name="source_1",
                display="side",
                props={
                    "url": "https://example.com",
                    "title": "Some Title",
                },
            )
        ],
    ).send()
```

public/elements/IFrame.jsx
```
export default function IFrame() {
    return (
        <iframe
            src={props.url}
            title={props.title}
            style={{ width: "100%", height: "100%", border: "none" }}
        />
    );
}
```