### PR TITLE
Fix full pathname for ws/socket.io.

### DIFF
--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -105,7 +105,7 @@ const useChatSession = () => {
       const uri = `${protocol}//${host}`;
       const path =
         pathname && pathname !== '/'
-          ? `${pathname}/ws/socket.io`
+          ? `${pathname}ws/socket.io`
           : '/ws/socket.io';
 
       try {


### PR DESCRIPTION
In copilot, the path was not generated correctly, when using custom `root_path`.

What I'm getting.
```
https://example.com/pathname//ws/socket.io/?EIO=4&transport=polling&t=PR4r3RN
```

What is expected:
```
https://example.com/pathname/ws/socket.io/?EIO=4&transport=polling&t=PR4r3RN
```

The path name needs to be corrected as the script is not handling redirect correctly.