### PR TITLE
fix: preserve line breaks in received messages

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -124,7 +124,7 @@ const Markdown = ({
 
   return (
     <ReactMarkdown
-      className={cn('prose lg:prose-xl', className)}
+      className={cn('prose lg:prose-xl whitespace-pre-wrap', className)}
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}
       components={{


### PR DESCRIPTION
So after careful investigation on #2367 and #2264, I tested as many scenarios as I could and concluded the following:

* Line breaks in received messages (both user and AI) are not preserved properly, and this PR fixes that
* There will still be cases of "improper" or "unexpected" rendering - for example, multiple consecutive new lines like this:
  ```text
  print("Line 1")

  print("Line 3")
  
  
  print("Line 6")
  ```
  which will be rendered into this:
  
  ```text
  print("Line 1")

  print("Line 3")
  
  print("Line 6")
  ```
  or code like this:
  ```python
  import os
  
  import streamlit as st
  
  from app_env import configure_logger
  
  configure_logger(os.path.basename(__file__))
  
  # This file contains the menu for the app. It is used to navigate between pages and to show the documentation link.
  
  # The default page to show when logged in
  DEFAULT_PAGE = "pages/example.py"
  
  
  def authenticated_menu():
      # Show a navigation menu for authenticated users
      with st.sidebar:
          st.sidebar.page_link("pages/example.py", label="Example Link", icon="🚀")
  ```
  will be rendered into this:
  <img width="1051" height="1141" alt="image" src="https://github.com/user-attachments/assets/8608330a-82a9-4770-99bc-6c36001ccf06" />
  
This happens because **Chainlit treats both user and AI messages as Markdown**, and changing this behavior would not only be a breaking change, but also potentially undesirable, as LLMs will interpret such text as Markdown too and we can''t distinguish cases where it should be treated as such and where it shouldn't. Any future issues caused by rendering user messages as Markdown should be closed with the resolution `won't fix`, and this behavior should be preserved at least until (if) #2357 is implemented.

If users desire to preserve formatting, they may use the \``` block:
<pre>
```python
import os

import streamlit as st

from app_env import configure_logger

configure_logger(os.path.basename(__file__))

# This file contains the menu for the app. It is used to navigate between pages and to show the documentation link.

# The default page to show when logged in
DEFAULT_PAGE = "pages/example.py"


def authenticated_menu():
    # Show a navigation menu for authenticated users
    with st.sidebar:
        st.sidebar.page_link("pages/example.py", label="Example Link", icon="🚀")
```
</pre>
will be rendered as
<img width="533" height="639" alt="image" src="https://github.com/user-attachments/assets/3cfc8bdc-0411-42d7-b12f-743b8c999111" />

