### PR TITLE
Collapse command buttons to icons for small screens

### DIFF
--- a/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
+++ b/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
@@ -50,7 +50,9 @@ export const CommandButtons = ({
                 }
               >
                 <Icon name={command.icon} className="!h-5 !w-5" />
-                {command.id}
+                <span className="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap flex-shrink md:flex-shrink-0 transition-all duration-200 max-sm:hidden">
+                  {command.id}
+                </span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>

--- a/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
+++ b/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
@@ -29,7 +29,7 @@ export const CommandButtons = ({
   if (!commandButtons.length) return null;
 
   return (
-    <div className="flex gap-2 ml-1 flex-wrap">
+    <div className="flex gap-0 ml-1 flex-wrap">
       <TooltipProvider>
         {commandButtons.map((command) => (
           <Tooltip key={command.id}>
@@ -50,7 +50,13 @@ export const CommandButtons = ({
                 }
               >
                 <Icon name={command.icon} className="!h-5 !w-5" />
-                <span className="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap flex-shrink md:flex-shrink-0 transition-all duration-200 max-sm:hidden">
+                <span
+                  className={cn(
+                    selectedCommandId === command.id
+                      ? 'max-w-full overflow-visible text-clip whitespace-normal'
+                      : 'max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap max-sm:hidden'
+                  )}
+                >
                   {command.id}
                 </span>
               </Button>


### PR DESCRIPTION
Commands on mobile quickly lead to multiple lines of commands in the UI. It is better to collapse the text and just keep the icon. This PR automatically collapses the text if the screen size is too small.