### PR TITLE
change width of element view in copilot

### DIFF
--- a/libs/copilot/src/components/ElementSideView.tsx
+++ b/libs/copilot/src/components/ElementSideView.tsx
@@ -16,7 +16,7 @@ export default function ElementSideView() {
 
   return (
     <Dialog open onOpenChange={(open) => !open && setSideView(undefined)}>
-      <DialogContent className="sm:max-w-md md:max-w-lg lg:max-w-xl">
+      <DialogContent className="max-w-[80%]">
         <DialogHeader>
           <DialogTitle>{sideView.title}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
the width of the element view in copilot is fixed and a bit small.

this changes the max width to be 80% which is convenient for many types of element like md.

this is photo screenshot comparing the change in width :

before : 
![Screenshot from 2025-07-08 18-14-54](https://github.com/user-attachments/assets/611e34fc-7f87-4ebd-9e6b-c0591e2988b5)

after: 
![Screenshot from 2025-07-08 18-09-53](https://github.com/user-attachments/assets/d0801b20-2bed-4724-9269-84bf4803ee22)
