### PR TITLE
feat: Add workflow to close old Issues/PRs

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -16,13 +16,13 @@ jobs:
           days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-label: "stale"
-          exempt-issue-labels: "enhancement,dev-tooling,e2e-tests,unit-tests"
+          exempt-issue-labels: "enhancement,dev-tooling,e2e-tests,unit-tests,keep-for-a-while"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
           days-before-pr-stale: 14
           days-before-pr-close: 7
           stale-pr-label: "stale"
-          exempt-pr-labels: "enhancement,dev-tooling,e2e-tests,unit-tests"
+          exempt-pr-labels: "enhancement,dev-tooling,e2e-tests,unit-tests,keep-for-a-while"
           stale-pr-message: "This PR is stale because it has been open for 14 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,4 +1,4 @@
-name: Close inactive issues
+name: Close inactive issues and pull requests
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -16,13 +16,13 @@ jobs:
           days-before-issue-stale: 14
           days-before-issue-close: 7
           stale-issue-label: "stale"
+          exempt-issue-labels: "enhancement,dev-tooling,e2e-tests,unit-tests"
           stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
-          any-of-issue-labels: 'question,needs-more-info'
           days-before-pr-stale: 14
           days-before-pr-close: 7
           stale-pr-label: "stale"
-          exempt-issue-labels: "skip-stale"
+          exempt-pr-labels: "enhancement,dev-tooling,e2e-tests,unit-tests"
           stale-pr-message: "This PR is stale because it has been open for 14 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,28 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+  
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          any-of-issue-labels: 'question,needs-more-info'
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          exempt-issue-labels: "skip-stale"
+          stale-pr-message: "This PR is stale because it has been open for 14 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the management of inactive issues and pull requests. The workflow uses the `actions/stale` action to mark issues and pull requests as stale and close them after a period of inactivity. This runs daily at 01:30 UTC.

### New workflow for managing stale issues and pull requests:
* [`.github/workflows/issues.yml`](diffhunk://#diff-25671745f65ff1eb3a5901f4fd263e7a59a36d522abd32b8240832f06e5227e8R1-R28): Introduced a workflow named "Close inactive issues" that runs on a daily schedule and can also be triggered manually. It marks issues and pull requests as stale after 14 days of inactivity and closes them 7 days later, with customizable messages and label configurations.


Initial draft to clean up the 407 issues and 35 PRs. We should probably include tags here to keep some feature request issues open that are still valid. This may be accomplished using [enhancement](https://github.com/Chainlit/chainlit/issues?q=state%3Aopen%20label%3Aenhancement) tag.