### PR TITLE
fix: include mime in element

### DIFF
--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -285,6 +285,7 @@ class ChainlitEmitter(BaseChainlitEmitter):
                         "chainlitKey": file["id"],
                         "display": "inline",
                         "type": Element.infer_type_from_mime(file["type"]),
+                        "mime": file["type"],
                     }
                 )
                 for file in files


### PR DESCRIPTION
This fixes the elements mime type for types like "plain/text" where the mimetype fixing in element.py (send) did not work