### PR TITLE
feat(auth): update require_login to check for CHAINLIT_AUTH_SECRET environment variable instead of CHAINLIT_CUSTOM_AUTH

### DIFF
--- a/backend/chainlit/auth/__init__.py
+++ b/backend/chainlit/auth/__init__.py
@@ -30,12 +30,7 @@ def is_oauth_enabled():
 
 
 def require_login():
-    return (
-        bool(os.environ.get("CHAINLIT_AUTH_SECRET"))
-        or config.code.password_auth_callback is not None
-        or config.code.header_auth_callback is not None
-        or is_oauth_enabled()
-    )
+    return bool(os.environ.get("CHAINLIT_AUTH_SECRET"))
 
 
 def get_configuration():

--- a/backend/chainlit/auth/__init__.py
+++ b/backend/chainlit/auth/__init__.py
@@ -31,7 +31,7 @@ def is_oauth_enabled():
 
 def require_login():
     return (
-        bool(os.environ.get("CHAINLIT_CUSTOM_AUTH"))
+        bool(os.environ.get("CHAINLIT_AUTH_SECRET"))
         or config.code.password_auth_callback is not None
         or config.code.header_auth_callback is not None
         or is_oauth_enabled()

--- a/backend/chainlit/cli/__init__.py
+++ b/backend/chainlit/cli/__init__.py
@@ -196,8 +196,6 @@ def chainlit_run(
         no_cache = True
         # This is required to have OpenAI LLM providers available for the CI run
         os.environ["OPENAI_API_KEY"] = "sk-FAKE-OPENAI-API-KEY"
-        # This is required for authentication tests
-        os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
     config.run.headless = headless
     config.run.debug = debug

--- a/cypress/e2e/chat_profiles/main.py
+++ b/cypress/e2e/chat_profiles/main.py
@@ -1,6 +1,9 @@
+import os
 from typing import Optional
 
 import chainlit as cl
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 starters = [
     cl.Starter(

--- a/cypress/e2e/config_overrides/main.py
+++ b/cypress/e2e/config_overrides/main.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import chainlit as cl
@@ -7,6 +8,8 @@ from chainlit.config import (
     McpFeature,
     UISettings,
 )
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 starters = [
     cl.Starter(

--- a/cypress/e2e/custom_data_layer/sql_alchemy.py
+++ b/cypress/e2e/custom_data_layer/sql_alchemy.py
@@ -1,8 +1,11 @@
+import os
 from typing import Optional
 
 import chainlit as cl
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
 from chainlit.data.storage_clients.azure import AzureStorageClient
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 storage_client = AzureStorageClient(
     account_url="<your_account_url>", container="<your_container>"

--- a/cypress/e2e/data_layer/main.py
+++ b/cypress/e2e/data_layer/main.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 import pickle
 from typing import Dict, List, Optional
@@ -17,6 +18,8 @@ from chainlit.types import (
     ThreadFilter,
 )
 from chainlit.utils import utc_now
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 now = utc_now()
 

--- a/cypress/e2e/header_auth/main.py
+++ b/cypress/e2e/header_auth/main.py
@@ -1,6 +1,9 @@
+import os
 from typing import Optional
 
 import chainlit as cl
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 
 @cl.header_auth_callback

--- a/cypress/e2e/password_auth/main.py
+++ b/cypress/e2e/password_auth/main.py
@@ -1,6 +1,9 @@
+import os
 from typing import Optional
 
 import chainlit as cl
+
+os.environ["CHAINLIT_AUTH_SECRET"] = "SUPER_SECRET"  # nosec B105
 
 
 @cl.password_auth_callback


### PR DESCRIPTION
## Summary
Currently, enabling authentication in Copilot requires setting **two** environment variables:  
- `CHAINLIT_AUTH_SECRET`  
- `CHAINLIT_CUSTOM_AUTH=true` (undocumented)  

See: [chainlit/chainlit#2190](https://github.com/Chainlit/chainlit/issues/2190)

## Problem
Requiring `CHAINLIT_CUSTOM_AUTH` is unnecessary and not documented, which can lead to confusion for users.

## Proposed Change
Remove the `CHAINLIT_CUSTOM_AUTH` check and rely solely on the presence of `CHAINLIT_AUTH_SECRET` to enable authentication.