### PR TITLE
feat(copilot): Improve name for root element id. And `opened` property.

### DIFF
--- a/cypress/e2e/copilot/spec.cy.ts
+++ b/cypress/e2e/copilot/spec.cy.ts
@@ -39,7 +39,9 @@ describe('Copilot', () => {
   });
 
   it('should be able to embed the copilot', () => {
+    cy.get('#chainlit-copilot-wrapper').should('not.exist');
     mountWidget();
+    cy.get('#chainlit-copilot-wrapper').should('exist');
     cy.window().then((win) => {
       win.addEventListener('chainlit-call-fn', (e) => {
         // @ts-expect-error is not a valid prop
@@ -57,7 +59,20 @@ describe('Copilot', () => {
 
     cy.step('Open copilot');
 
+    cy.get('#chainlit-copilot-button', opts).should(
+      'have.attr',
+      'aria-expanded',
+      'false'
+    );
+    cy.get('#chainlit-copilot', opts).should('not.exist');
+
     cy.get('#chainlit-copilot-button', opts).click();
+
+    cy.get('#chainlit-copilot-button', opts).should(
+      'have.attr',
+      'aria-expanded',
+      'true'
+    );
     cy.get('#chainlit-copilot', opts).should('exist');
 
     cy.get('.step', opts).should('have.length', 1);
@@ -186,5 +201,18 @@ describe('Copilot', () => {
         );
       });
     });
+  });
+
+  it('should be opened if config.opened is true', () => {
+    mountWidget({
+      opened: true
+    });
+
+    cy.get('#chainlit-copilot-button', opts).should(
+      'have.attr',
+      'aria-expanded',
+      'true'
+    );
+    cy.get('#chainlit-copilot', opts).should('exist');
   });
 });

--- a/libs/copilot/index.tsx
+++ b/libs/copilot/index.tsx
@@ -17,7 +17,7 @@ import {
 } from './src/state';
 import { IWidgetConfig } from './src/types';
 
-const id = 'chainlit-copilot';
+const id = 'chainlit-copilot-wrapper';
 let root: ReactDOM.Root | null = null;
 
 declare global {

--- a/libs/copilot/src/types.ts
+++ b/libs/copilot/src/types.ts
@@ -12,4 +12,5 @@ export interface IWidgetConfig {
   additionalQueryParamsForAPI?: Record<string, string>;
   expanded?: boolean;
   language?: string;
+  opened?: boolean;
 }

--- a/libs/copilot/src/widget.tsx
+++ b/libs/copilot/src/widget.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 const Widget = ({ config, error }: Props) => {
   const [expanded, setExpanded] = useState(config?.expanded || false);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(config?.opened || false);
   const projectConfig = useConfig();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR makes two main changes to the Copilot widget:

1. **Rename root element ID**  
   - The HTML `div` that gets created when mounting the widget previously used the ID `chainlit-copilot`.  
   - This ID was also used by an internal element **inside** the widget itself (see [`libs/copilot/src/widget.tsx#110`](https://github.com/Chainlit/chainlit/blob/main/libs/copilot/src/widget.tsx#L110)), leading to duplicate IDs in the DOM.  
   - To fix this, the root element ID has been renamed to `chainlit-copilot-wrapper`.  
   - ⚠️ **Breaking change**: If users reference this root element ID in their own code or styling, they will need to update it. I recommend a **major version bump** for this change.

2. **Add `opened` config option**  
   - A new optional `opened` property has been added to the widget config (`IWidgetConfig`).  
   - If `opened` is set to `true`, the Copilot widget will start in an open state immediately upon mounting.

## Testing
- Updated Cypress tests to validate the existence of `#chainlit-copilot-wrapper`.
- Added a test case to ensure that setting `config.opened = true` correctly opens the widget on mount.

## Impact
- **Breaking change**: Root element ID change (`chainlit-copilot` → `chainlit-copilot-wrapper`).
- New `opened` property improves flexibility for initial widget state.