### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           poetry-working-directory: ${{ env.BACKEND_DIR }}
       - name: Build Python distribution
-        run: poetry self add poetry-plugin-ignore-build-script && poetry build --ignore-build-script
+        run: sed -i '/\[tool.poetry.build\]/,/^script = .*/d' pyproject.toml && poetry build
         working-directory: ${{ env.BACKEND_DIR }}
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Use in-place command to modify `pyproject.toml` to fix python-poetry/poetry#8039 instead of using the `poetry-plugin-ignore-build-script`, which is incompatible with Poetry 2.
