### PR TITLE
feat: remove watermark logo

### DIFF
--- a/backend/chainlit/translations/en-US.json
+++ b/backend/chainlit/translations/en-US.json
@@ -111,7 +111,7 @@
     "settings": {
       "title": "Settings panel"
     },
-    "watermark": "LLMs can make mistakes. Consider checking important information."
+    "watermark": "LLMs can make mistakes. Check important info."
   },
   "threadHistory": {
     "sidebar": {

--- a/frontend/src/components/WaterMark.tsx
+++ b/frontend/src/components/WaterMark.tsx
@@ -1,16 +1,8 @@
 import { Translator } from 'components/i18n';
 
-import 'assets/logo_dark.svg';
-import LogoDark from 'assets/logo_dark.svg?react';
-import 'assets/logo_light.svg';
-import LogoLight from 'assets/logo_light.svg?react';
 
-import { useTheme } from './ThemeProvider';
 
 export default function WaterMark() {
-  const { variant } = useTheme();
-  const Logo = variant === 'light' ? LogoLight : LogoDark;
-
   return (
     <div
       className="watermark"
@@ -23,14 +15,6 @@ export default function WaterMark() {
       <div className="text-xs text-muted-foreground">
         <Translator path="chat.watermark" />
       </div>
-      <Logo
-        style={{
-          width: 65,
-          height: 'auto',
-          filter: 'grayscale(1)',
-          marginLeft: '4px'
-        }}
-      />
     </div>
   );
 }


### PR DESCRIPTION
This pull request includes updates to improve the watermark text and simplify the `WaterMark` component by removing unused assets and logic for theme-based logo rendering.

### Improvements to watermark text:
* [`backend/chainlit/translations/en-US.json`](diffhunk://#diff-8589b2dc8a08fcfdc5201d4cb8914a3d60969d81956e489df9c91b181c103496L114-R114): Updated the watermark text to make it more concise, changing "LLMs can make mistakes. Consider checking important information." to "LLMs can make mistakes. Check important info."

### Simplification of `WaterMark` component:
* [`frontend/src/components/WaterMark.tsx`](diffhunk://#diff-986041e01dd400bdb966fc76d05cd61fa557fdc2c9663b140accb98288a7c5e3L3-L13): Removed imports for `logo_dark.svg` and `logo_light.svg` assets and the associated logic for rendering theme-based logos. Simplified the component by eliminating the `useTheme` hook and the conditional logo rendering logic. [[1]](diffhunk://#diff-986041e01dd400bdb966fc76d05cd61fa557fdc2c9663b140accb98288a7c5e3L3-L13) [[2]](diffhunk://#diff-986041e01dd400bdb966fc76d05cd61fa557fdc2c9663b140accb98288a7c5e3L26-L33)