### PR TITLE
fix: avoid /logo call if logo_file_url is set

### DIFF
--- a/frontend/src/components/Elements/CustomElement/index.tsx
+++ b/frontend/src/components/Elements/CustomElement/index.tsx
@@ -1,3 +1,4 @@
+import { MessageContext } from 'contexts/MessageContext';
 import {
   memo,
   useCallback,
@@ -19,8 +20,6 @@ import {
   useAuth,
   useChatInteract
 } from '@chainlit/react-client';
-
-import { MessageContext } from 'contexts/MessageContext';
 
 import Alert from '@/components/Alert';
 

--- a/frontend/src/components/WaterMark.tsx
+++ b/frontend/src/components/WaterMark.tsx
@@ -1,7 +1,5 @@
 import { Translator } from 'components/i18n';
 
-
-
 export default function WaterMark() {
   return (
     <div

--- a/frontend/src/components/chat/MessageComposer/Mcp/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/Mcp/index.tsx
@@ -35,7 +35,6 @@ const McpButton = ({ disabled }: Props) => {
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('add');
 
-
   const allowSse = !!config?.features.mcp?.sse?.enabled;
   const allowStdio = !!config?.features.mcp?.stdio?.enabled;
   const allowHttp = !!config?.features.mcp?.streamable_http?.enabled;

--- a/frontend/src/components/chat/Messages/Message/Avatar.tsx
+++ b/frontend/src/components/chat/Messages/Message/Avatar.tsx
@@ -33,7 +33,8 @@ const MessageAvatar = ({ author, hide, isError }: Props) => {
   }, [config, chatProfile]);
 
   const avatarUrl = useMemo(() => {
-    if (config?.ui?.default_avatar_file_url) return config?.ui?.default_avatar_file_url;
+    if (config?.ui?.default_avatar_file_url)
+      return config?.ui?.default_avatar_file_url;
     const isAssistant = !author || author === config?.ui.name;
     if (isAssistant && selectedChatProfile?.icon) {
       return selectedChatProfile.icon;

--- a/frontend/src/lib/message.ts
+++ b/frontend/src/lib/message.ts
@@ -2,7 +2,8 @@ import type { IMessageElement } from 'client-types/';
 
 const toSafeLinkTarget = (name: string) =>
   encodeURIComponent(name.replace(/\s+/g, '_'))
-    .replace(/\(/g, '%28').replace(/\)/g, '%29'); // Encode parentheses to avoid issues in URLs
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29'); // Encode parentheses to avoid issues in URLs
 
 const isForIdMatch = (id: string | number | undefined, forId: string) => {
   if (!forId || !id) {

--- a/libs/copilot/src/components/Header.tsx
+++ b/libs/copilot/src/components/Header.tsx
@@ -5,17 +5,29 @@ import { Logo } from '@chainlit/app/src/components/Logo';
 import ChatProfiles from '@chainlit/app/src/components/header/ChatProfiles';
 import NewChatButton from '@chainlit/app/src/components/header/NewChat';
 import { Button } from '@chainlit/app/src/components/ui/button';
-import { useAudio, useConfig } from '@chainlit/react-client';
+import { IChainlitConfig, useAudio } from '@chainlit/react-client';
 
 import { useCopilotInteract } from '../hooks';
+
+interface IProjectConfig {
+  config?: IChainlitConfig;
+  error?: Error;
+  isLoading: boolean;
+  language: string;
+}
 
 interface Props {
   expanded: boolean;
   setExpanded: (expanded: boolean) => void;
+  projectConfig: IProjectConfig;
 }
 
-const Header = ({ expanded, setExpanded }: Props): JSX.Element => {
-  const { config } = useConfig();
+const Header = ({
+  expanded,
+  setExpanded,
+  projectConfig
+}: Props): JSX.Element => {
+  const { config } = projectConfig;
   const { audioConnection } = useAudio();
   const { startNewChat } = useCopilotInteract();
 

--- a/libs/copilot/src/widget.tsx
+++ b/libs/copilot/src/widget.tsx
@@ -9,6 +9,7 @@ import {
   PopoverContent,
   PopoverTrigger
 } from '@chainlit/app/src/components/ui/popover';
+import { useConfig } from '@chainlit/react-client';
 
 import Header from './components/Header';
 
@@ -27,6 +28,7 @@ interface Props {
 const Widget = ({ config, error }: Props) => {
   const [expanded, setExpanded] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const projectConfig = useConfig();
 
   useEffect(() => {
     window.toggleChainlitCopilot = () => setIsOpen((prev) => !prev);
@@ -110,7 +112,11 @@ const Widget = ({ config, error }: Props) => {
             <Alert variant="error">{error}</Alert>
           ) : (
             <>
-              <Header expanded={expanded} setExpanded={setExpanded} />
+              <Header
+                expanded={expanded}
+                setExpanded={setExpanded}
+                projectConfig={projectConfig}
+              />
               <div className="flex flex-grow overflow-y-auto">
                 <ChatWrapper />
               </div>

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -143,9 +143,17 @@ const useChatSession = () => {
             if (mcp.clientType === 'sse') {
               promise = client.connectSseMCP(sessionId, mcp.name, mcp.url!);
             } else if (mcp.clientType === 'streamable-http') {
-              promise = client.connectStreamableHttpMCP(sessionId, mcp.name, mcp.url!);
+              promise = client.connectStreamableHttpMCP(
+                sessionId,
+                mcp.name,
+                mcp.url!
+              );
             } else {
-              promise = client.connectStdioMCP(sessionId, mcp.name, mcp.command!);
+              promise = client.connectStdioMCP(
+                sessionId,
+                mcp.name,
+                mcp.command!
+              );
             }
             promise
               .then(async ({ success, mcp }) => {


### PR DESCRIPTION
### What this PR does
- Prevents an unnecessary call to the `/logo` endpoint on first render by preloading project settings when Copilot initializes
- Applies Prettier formatting to maintain consistent code style.

### Why it’s needed
- On initial load, Copilot was making a redundant request to `/logo`, even when `logo_file_url` was already configured. This PR ensures that project settings are fetched early, so unnecessary network calls are avoided, [read more about the issue.](https://github.com/Chainlit/chainlit/issues/2339)

### How to test
- Configure `logo_file_url` (under UI section) in `config.toml` file
- Run the chainlit server locally, and [create a test site to use copilot mode.](https://docs.chainlit.io/deploy/copilot#embedding-the-copilot)
- Click the copilot icon to open the chat.
- Confirm that no request to `/logo` is made
- Check that the UI still displays the logo as expected.
