### PR TITLE
refactor: remove unused font_family from configuration

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -315,7 +315,6 @@ class UISettings(DataClassJsonMixin):
     name: str
     description: str = ""
     cot: Literal["hidden", "tool_call", "full"] = "full"
-    font_family: Optional[str] = None
     default_theme: Optional[Literal["light", "dark"]] = "dark"
     layout: Optional[Literal["default", "wide"]] = "default"
     default_sidebar_state: Optional[Literal["open", "closed"]] = "open"

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -32,7 +32,6 @@ export interface IChainlitConfig {
   ui: {
     name: string;
     description?: string;
-    font_family?: string;
     default_theme?: 'light' | 'dark';
     layout?: 'default' | 'wide';
     default_sidebar_state?: 'open' | 'closed';


### PR DESCRIPTION
Instead of `font_family`, `custom_fonts` + separate `--font-*` css variables used in `public/theme.json` as described in [Chainlit](https://docs.chainlit.io/customisation/theme) and [Shadecdn](https://ui.shadcn.com/docs/theming#list-of-variables) documentation, but this setting wasn't removed

Tested with #2368 just in case, please merge it first