### PR TITLE
fix: generate signed url when loading elements from dynamodb datalayer

### DIFF
--- a/backend/chainlit/data/dynamodb.py
+++ b/backend/chainlit/data/dynamodb.py
@@ -522,6 +522,10 @@ class DynamoDBDataLayer(BaseDataLayer):
                 thread_dict = item
 
             elif item["SK"].startswith("ELEMENT"):
+                if self.storage_provider is not None:
+                    item["url"] = await self.storage_provider.get_read_url(
+                        object_key=item["objectKey"],
+                    )
                 elements.append(item)
 
             elif item["SK"].startswith("STEP"):


### PR DESCRIPTION
During thread loading with DynamoDBDataLayer, when using a storage provider, fill the "url" field of an element with the signed url generated by the storage provider.

Closes #1962.