### PR TITLE
test: restore temporarily skipped test

### DIFF
--- a/cypress/e2e/data_layer/spec.cy.ts
+++ b/cypress/e2e/data_layer/spec.cy.ts
@@ -158,7 +158,7 @@ describe('Data Layer', () => {
       verifyThreadResume();
     });
 
-    it.skip('Verifies thread continuation after server restart and new thread creation', () => {
+    it('Verifies thread continuation after server restart and new thread creation', () => {
       cy.task('restartChainlit', Cypress.spec).then(() => {
         cy.section('Before server restart');
 


### PR DESCRIPTION
Somewhere in #2327, my revert commit for the temporarily skipped test was missed. This PR restores that test.