### PR TITLE
feat: enable gzip compression for frontend

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -25,6 +25,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from starlette.datastructures import URL
@@ -215,6 +216,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(GZipMiddleware)
 
 # config.run.root_path is only set when started with --root-path. Not on submounts.
 router = APIRouter(prefix=config.run.root_path)


### PR DESCRIPTION
This PR reduces the frontend bundle size from 3.7 MB to 1 MB and partially addresses #2340. A proper fix would involve improving tree shaking and chunk splitting in the frontend, but that would require additional configuration and possibly some refactoring.
