### PR TITLE
Allow more than 4 starters via cl.ChatProfile

### DIFF
--- a/frontend/src/components/chat/Starters.tsx
+++ b/frontend/src/components/chat/Starters.tsx
@@ -19,7 +19,7 @@ export default function Starters({ className }: Props) {
         (profile) => profile.name === chatProfile
       );
       if (selectedChatProfile?.starters) {
-        return selectedChatProfile.starters.slice(0, 4);
+        return selectedChatProfile.starters;
       }
     }
     return config?.starters;


### PR DESCRIPTION
Match @cl.set_starters functionality in cl.ChatProfile's starters array by allowing more than 4 starters