### PR TITLE
Resolve Python Logger warnings

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -138,7 +138,7 @@ class ChainlitDataLayer(BaseDataLayer):
     @queue_until_user_message()
     async def create_element(self, element: "Element"):
         if not self.storage_client:
-            logger.warn(
+            logger.warning(
                 "Data Layer: create_element error. No cloud storage configured!"
             )
             return

--- a/backend/chainlit/data/storage_clients/azure.py
+++ b/backend/chainlit/data/storage_clients/azure.py
@@ -53,7 +53,7 @@ class AzureStorageClient(BaseStorageClient):
             self.sas_token = sas_token
             logger.info("AzureStorageClient initialized")
         except Exception as e:
-            logger.warn(f"AzureStorageClient initialization error: {e}")
+            logger.warning(f"AzureStorageClient initialization error: {e}")
 
     async def upload_file(
         self,
@@ -77,5 +77,5 @@ class AzureStorageClient(BaseStorageClient):
             )
             return {"object_key": object_key, "url": url}
         except Exception as e:
-            logger.warn(f"AzureStorageClient, upload_file error: {e}")
+            logger.warning(f"AzureStorageClient, upload_file error: {e}")
             return {}

--- a/backend/chainlit/data/storage_clients/azure_blob.py
+++ b/backend/chainlit/data/storage_clients/azure_blob.py
@@ -87,5 +87,5 @@ class AzureBlobStorageClient(BaseStorageClient):
             await blob_client.delete_blob()
             return True
         except Exception as e:
-            logger.warn(f"AzureBlobStorageClient, delete_file error: {e}")
+            logger.warning(f"AzureBlobStorageClient, delete_file error: {e}")
             return False

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -79,7 +79,7 @@ class GCSStorageClient(BaseStorageClient):
             self.bucket.blob(object_key).delete()
             return True
         except Exception as e:
-            logger.warn(f"GCSStorageClient, delete_file error: {e}")
+            logger.warning(f"GCSStorageClient, delete_file error: {e}")
             return False
 
     async def delete_file(self, object_key: str) -> bool:

--- a/backend/chainlit/data/storage_clients/s3.py
+++ b/backend/chainlit/data/storage_clients/s3.py
@@ -18,7 +18,7 @@ class S3StorageClient(BaseStorageClient):
             self.client = boto3.client("s3", **kwargs)
             logger.info("S3StorageClient initialized")
         except Exception as e:
-            logger.warn(f"S3StorageClient initialization error: {e}")
+            logger.warning(f"S3StorageClient initialization error: {e}")
 
     def sync_get_read_url(self, object_key: str) -> str:
         try:
@@ -29,7 +29,7 @@ class S3StorageClient(BaseStorageClient):
             )
             return url
         except Exception as e:
-            logger.warn(f"S3StorageClient, get_read_url error: {e}")
+            logger.warning(f"S3StorageClient, get_read_url error: {e}")
             return object_key
 
     async def get_read_url(self, object_key: str) -> str:
@@ -49,7 +49,7 @@ class S3StorageClient(BaseStorageClient):
             url = f"https://{self.bucket}.s3.amazonaws.com/{object_key}"
             return {"object_key": object_key, "url": url}
         except Exception as e:
-            logger.warn(f"S3StorageClient, upload_file error: {e}")
+            logger.warning(f"S3StorageClient, upload_file error: {e}")
             return {}
 
     async def upload_file(
@@ -68,7 +68,7 @@ class S3StorageClient(BaseStorageClient):
             self.client.delete_object(Bucket=self.bucket, Key=object_key)
             return True
         except Exception as e:
-            logger.warn(f"S3StorageClient, delete_file error: {e}")
+            logger.warning(f"S3StorageClient, delete_file error: {e}")
             return False
 
     async def delete_file(self, object_key: str) -> bool:


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```