### PR TITLE
Update close_stale.yml

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          operations-per-run: 100
+          operations-per-run: 400
           ascending: true
           days-before-issue-stale: 14
           days-before-issue-close: 7


### PR DESCRIPTION
I thought operations-per-run was how many items (issues, PRs) to review but each issue performs 4 operations so only a total of 25 issues are in scope each run. This PR makes it 400 so that the intended 100 items are reviewed.