### PR TITLE
Revert "fix: preserve line breaks in received messages (#2372)"

### DIFF
--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -124,7 +124,7 @@ const Markdown = ({
 
   return (
     <ReactMarkdown
-      className={cn('prose lg:prose-xl whitespace-pre-wrap', className)}
+      className={cn('prose lg:prose-xl', className)}
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}
       components={{


### PR DESCRIPTION
This reverts commit 63a0b202967a8d18626cc17d2ed2dbfe3413fb5c.

This PR reverts a part of solution for #2367 and closes #2375.

Ignoring of some line breaks and removal of leading whitespaces [are part of Markdown](https://github.com/orgs/remarkjs/discussions/1194).

User messages rendered as Markdown by both Chainlit and all popular LLM chats.

All future issues about that should be closed with resolution `won't fix`