### PR TITLE
fix(ui): adding container prop to dropdown portal (Render the Portal Inside Copilot's Shadow DOM)

### DIFF
--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -57,7 +57,7 @@ const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
+  <DropdownMenuPrimitive.Portal container={window.cl_shadowRootElement || document.body}>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}


### PR DESCRIPTION
fix(ui): adding container prop to dropdown portal (Render the Portal Inside Copilot's Shadow DOM)

At present, the Copilot mode hasn't utilized this component. Yet, to avoid potential future errors, this PR is submitted.