### PR TITLE
fix: postgres query syntax error in data_layer

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -561,12 +561,19 @@ class ChainlitDataLayer(BaseDataLayer):
 
         update_sets = [f'"{k}" = EXCLUDED."{k}"' for k in data.keys() if k != "id"]
 
-        query = f"""
-            INSERT INTO "Thread" ({", ".join(columns)})
-            VALUES ({", ".join(placeholders)})
-            ON CONFLICT (id) DO UPDATE
-            SET {", ".join(update_sets)};
-        """
+        if update_sets:
+            query = f"""
+                INSERT INTO "Thread" ({", ".join(columns)})
+                VALUES ({", ".join(placeholders)})
+                ON CONFLICT (id) DO UPDATE
+                SET {", ".join(update_sets)};
+            """
+        else:
+            query = f"""
+                INSERT INTO "Thread" ({", ".join(columns)})
+                VALUES ({", ".join(placeholders)})
+                ON CONFLICT (id) DO NOTHING
+            """
 
         await self.execute_query(query, {str(i + 1): v for i, v in enumerate(values)})
 


### PR DESCRIPTION
Original behavior: 
`asyncpg.exceptions.PostgresSyntaxError: syntax error at or near ";"`

Caused by this query:
```
postgres-1    | 2025-07-15 12:26:38.419 UTC [544] STATEMENT:  
postgres-1    |                     INSERT INTO "Thread" ("id")
postgres-1    |                     VALUES ($1)
postgres-1    |                     ON CONFLICT (id) DO UPDATE
postgres-1    |                     SET ;
```

which happens when `update_sets` is empty list. 

After suggested fix there is no query error. This is the new query:
```
postgres-1    | 2025-07-15 12:28:44.355 UTC [562] STATEMENT:  
postgres-1    |                     INSERT INTO "Thread" ("id")
postgres-1    |                     VALUES ($1)
postgres-1    |                     ON CONFLICT (id) DO NOTHING
```