### PR TITLE
fix: data persistence bug introduced in #2433

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -27,6 +27,7 @@ from chainlit.types import (
 from chainlit.user import PersistedUser, User
 
 if TYPE_CHECKING:
+    from chainlit.data.storage_clients.gcs import GCSStorageClient
     from chainlit.element import Element, ElementDict
     from chainlit.step import StepDict
 
@@ -199,17 +200,9 @@ class ChainlitDataLayer(BaseDataLayer):
             path = f"files/{element.id}"
 
         if content is not None:
-            # Import GCSStorageClient only when needed to avoid requiring optional dependencies
-            try:
-                from chainlit.data.storage_clients.gcs import GCSStorageClient
-            except ImportError:
-                GCSStorageClient = None
             content_disposition = (
                 f'attachment; filename="{element.name}"'
-                if not (
-                    GCSStorageClient
-                    and isinstance(self.storage_client, GCSStorageClient)
-                )
+                if not isinstance(self.storage_client, GCSStorageClient)
                 else None
             )
             await self.storage_client.upload_file(

--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -206,7 +206,10 @@ class ChainlitDataLayer(BaseDataLayer):
                 GCSStorageClient = None
             content_disposition = (
                 f'attachment; filename="{element.name}"'
-                if not (GCSStorageClient and isinstance(self.storage_client, GCSStorageClient))
+                if not (
+                    GCSStorageClient
+                    and isinstance(self.storage_client, GCSStorageClient)
+                )
                 else None
             )
             await self.storage_client.upload_file(

--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -26,8 +26,13 @@ from chainlit.types import (
 )
 from chainlit.user import PersistedUser, User
 
-if TYPE_CHECKING:
+# Import for runtime usage (isinstance checks)
+try:
     from chainlit.data.storage_clients.gcs import GCSStorageClient
+except ImportError:
+    GCSStorageClient = None  # type: ignore[assignment,misc]
+
+if TYPE_CHECKING:
     from chainlit.element import Element, ElementDict
     from chainlit.step import StepDict
 
@@ -202,7 +207,10 @@ class ChainlitDataLayer(BaseDataLayer):
         if content is not None:
             content_disposition = (
                 f'attachment; filename="{element.name}"'
-                if not isinstance(self.storage_client, GCSStorageClient)
+                if not (
+                    GCSStorageClient is not None
+                    and isinstance(self.storage_client, GCSStorageClient)
+                )
                 else None
             )
             await self.storage_client.upload_file(


### PR DESCRIPTION
The Type Checking fix from #2433 introduced a new issue that causes an error while persisting to the database.
This PR should fix that while passing mypy checks. 

    if not isinstance(self.storage_client, GCSStorageClient)
                                           ^^^^^^^^^^^^^^^^
NameError: name 'GCSStorageClient' is not defined. Did you mean: 'BaseStorageClient'?