### PR TITLE
Import timestamp_utc from chainlit.utils

### DIFF
--- a/backend/chainlit/mistralai/__init__.py
+++ b/backend/chainlit/mistralai/__init__.py
@@ -3,9 +3,9 @@ from typing import Union
 
 from literalai import ChatGeneration, CompletionGeneration
 
-from chainlit.utils import timestamp_utc
 from chainlit.context import get_context
 from chainlit.step import Step
+from chainlit.utils import timestamp_utc
 
 
 def instrument_mistralai():

--- a/backend/chainlit/mistralai/__init__.py
+++ b/backend/chainlit/mistralai/__init__.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from literalai import ChatGeneration, CompletionGeneration
 
-from chainlit import timestamp_utc
+from chainlit.utils import timestamp_utc
 from chainlit.context import get_context
 from chainlit.step import Step
 

--- a/backend/chainlit/openai/__init__.py
+++ b/backend/chainlit/openai/__init__.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from literalai import ChatGeneration, CompletionGeneration
 
-from chainlit import timestamp_utc
+from chainlit.utils import timestamp_utc
 from chainlit.context import local_steps
 from chainlit.step import Step
 from chainlit.utils import check_module_version

--- a/backend/chainlit/openai/__init__.py
+++ b/backend/chainlit/openai/__init__.py
@@ -3,10 +3,9 @@ from typing import Union
 
 from literalai import ChatGeneration, CompletionGeneration
 
-from chainlit.utils import timestamp_utc
 from chainlit.context import local_steps
 from chainlit.step import Step
-from chainlit.utils import check_module_version
+from chainlit.utils import check_module_version, timestamp_utc
 
 
 def instrument_openai():


### PR DESCRIPTION
Due to changes from #2245, the openai and mistralai sub-modules cannot be loaded anymore, as timestamp_utc is not loaded from the chainlit.utils.

These changes correctly import timestamp_utc again.
