### PR TITLE
fix: missing / in url with base path when connecting Streamable HTTP MCP

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -30,7 +30,7 @@ class ExtendedChainlitAPI extends ChainlitAPI {
     headers?: Record<string, string>
   ) {
     // Assumes the backend expects { clientType, name, url }
-    return fetch(`${this.httpEndpoint}/mcp`, {
+    return fetch(new URL("mcp", this.httpEndpoint.endsWith("/") ? this.httpEndpoint : `${this.httpEndpoint}/`), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
In example, with `CHAINLIT_ROOT_PATH=/mypath`