### PR TITLE
fix(data-layer): add graceful shutdown handlers for DB connection cleanup

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -1,5 +1,8 @@
 import json
 import uuid
+import signal
+import atexit
+import asyncio
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
@@ -42,6 +45,11 @@ class ChainlitDataLayer(BaseDataLayer):
         self.storage_client = storage_client
         self.show_logger = show_logger
 
+        # Register cleanup handlers for application termination
+        atexit.register(self._sync_cleanup)
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            signal.signal(sig, self._signal_handler)
+
     async def connect(self):
         if not self.pool:
             self.pool = await asyncpg.create_pool(self.database_url)
@@ -55,16 +63,24 @@ class ChainlitDataLayer(BaseDataLayer):
         if not self.pool:
             await self.connect()
 
-        async with self.pool.acquire() as connection:  # type: ignore
-            try:
-                if params:
-                    records = await connection.fetch(query, *params.values())
-                else:
-                    records = await connection.fetch(query)
-                return [dict(record) for record in records]
-            except Exception as e:
-                logger.error(f"Database error: {e!s}")
-                raise
+        try:
+            async with self.pool.acquire() as connection:  # type: ignore
+                try:
+                    if params:
+                        records = await connection.fetch(query, *params.values())
+                    else:
+                        records = await connection.fetch(query)
+                    return [dict(record) for record in records]
+                except Exception as e:
+                    logger.error(f"Database error: {e!s}")
+                    raise
+        except (asyncpg.exceptions.ConnectionDoesNotExistError, 
+                asyncpg.exceptions.InterfaceError) as e:
+            # Handle connection issues by cleaning up and rethrowing
+            logger.error(f"Connection error: {e!s}, cleaning up pool")
+            await self.cleanup()
+            self.pool = None
+            raise
 
     async def get_user(self, identifier: str) -> Optional[PersistedUser]:
         query = """
@@ -626,6 +642,28 @@ class ChainlitDataLayer(BaseDataLayer):
         """Cleanup database connections"""
         if self.pool:
             await self.pool.close()
+
+    def _sync_cleanup(self):
+        """Cleanup database connections in a synchronous context."""
+        if self.pool and not self.pool.is_closing():
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(self.cleanup())
+            else:
+                try:
+                    cleanup_loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(cleanup_loop)
+                    cleanup_loop.run_until_complete(self.cleanup())
+                    cleanup_loop.close()
+                except Exception as e:
+                    logger.error(f"Error during sync cleanup: {e}")
+
+    def _signal_handler(self, sig, frame):
+        """Handle signals for graceful shutdown."""
+        logger.info(f"Received signal {sig}, cleaning up connection pool.")
+        self._sync_cleanup()
+        # Re-raise the signal after cleanup
+        signal.default_int_handler(sig, frame)
 
 
 def truncate(text: Optional[str], max_length: int = 255) -> Optional[str]:


### PR DESCRIPTION
Register signal and atexit handlers to ensure proper asyncpg connection pool
cleanup during application shutdown. Improves resilience against connection
errors and resource leaks.

Fixes #2169
