### PR TITLE
ci: bring back pnpm cache

### DIFF
--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -17,16 +17,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: pnpm/action-setup@v4
+      name: Install pnpm
+      with:
+        run_install: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-    - name: Enable corepack
-      run: corepack enable
-      shell: bash
-    - name: Install pnpm
-      run: corepack install
-      shell: bash
+        cache: 'pnpm'
+        cache-dependency-path: '**/pnpm-lock.yaml'
     - name: Install JS dependencies
       run: pnpm install ${{ inputs.pnpm-install-args }}
       shell: bash


### PR DESCRIPTION
This PR brings back `pnpm` caching after #2257 and extends it to include the `libs/` folder with the shared `react-client` and `copilot` libraries. CI should run a bit faster as a result.
