### PR TITLE
fix: disable GZIP compression due to a safari issue

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -25,7 +25,6 @@ from fastapi import (
     UploadFile,
     status,
 )
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from starlette.datastructures import URL
@@ -216,8 +215,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-app.add_middleware(GZipMiddleware)
 
 # config.run.root_path is only set when started with --root-path. Not on submounts.
 router = APIRouter(prefix=config.run.root_path)


### PR DESCRIPTION
This reverts commit 239a17a0df2802fb4a93f8bbbcb8660c69097c44.

Adding GZIP compression plays badly with websockets. This PR removes it to enable Safari again (including all Safari-based browsers such as all browsers on iPhones).

Citing from release of version 1.0.506

> - disable gzip middleware to prevent a compression issue on safari