### PR TITLE
fix: only update metadata field when not None to prevent overwriting with {}

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -548,7 +548,7 @@ class ChainlitDataLayer(BaseDataLayer):
             "name": thread_name,
             "userId": user_id,
             "tags": tags,
-            "metadata": json.dumps(metadata or {}),
+            "metadata": json.dumps(metadata) if metadata is not None else None,
         }
 
         # Remove None values


### PR DESCRIPTION
Only update SQL metadata field when metadata is not None; otherwise, existing metadata will be overwritten as an empty object ({}).