### PR TITLE
Update widget.tsx

### DIFF
--- a/libs/copilot/src/widget.tsx
+++ b/libs/copilot/src/widget.tsx
@@ -39,6 +39,7 @@ const Widget = ({ config, error }: Props) => {
       window.toggleChainlitCopilot = () => console.error('Widget not mounted.');
       window.getChainlitCopilotThreadId = () => null;
 
+      window.clearChainlitCopilotThreadId?.();
       window.clearChainlitCopilotThreadId = () =>
         console.error('Widget not mounted.');
     };


### PR DESCRIPTION
Before Widget unmounted and clear the method of window.clearChainlitCopilotThredId, call the window.clearChainlitCopilotThreadId?.();

which can fix the bug : https://github.com/Chainlit/chainlit/issues/2384