### PR TITLE
feat: Reduce LiteralAI dependencies

### DIFF
--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -1,7 +1,8 @@
 import os
+from datetime import datetime, timezone
 
 from dotenv import load_dotenv
-from datetime import datetime, timezone
+
 # ruff: noqa: E402
 # Keep this here to ensure imports have environment available.
 env_file = os.getenv("CHAINLIT_ENV_FILE", ".env")
@@ -15,7 +16,6 @@ if env_found:
 import asyncio
 from typing import TYPE_CHECKING, Any, Dict
 
-from chainlit.generation import ChatGeneration, CompletionGeneration, GenerationMessage
 from pydantic.dataclasses import dataclass
 
 import chainlit.input_widget as input_widget
@@ -39,6 +39,7 @@ from chainlit.element import (
     Text,
     Video,
 )
+from chainlit.generation import ChatGeneration, CompletionGeneration, GenerationMessage
 from chainlit.message import (
     AskActionMessage,
     AskFileMessage,
@@ -101,9 +102,16 @@ def sleep(duration: int):
     """
     return asyncio.sleep(duration)
 
+
 def utc_now():
     dt = datetime.now(timezone.utc).replace(tzinfo=None)
     return dt.isoformat() + "Z"
+
+
+def timestamp_utc(timestamp: float):
+    dt = datetime.fromtimestamp(timestamp, timezone.utc).replace(tzinfo=None)
+    return dt.isoformat() + "Z"
+
 
 @dataclass()
 class CopilotFunction:

--- a/backend/chainlit/__init__.py
+++ b/backend/chainlit/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 from dotenv import load_dotenv
-
+from datetime import datetime, timezone
 # ruff: noqa: E402
 # Keep this here to ensure imports have environment available.
 env_file = os.getenv("CHAINLIT_ENV_FILE", ".env")
@@ -15,7 +15,7 @@ if env_found:
 import asyncio
 from typing import TYPE_CHECKING, Any, Dict
 
-from literalai import ChatGeneration, CompletionGeneration, GenerationMessage
+from chainlit.generation import ChatGeneration, CompletionGeneration, GenerationMessage
 from pydantic.dataclasses import dataclass
 
 import chainlit.input_widget as input_widget
@@ -101,6 +101,9 @@ def sleep(duration: int):
     """
     return asyncio.sleep(duration)
 
+def utc_now():
+    dt = datetime.now(timezone.utc).replace(tzinfo=None)
+    return dt.isoformat() + "Z"
 
 @dataclass()
 class CopilotFunction:

--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -2,9 +2,9 @@ import asyncio
 import uuid
 from typing import Any, Dict, List, Literal, Optional, Union, cast, get_args
 
-from literalai.helper import utc_now
 from socketio.exceptions import TimeoutError
 
+from chainlit import utc_now
 from chainlit.chat_context import chat_context
 from chainlit.config import config
 from chainlit.data import get_data_layer

--- a/backend/chainlit/generation.py
+++ b/backend/chainlit/generation.py
@@ -1,0 +1,237 @@
+# This file exists to remove the LiteralAI dependency and maintain compatability.
+# Copied from https://github.com/Chainlit/literalai-python/blob/main/literalai/observability/generation.py and https://github.com/Chainlit/literalai-python/blob/main/literalai/my_types.py
+
+from abc import abstractmethod
+from enum import Enum, unique
+from typing import Dict, List, Literal, Optional, Union
+import json
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+from typing_extensions import TypedDict
+
+GenerationMessageRole = Literal["user", "assistant", "tool", "function", "system"]
+
+class ImageUrlContent(TypedDict, total=False):
+    type: Literal["image_url"]
+    image_url: Dict
+
+class TextContent(TypedDict, total=False):
+    type: Literal["text"]
+    text: str
+
+class Utils:
+    def __str__(self):
+        return json.dumps(self.to_dict(), sort_keys=True, indent=4)
+
+    def __repr__(self):
+        return json.dumps(self.to_dict(), sort_keys=True, indent=4)
+
+    @abstractmethod
+    def to_dict(self):
+        pass
+
+@unique
+class GenerationType(str, Enum):
+    CHAT = "CHAT"
+    COMPLETION = "COMPLETION"
+
+    def __str__(self):
+        return self.value
+
+    def __repr__(self):
+        return f"GenerationType.{self.name}"
+
+    def to_json(self):
+        return self.value
+
+
+class GenerationMessage(TypedDict, total=False):
+    uuid: Optional[str]
+    templated: Optional[bool]
+    name: Optional[str]
+    role: Optional[GenerationMessageRole]
+    content: Optional[Union[str, List[Union[TextContent, ImageUrlContent]]]]
+    function_call: Optional[Dict]
+    tool_calls: Optional[List[Dict]]
+    tool_call_id: Optional[str]
+
+
+@dataclass(repr=False)
+class BaseGeneration(Utils):
+    """
+    Base class for generation objects, containing common attributes and methods.
+
+    Attributes:
+        id (Optional[str]): The unique identifier of the generation.
+        prompt_id (Optional[str]): The unique identifier of the prompt associated with the generation.
+        provider (Optional[str]): The provider of the generation.
+        model (Optional[str]): The model used for the generation.
+        error (Optional[str]): Any error message associated with the generation.
+        settings (Optional[Dict]): Settings used for the generation.
+        variables (Optional[Dict]): Variables used in the generation.
+        tags (Optional[List[str]]): Tags associated with the generation.
+        metadata (Optional[Dict]): Metadata associated with the generation.
+        tools (Optional[List[Dict]]): Tools used in the generation.
+        token_count (Optional[int]): The total number of tokens in the generation.
+        input_token_count (Optional[int]): The number of input tokens in the generation.
+        output_token_count (Optional[int]): The number of output tokens in the generation.
+        tt_first_token (Optional[float]): Time to first token in the generation.
+        token_throughput_in_s (Optional[float]): Token throughput in seconds.
+        duration (Optional[float]): Duration of the generation.
+
+    Methods:
+        from_dict(cls, generation_dict: Dict) -> Union["ChatGeneration", "CompletionGeneration"]:
+            Creates a generation object from a dictionary.
+        to_dict(self) -> Dict:
+            Converts the generation object to a dictionary.
+    """
+
+    id: Optional[str] = None
+    prompt_id: Optional[str] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    error: Optional[str] = None
+    settings: Optional[Dict] = Field(default_factory=lambda: {})
+    variables: Optional[Dict] = Field(default_factory=lambda: {})
+    tags: Optional[List[str]] = Field(default_factory=lambda: [])
+    metadata: Optional[Dict] = Field(default_factory=lambda: {})
+    tools: Optional[List[Dict]] = None
+    token_count: Optional[int] = None
+    input_token_count: Optional[int] = None
+    output_token_count: Optional[int] = None
+    tt_first_token: Optional[float] = None
+    token_throughput_in_s: Optional[float] = None
+    duration: Optional[float] = None
+
+    @classmethod
+    def from_dict(
+        cls, generation_dict: Dict
+    ) -> Union["ChatGeneration", "CompletionGeneration"]:
+        type = GenerationType(generation_dict.get("type"))
+        if type == GenerationType.CHAT:
+            return ChatGeneration.from_dict(generation_dict)
+        elif type == GenerationType.COMPLETION:
+            return CompletionGeneration.from_dict(generation_dict)
+        else:
+            raise ValueError(f"Unknown generation type: {type}")
+
+    def to_dict(self):
+        _dict = {
+            "promptId": self.prompt_id,
+            "provider": self.provider,
+            "model": self.model,
+            "error": self.error,
+            "settings": self.settings,
+            "variables": self.variables,
+            "tags": self.tags,
+            "metadata": self.metadata,
+            "tools": self.tools,
+            "tokenCount": self.token_count,
+            "inputTokenCount": self.input_token_count,
+            "outputTokenCount": self.output_token_count,
+            "ttFirstToken": self.tt_first_token,
+            "tokenThroughputInSeconds": self.token_throughput_in_s,
+            "duration": self.duration,
+        }
+        if self.id:
+            _dict["id"] = self.id
+        return _dict
+
+
+@dataclass(repr=False)
+class CompletionGeneration(BaseGeneration, Utils):
+    """
+    Represents a completion generation with a prompt and its corresponding completion.
+
+    Attributes:
+        prompt (Optional[str]): The prompt text for the generation.
+        completion (Optional[str]): The generated completion text.
+        type (GenerationType): The type of generation, which is set to GenerationType.COMPLETION.
+    """
+
+    prompt: Optional[str] = None
+    completion: Optional[str] = None
+    type = GenerationType.COMPLETION
+
+    def to_dict(self):
+        _dict = super().to_dict()
+        _dict.update(
+            {
+                "prompt": self.prompt,
+                "completion": self.completion,
+                "type": self.type.value,
+            }
+        )
+        return _dict
+
+    @classmethod
+    def from_dict(cls, generation_dict: Dict):
+        return CompletionGeneration(
+            id=generation_dict.get("id"),
+            prompt_id=generation_dict.get("promptId"),
+            error=generation_dict.get("error"),
+            tags=generation_dict.get("tags"),
+            provider=generation_dict.get("provider"),
+            model=generation_dict.get("model"),
+            variables=generation_dict.get("variables"),
+            tools=generation_dict.get("tools"),
+            settings=generation_dict.get("settings"),
+            token_count=generation_dict.get("tokenCount"),
+            input_token_count=generation_dict.get("inputTokenCount"),
+            output_token_count=generation_dict.get("outputTokenCount"),
+            tt_first_token=generation_dict.get("ttFirstToken"),
+            token_throughput_in_s=generation_dict.get("tokenThroughputInSeconds"),
+            duration=generation_dict.get("duration"),
+            prompt=generation_dict.get("prompt"),
+            completion=generation_dict.get("completion"),
+        )
+
+
+@dataclass(repr=False)
+class ChatGeneration(BaseGeneration, Utils):
+    """
+    Represents a chat generation with a list of messages and a message completion.
+
+    Attributes:
+        messages (Optional[List[GenerationMessage]]): The list of messages in the chat generation.
+        message_completion (Optional[GenerationMessage]): The completion message of the chat generation.
+        type (GenerationType): The type of generation, which is set to GenerationType.CHAT.
+    """
+
+    type = GenerationType.CHAT
+    messages: Optional[List[GenerationMessage]] = Field(default_factory=lambda: [])
+    message_completion: Optional[GenerationMessage] = None
+
+    def to_dict(self):
+        _dict = super().to_dict()
+        _dict.update(
+            {
+                "messages": self.messages,
+                "messageCompletion": self.message_completion,
+                "type": self.type.value,
+            }
+        )
+        return _dict
+
+    @classmethod
+    def from_dict(self, generation_dict: Dict):
+        return ChatGeneration(
+            id=generation_dict.get("id"),
+            prompt_id=generation_dict.get("promptId"),
+            error=generation_dict.get("error"),
+            tags=generation_dict.get("tags"),
+            provider=generation_dict.get("provider"),
+            model=generation_dict.get("model"),
+            variables=generation_dict.get("variables"),
+            tools=generation_dict.get("tools"),
+            settings=generation_dict.get("settings"),
+            token_count=generation_dict.get("tokenCount"),
+            input_token_count=generation_dict.get("inputTokenCount"),
+            output_token_count=generation_dict.get("outputTokenCount"),
+            tt_first_token=generation_dict.get("ttFirstToken"),
+            token_throughput_in_s=generation_dict.get("tokenThroughputInSeconds"),
+            duration=generation_dict.get("duration"),
+            messages=generation_dict.get("messages", []),
+            message_completion=generation_dict.get("messageCompletion"),
+        )

--- a/backend/chainlit/generation.py
+++ b/backend/chainlit/generation.py
@@ -18,8 +18,6 @@ MessageStepType = Literal["user_message", "assistant_message", "system_message"]
 
 StepType = Union[TrueStepType, MessageStepType]
 
-MessageStepType = Literal["user_message", "assistant_message", "system_message"]
-
 GenerationMessageRole = Literal["user", "assistant", "tool", "function", "system"]
 
 
@@ -122,13 +120,13 @@ class BaseGeneration(Utils):
     def from_dict(
         cls, generation_dict: Dict
     ) -> Union["ChatGeneration", "CompletionGeneration"]:
-        type = GenerationType(generation_dict.get("type"))
-        if type == GenerationType.CHAT:
+        _type = GenerationType(generation_dict.get("type"))
+        if _type == GenerationType.CHAT:
             return ChatGeneration.from_dict(generation_dict)
-        elif type == GenerationType.COMPLETION:
+        elif _type == GenerationType.COMPLETION:
             return CompletionGeneration.from_dict(generation_dict)
         else:
-            raise ValueError(f"Unknown generation type: {type}")
+            raise ValueError(f"Unknown generation type: {_type}")
 
     def to_dict(self):
         _dict = {

--- a/backend/chainlit/generation.py
+++ b/backend/chainlit/generation.py
@@ -1,24 +1,37 @@
 # This file exists to remove the LiteralAI dependency and maintain compatability.
 # Copied from https://github.com/Chainlit/literalai-python/blob/main/literalai/observability/generation.py and https://github.com/Chainlit/literalai-python/blob/main/literalai/my_types.py
 
+import json
 from abc import abstractmethod
 from enum import Enum, unique
 from typing import Dict, List, Literal, Optional, Union
-import json
 
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 from typing_extensions import TypedDict
 
+TrueStepType = Literal[
+    "run", "tool", "llm", "embedding", "retrieval", "rerank", "undefined"
+]
+
+MessageStepType = Literal["user_message", "assistant_message", "system_message"]
+
+StepType = Union[TrueStepType, MessageStepType]
+
+MessageStepType = Literal["user_message", "assistant_message", "system_message"]
+
 GenerationMessageRole = Literal["user", "assistant", "tool", "function", "system"]
+
 
 class ImageUrlContent(TypedDict, total=False):
     type: Literal["image_url"]
     image_url: Dict
 
+
 class TextContent(TypedDict, total=False):
     type: Literal["text"]
     text: str
+
 
 class Utils:
     def __str__(self):
@@ -30,6 +43,7 @@ class Utils:
     @abstractmethod
     def to_dict(self):
         pass
+
 
 @unique
 class GenerationType(str, Enum):
@@ -92,10 +106,10 @@ class BaseGeneration(Utils):
     provider: Optional[str] = None
     model: Optional[str] = None
     error: Optional[str] = None
-    settings: Optional[Dict] = Field(default_factory=lambda: {})
-    variables: Optional[Dict] = Field(default_factory=lambda: {})
-    tags: Optional[List[str]] = Field(default_factory=lambda: [])
-    metadata: Optional[Dict] = Field(default_factory=lambda: {})
+    settings: Optional[Dict] = Field(default_factory=dict)
+    variables: Optional[Dict] = Field(default_factory=dict)
+    tags: Optional[List[str]] = Field(default_factory=list)
+    metadata: Optional[Dict] = Field(default_factory=dict)
     tools: Optional[List[Dict]] = None
     token_count: Optional[int] = None
     input_token_count: Optional[int] = None
@@ -200,7 +214,7 @@ class ChatGeneration(BaseGeneration, Utils):
     """
 
     type = GenerationType.CHAT
-    messages: Optional[List[GenerationMessage]] = Field(default_factory=lambda: [])
+    messages: Optional[List[GenerationMessage]] = Field(default_factory=list)
     message_completion: Optional[GenerationMessage] = None
 
     def to_dict(self):

--- a/backend/chainlit/langchain/callbacks.py
+++ b/backend/chainlit/langchain/callbacks.py
@@ -7,11 +7,15 @@ from langchain.callbacks.tracers.schemas import Run
 from langchain.schema import BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from langchain_core.tracers.base import AsyncBaseTracer
-from literalai import ChatGeneration, CompletionGeneration, GenerationMessage
-from literalai.helper import utc_now
-from literalai.observability.step import TrueStepType
 
+from chainlit import utc_now
 from chainlit.context import context_var
+from chainlit.generation import (
+    ChatGeneration,
+    CompletionGeneration,
+    GenerationMessage,
+    TrueStepType,
+)
 from chainlit.message import Message
 from chainlit.step import Step
 

--- a/backend/chainlit/llama_index/callbacks.py
+++ b/backend/chainlit/llama_index/callbacks.py
@@ -1,14 +1,14 @@
 from typing import Any, Dict, List, Optional
 
-from literalai import ChatGeneration, CompletionGeneration, GenerationMessage
-from literalai.helper import utc_now
 from llama_index.core.callbacks import TokenCountingHandler
 from llama_index.core.callbacks.schema import CBEventType, EventPayload
 from llama_index.core.llms import ChatMessage, ChatResponse, CompletionResponse
 from llama_index.core.tools.types import ToolMetadata
 
+from chainlit import utc_now
 from chainlit.context import context_var
 from chainlit.element import Text
+from chainlit.generation import ChatGeneration, CompletionGeneration, GenerationMessage
 from chainlit.step import Step, StepType
 
 DEFAULT_IGNORE = [

--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -5,15 +5,14 @@ import uuid
 from abc import ABC
 from typing import Dict, List, Optional, Union, cast
 
-from literalai.helper import utc_now
-from literalai.observability.step import MessageStepType
-
+from chainlit import utc_now
 from chainlit.action import Action
 from chainlit.chat_context import chat_context
 from chainlit.config import config
 from chainlit.context import context, local_steps
 from chainlit.data import get_data_layer
 from chainlit.element import ElementBased
+from chainlit.generation import MessageStepType
 from chainlit.logger import logger
 from chainlit.step import StepDict
 from chainlit.telemetry import trace_event

--- a/backend/chainlit/mistralai/__init__.py
+++ b/backend/chainlit/mistralai/__init__.py
@@ -1,10 +1,9 @@
 import asyncio
 from typing import Union
 
-from literalai import ChatGeneration, CompletionGeneration
-from literalai.helper import timestamp_utc
-
+from chainlit import timestamp_utc
 from chainlit.context import get_context
+from chainlit.generation import ChatGeneration, CompletionGeneration
 from chainlit.step import Step
 
 

--- a/backend/chainlit/openai/__init__.py
+++ b/backend/chainlit/openai/__init__.py
@@ -1,10 +1,9 @@
 import asyncio
 from typing import Union
 
-from literalai import ChatGeneration, CompletionGeneration
-from literalai.helper import timestamp_utc
-
+from chainlit import timestamp_utc
 from chainlit.context import local_steps
+from chainlit.generation import ChatGeneration, CompletionGeneration
 from chainlit.step import Step
 from chainlit.utils import check_module_version
 

--- a/backend/chainlit/step.py
+++ b/backend/chainlit/step.py
@@ -7,14 +7,12 @@ from copy import deepcopy
 from functools import wraps
 from typing import Callable, Dict, List, Optional, TypedDict, Union
 
-from literalai import BaseGeneration
-from literalai.helper import utc_now
-from literalai.observability.step import StepType, TrueStepType
-
+from chainlit import utc_now
 from chainlit.config import config
 from chainlit.context import CL_RUN_NAMES, context, local_steps
 from chainlit.data import get_data_layer
 from chainlit.element import Element
+from chainlit.generation import BaseGeneration, StepType, TrueStepType
 from chainlit.logger import logger
 from chainlit.telemetry import trace_event
 from chainlit.types import FeedbackDict

--- a/cypress/e2e/data_layer/main.py
+++ b/cypress/e2e/data_layer/main.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 import chainlit as cl
 import chainlit.data as cl_data
+from chainlit import utc_now
 from chainlit.data.utils import queue_until_user_message
 from chainlit.element import Element, ElementDict
 from chainlit.socket import persist_user_session
@@ -16,7 +17,6 @@ from chainlit.types import (
     ThreadDict,
     ThreadFilter,
 )
-from literalai.helper import utc_now
 
 now = utc_now()
 


### PR DESCRIPTION
> [!WARNING]  
> Work-In-Progress

LiteralAI will be going away and is inter-twined with Chainlit. This PR intends to begin reducing our dependencies on LiteralAI and get some PRs merged, with the intention of fully removing in the future. Starting with datetime functions that can just be in Chainlit directly.