### PR TITLE
feat: Added ADC support for google cloud storage adapter

### DIFF
--- a/backend/chainlit/data/__init__.py
+++ b/backend/chainlit/data/__init__.py
@@ -53,9 +53,7 @@ def get_data_layer():
                 gcs_project_id = os.getenv("APP_GCS_PROJECT_ID")
                 gcs_client_email = os.getenv("APP_GCS_CLIENT_EMAIL")
                 gcs_private_key = os.getenv("APP_GCS_PRIVATE_KEY")
-                is_using_gcs = bool(
-                    gcs_project_id and gcs_client_email and gcs_private_key
-                )
+                is_using_gcs = bool(gcs_project_id)
 
                 # Azure Storage
                 azure_storage_account = os.getenv("APP_AZURE_STORAGE_ACCOUNT")

--- a/backend/chainlit/data/storage_clients/gcs.py
+++ b/backend/chainlit/data/storage_clients/gcs.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
+from google.auth import default
 from google.cloud import storage  # type: ignore
 from google.oauth2 import service_account
 
@@ -10,18 +11,30 @@ from chainlit.logger import logger
 
 class GCSStorageClient(BaseStorageClient):
     def __init__(
-        self, project_id: str, client_email: str, private_key: str, bucket_name: str
+        self,
+        bucket_name: str,
+        project_id: Optional[str] = None,
+        client_email: Optional[str] = None,
+        private_key: Optional[str] = None,
     ):
-        # Go to IAM & Admin, click on Service Accounts, and generate a new JSON key
-        credentials = service_account.Credentials.from_service_account_info(
-            {
-                "type": "service_account",
-                "project_id": project_id,
-                "private_key": private_key,
-                "client_email": client_email,
-                "token_uri": "https://oauth2.googleapis.com/token",
-            }
-        )
+        if client_email and private_key and project_id:
+            # Go to IAM & Admin, click on Service Accounts, and generate a new JSON key
+            logger.info("Using Private Key from Environment Variable")
+            credentials = service_account.Credentials.from_service_account_info(
+                {
+                    "type": "service_account",
+                    "project_id": project_id,
+                    "private_key": private_key,
+                    "client_email": client_email,
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                }
+            )
+        else:
+            # Application Default Credentials (e.g. in Google Cloud Run)
+            logger.info("Using Application Default Credentials.")
+            credentials, default_project_id = default()
+            if not project_id:
+                project_id = default_project_id
 
         self.client = storage.Client(project=project_id, credentials=credentials)
         self.bucket = self.client.bucket(bucket_name)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -120,6 +120,7 @@ module = [
     "google-cloud-storage",
     "azure.storage.blob",
     "azure.storage.blob.aio",
+    "google.auth",
     "google.oauth2"
 ]
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
When trying to use https://github.com/Chainlit/chainlit/blob/main/backend/chainlit/data/storage_clients/gcs.py the gcs storage client in cloud run, it's currently necessary to set an environment variable with a PRIVATE KEY (of a service account) to allow access. Often those keys need to be rotated so it's annoying if you have to do this.

**Describe the solution you'd like**
There is a standard way of using the assigned service account in google cloud run and it works via https://cloud.google.com/docs/authentication/application-default-credentials application default credentials.

That's why I added (and was not able to find and run tests for it - but all other unit tests have been happy - so please check it, too!) the default way to initialize credentials via auth.default() if no other credentials like private key have been provided.

**Describe alternatives you've considered**
I also looked into https://github.com/Chainlit/chainlit-community/tree/main/packages/storage_clients/gcs/src/chainlit_gcs but I am not sure what is the "leading" part of chainlit for this.