### PR TITLE
Feat: AskElementMessage - Time-gated forms in CustomElements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Header link now have an optional `display_name` to display text next to the icon
 - The default .env file loaded by chainlit is now configurable with `CHAINLIT_ENV_FILE`
 
+
 ### Changed
 
 - **[breaking]**: `http_referer`, `http_cookie` and `languages` are no longer directly available in the session object. Instead, `environ` is available containing all of those plus other HTTP headers

--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -42,6 +42,7 @@ from chainlit.element import (
 from chainlit.message import (
     AskActionMessage,
     AskFileMessage,
+    AskElementMessage,
     AskUserMessage,
     ErrorMessage,
     Message,
@@ -126,6 +127,7 @@ __all__ = [
     "Action",
     "AskActionMessage",
     "AskFileMessage",
+    "AskElementMessage",
     "AskUserMessage",
     "AsyncLangchainCallbackHandler",
     "Audio",

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -353,6 +353,9 @@ class ChainlitEmitter(BaseChainlitEmitter):
                     action_res = cast(AskActionResponse, user_res)
                     final_res = action_res
                     interaction = action_res["name"]
+                elif spec.type == "element":
+                    final_res = cast(Dict[str, Any], user_res)
+                    interaction = "custom_element"
 
                 if not self.session.has_first_interaction and interaction:
                     self.session.has_first_interaction = True

--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -3,7 +3,7 @@ import json
 import time
 import uuid
 from abc import ABC
-from typing import Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from literalai.helper import utc_now
 from literalai.observability.step import MessageStepType
@@ -13,7 +13,7 @@ from chainlit.chat_context import chat_context
 from chainlit.config import config
 from chainlit.context import context, local_steps
 from chainlit.data import get_data_layer
-from chainlit.element import ElementBased
+from chainlit.element import CustomElement, ElementBased
 from chainlit.logger import logger
 from chainlit.step import StepDict
 from chainlit.telemetry import trace_event
@@ -22,6 +22,7 @@ from chainlit.types import (
     AskActionSpec,
     AskFileResponse,
     AskFileSpec,
+    AskElementSpec,
     AskSpec,
     FileDict,
 )
@@ -557,6 +558,72 @@ class AskActionMessage(AskMessageBase):
             self.content = "Timed out: no action was taken"
         else:
             self.content = f"**Selected:** {res['label']}"
+
+        self.wait_for_answer = False
+
+        await self.update()
+
+        return res
+
+
+class AskElementMessage(AskMessageBase):
+    """Ask the user to submit a custom element."""
+
+    def __init__(
+        self,
+        content: str,
+        element: CustomElement,
+        author=config.ui.name,
+        timeout=90,
+        raise_on_timeout=False,
+    ):
+        self.content = content
+        self.element = element
+        self.author = author
+        self.timeout = timeout
+        self.raise_on_timeout = raise_on_timeout
+
+        super().__post_init__()
+
+    async def send(self) -> Union[Dict[str, Any], None]:
+        """Send the custom element to the UI and wait for the reply."""
+        trace_event("send_ask_element")
+
+        if not self.created_at:
+            self.created_at = utc_now()
+
+        if self.streaming:
+            self.streaming = False
+
+        if config.code.author_rename:
+            self.author = await config.code.author_rename(self.author)
+
+        self.wait_for_answer = True
+
+        step_dict = await self._create()
+
+        await self.element.send(for_id=str(step_dict["id"]))
+
+        spec = AskElementSpec(
+            type="element",
+            step_id=step_dict["id"],
+            timeout=self.timeout,
+            element_id=self.element.id,
+        )
+
+        res = cast(
+            Union[Dict[str, Any], None],
+            await context.emitter.send_ask_user(step_dict, spec, self.raise_on_timeout),
+        )
+
+        await self.element.remove()
+
+        if res is None:
+            self.content = "Timed out"
+        elif res.get("submitted"):
+            self.content = "Thanks for submitting"
+        else:
+            self.content = "Cancelled"
 
         self.wait_for_answer = False
 

--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -125,7 +125,7 @@ class AskSpec(DataClassJsonMixin):
     """Specification for asking the user."""
 
     timeout: int
-    type: Literal["text", "file", "action"]
+    type: Literal["text", "file", "action", "element"]
     step_id: str
 
 
@@ -138,6 +138,12 @@ class AskFileSpec(FileSpec, AskSpec, DataClassJsonMixin):
 class AskActionSpec(ActionSpec, AskSpec, DataClassJsonMixin):
     """Specification for asking the user an action"""
 
+
+@dataclass
+class AskElementSpec(AskSpec, DataClassJsonMixin):
+    """Specification for asking the user a custom element"""
+
+    element_id: str
 
 class FileReference(TypedDict):
     id: str

--- a/cypress/e2e/ask_custom_element/main.py
+++ b/cypress/e2e/ask_custom_element/main.py
@@ -1,0 +1,36 @@
+import chainlit as cl
+
+
+@cl.on_chat_start
+async def on_start():
+    element = cl.CustomElement(
+        name="JiraTicket",
+        display="inline",
+        props={
+            "timeout": 20,
+            "fields": [
+                {"id": "summary", "label": "Summary", "type": "text", "required": True},
+                {"id": "description", "label": "Description", "type": "textarea"},
+                {
+                    "id": "due",
+                    "label": "Due Date",
+                    "type": "date",
+                },
+                {
+                    "id": "priority",
+                    "label": "Priority",
+                    "type": "select",
+                    "options": ["Low", "Medium", "High"],
+                    "value": "Medium",
+                    "required": True,
+                },
+            ],
+        },
+    )
+    res = await cl.AskElementMessage(
+        content="Create a new Jira ticket:", element=element, timeout=10
+    ).send()
+    if res and res.get("submitted"):
+        await cl.Message(
+            content=f"Ticket '{res['summary']}' with priority {res['priority']} submitted"
+        ).send()

--- a/cypress/e2e/ask_custom_element/public/elements/JiraTicket.jsx
+++ b/cypress/e2e/ask_custom_element/public/elements/JiraTicket.jsx
@@ -1,0 +1,99 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import React, { useEffect, useMemo, useState } from 'react';
+
+export default function JiraTicket() {
+  const [timeLeft, setTimeLeft] = useState(props.timeout || 30);
+  const [values, setValues] = useState(() => {
+    const init = {};
+    (props.fields || []).forEach((f) => {
+      init[f.id] = f.value || '';
+    });
+    return init;
+  });
+
+  const allValid = useMemo(() => {
+    if (!props.fields) return true;
+    return props.fields.every((f) => {
+      if (!f.required) return true;
+      const val = values[f.id];
+      return val !== undefined && val !== '';
+    });
+  }, [props.fields, values]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeLeft((t) => (t > 0 ? t - 1 : 0));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleChange = (id, val) => {
+    setValues((v) => ({ ...v, [id]: val }));
+  };
+
+  const renderField = (field) => {
+    const value = values[field.id];
+    switch (field.type) {
+      case 'textarea':
+        return <Textarea id={field.id} value={value} onChange={(e) => handleChange(field.id, e.target.value)} />;
+      case 'select':
+        return (
+          <Select value={value} onValueChange={(val) => handleChange(field.id, val)}>
+            <SelectTrigger id={field.id}>
+              <SelectValue placeholder={field.label} />
+            </SelectTrigger>
+            <SelectContent>
+              {field.options.map((opt) => (
+                <SelectItem key={opt} value={opt}>
+                  {opt}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      case 'date':
+        return <Input type="date" id={field.id} value={value} onChange={(e) => handleChange(field.id, e.target.value)} />;
+      case 'datetime':
+        return <Input type="datetime-local" id={field.id} value={value} onChange={(e) => handleChange(field.id, e.target.value)} />;
+      default:
+        return <Input id={field.id} value={value} onChange={(e) => handleChange(field.id, e.target.value)} />;
+    }
+  };
+
+  return (
+    <Card id="jira-ticket" className="mt-4 w-full max-w-3xl grid grid-cols-2 gap-4">
+      <CardHeader className="col-span-2">
+        <CardTitle>Create JIRA Ticket</CardTitle>
+        <CardDescription>Provide details for the new issue. {timeLeft}s left</CardDescription>
+      </CardHeader>
+      <CardContent className="col-span-2 grid grid-cols-2 gap-4">
+        {props.fields.map((field) => (
+          <div key={field.id} className="flex flex-col gap-2">
+            <Label htmlFor={field.id}>
+              {field.label}
+              {field.required && <span className="text-red-500">*</span>}
+            </Label>
+            {renderField(field)}
+          </div>
+        ))}
+      </CardContent>
+      <CardFooter className="col-span-2 flex justify-end gap-2">
+        <Button id="ticket-cancel" variant="outline" onClick={() => cancelElement()}>
+          Cancel
+        </Button>
+        <Button
+          id="ticket-submit"
+          disabled={!allValid}
+          onClick={() => submitElement({ submitted: true, ...values })}
+        >
+          Submit
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/cypress/e2e/ask_custom_element/spec.cy.ts
+++ b/cypress/e2e/ask_custom_element/spec.cy.ts
@@ -1,0 +1,17 @@
+import { runTestServer } from '../../support/testUtils';
+
+describe('Ask Custom Element', () => {
+  before(() => {
+    runTestServer();
+  });
+
+  it('should send element props to the backend', () => {
+    cy.get('.step').should('have.length', 1);
+    cy.get('#ticket-submit').should('be.disabled');
+    cy.get('#summary').type('Bug fix');
+    cy.get('#description').type('Detailed description');
+    cy.get('#ticket-submit').should('not.be.disabled').click();
+    cy.get('.step').should('have.length', 3);
+    cy.get('.step').eq(2).should('contain', 'Bug fix');
+  });
+});

--- a/frontend/src/components/Elements/CustomElement/index.tsx
+++ b/frontend/src/components/Elements/CustomElement/index.tsx
@@ -20,6 +20,8 @@ import {
   useChatInteract
 } from '@chainlit/react-client';
 
+import { MessageContext } from 'contexts/MessageContext';
+
 import Alert from '@/components/Alert';
 
 import Imports from './Imports';
@@ -30,6 +32,7 @@ const CustomElement = memo(function ({ element }: { element: ICustomElement }) {
   const sessionId = useRecoilValue(sessionIdState);
   const { sendMessage } = useChatInteract();
   const { user } = useAuth();
+  const { askUser } = useContext(MessageContext);
 
   const [sourceCode, setSourceCode] = useState<string>();
   const [error, setError] = useState<string>();
@@ -78,6 +81,27 @@ const CustomElement = memo(function ({ element }: { element: ICustomElement }) {
     [sendMessage, user]
   );
 
+  const submitElement = useCallback(
+    (props: Record<string, unknown>) => {
+      if (
+        askUser?.spec.type === 'element' &&
+        askUser.spec.step_id === element.forId
+      ) {
+        askUser.callback({ submitted: true, ...props });
+      }
+    },
+    [askUser, element.forId]
+  );
+
+  const cancelElement = useCallback(() => {
+    if (
+      askUser?.spec.type === 'element' &&
+      askUser.spec.step_id === element.forId
+    ) {
+      askUser.callback({ submitted: false });
+    }
+  }, [askUser, element.forId]);
+
   const props = useMemo(() => {
     return JSON.parse(JSON.stringify(element.props));
   }, [element.props]);
@@ -96,7 +120,9 @@ const CustomElement = memo(function ({ element }: { element: ICustomElement }) {
           updateElement,
           deleteElement,
           callAction,
-          sendUserMessage
+          sendUserMessage,
+          submitElement,
+          cancelElement
         }}
         onRendered={(error) => setError(error?.message)}
       />

--- a/libs/react-client/src/types/file.ts
+++ b/libs/react-client/src/types/file.ts
@@ -16,11 +16,12 @@ export interface IFileRef {
 }
 
 export interface IAsk {
-  callback: (payload: IStep | IFileRef[] | IAction) => void;
+  callback: (payload: IStep | IFileRef[] | IAction | Record<string, unknown>) => void;
   spec: {
-    type: 'text' | 'file' | 'action';
+    type: 'text' | 'file' | 'action' | 'element';
     step_id: string;
     timeout: number;
+    element_id?: string;
   } & FileSpec &
     ActionSpec;
   parentId?: string;

--- a/libs/react-client/src/useChatData.ts
+++ b/libs/react-client/src/useChatData.ts
@@ -39,7 +39,8 @@ const useChatData = () => {
     !connected ||
     loading ||
     askUser?.spec.type === 'file' ||
-    askUser?.spec.type === 'action';
+    askUser?.spec.type === 'action' ||
+    askUser?.spec.type === 'element';
 
   return {
     actions,


### PR DESCRIPTION
## ✨ Feature: AskElementMessage - Block the chat until a user completes a custom element

> **Goal:** Allow agents to send interactive, consent-gated UI components (custom elements) to the front end, let users review or edit their values, and submit them back to the backend.

### 🎯 Why this matters
- Empowers end users to **review**, **modify**, and **consent** to any tool-provided data before it’s executed.  
- Enables corporate compliance workflows where certain tool calls (e.g. expense approvals, data exports) must be explicit and auditable.  
- **Blocks** further chat interactions until user input is received—preventing ambiguous or unauthorized actions.

### 🔄 Expected flow
1. **Agent** calls a consent-gated tool (e.g. an expense-logging API).  
2. Backend sends a **CustomElement** to the front end:  
   - Renders user-editable fields with a timeout.  
   - Temporarily blocks chat until submission.  
3. **User** modifies or confirms the pre-filled values and submits.  
4. Backend receives the **updated props** and proceeds with the tool call using the user-approved data.

**Example:**

![demo](https://github.com/user-attachments/assets/d8d2c58a-2a9d-4d92-b7f7-6495d36a37a7)

---

### 📋 Example: Raising an Expense Request w/ code

<img src="https://github.com/user-attachments/assets/d6ef8d83-42b0-4f37-a14e-6d4f0bc44abc" alt="Expense request form" style="max-width:100%;border:1px solid var(--shadcn-border)" />

<details>
<summary><strong>How it’s wired up (Python backend)</strong></summary>

```python
import chainlit as cl

@cl.on_chat_start
async def start_log_expense():
    exp = cl.CustomElement(
        name="LogExpense",
        display="inline",
        props={
            "timeout": 50,
            "fields": [
                {"id": "amount", "label": "Amount (AUD)", "type": "text", "value": "123.45", "required": True},
                {"id": "category", "label": "Category", "type": "select", "options": ["Travel","Meals","Other"], "value": "Meals", "required": True},
                {"id": "date", "label": "Date", "type": "date", "value": "2025-06-05"},
                {"id": "notes", "label": "Notes", "type": "textarea", "value": "Client lunch at Café Vue."},
            ],
        },
    )
    res = await cl.AskElementMessage("Log a new expense:", element=exp).send()
    if res and res.get("submitted"):
        await cl.Message(
            content=f"💰 Logged {res['amount']} on {res['date']}"
        ).send()
```
</details> <details> <summary><strong>JSX for the `LogExpense` element</strong></summary>

```jsx
import { Button } from "@/components/ui/button";
import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
import { Input } from "@/components/ui/input";
import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
import { Textarea } from "@/components/ui/textarea";
import React, { useEffect, useMemo, useState } from "react";

export default function LogExpense() {
  const [timeLeft, setTimeLeft] = useState(props.timeout);
  const [vals, setVals] = useState(() =>
    Object.fromEntries(props.fields.map(f => [f.id, f.value || ""]))
  );

  const allValid = useMemo(
    () => props.fields.filter(f => f.required).every(f => vals[f.id] !== ""),
    [vals]
  );

  useEffect(() => {
    const iv = setInterval(() => setTimeLeft(t => Math.max(0, t - 1)), 1000);
    return () => clearInterval(iv);
  }, []);

  const onChange = (id, value) => setVals(vs => ({ ...vs, [id]: value }));

  const renderField = f => {
    switch (f.type) {
      case "select":
        return (
          <Select value={vals[f.id]} onValueChange={v => onChange(f.id, v)} className="w-full">
            <SelectTrigger id={f.id}><SelectValue placeholder={f.label}/></SelectTrigger>
            <SelectContent>
              {f.options.map(o => <SelectItem key={o} value={o}>{o}</SelectItem>)}
            </SelectContent>
          </Select>
        );
      case "textarea":
        return <Textarea id={f.id} value={vals[f.id]} onChange={e => onChange(f.id, e.target.value)} className="w-full" />;
      default:
        return <Input type={f.type} id={f.id} value={vals[f.id]} onChange={e => onChange(f.id, e.target.value)} className="w-full" />;
    }
  };

  return (
    <Card className="w-full p-4 space-y-4">
      <CardHeader>
        <CardTitle className="flex justify-between items-center">
          <span>Log Expense</span>
          <span className="text-sm text-muted-foreground">{timeLeft}s</span>
        </CardTitle>
      </CardHeader>
      <CardContent className="space-y-4">
        {props.fields.map(f => (
          <div key={f.id} className="flex flex-col space-y-1">
            <label htmlFor={f.id} className="font-semibold">
              {f.label}{f.required && <span className="text-red-500">*</span>}
            </label>
            {renderField(f)}
          </div>
        ))}
      </CardContent>
      <CardFooter className="flex justify-end space-x-2">
        <Button variant="outline" onClick={() => cancelElement()}>Cancel</Button>
        <Button disabled={!allValid} onClick={() => submitElement({ submitted: true, ...vals })}>
          Log Expense
        </Button>
      </CardFooter>
    </Card>
  );
}
```
</details>

---

This pattern can be reused for any consent-gated tool: expose the data in a form, block until user approval, then feed the updated props back into the next step.

Adds: https://github.com/Chainlit/chainlit/issues/2041