### PR TITLE
fix: properly escape html on paste

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -244,7 +244,10 @@ const Input = forwardRef<InputMethods, Props>(
 
         const textData = event.clipboardData?.getData('text/plain');
         if (textData) {
-          document.execCommand('insertText', false, textData);
+          const escapedText = document.createTextNode(textData).textContent;
+          if (escapedText) {
+            document.execCommand('insertText', false, escapedText);
+          }
           const inputEvent = new Event('input', {
             bubbles: true,
             composed: true


### PR DESCRIPTION
Fixes #2326, proper implementation of #2267 and #2246, related to #2264