### PR TITLE
Fix (chainlit_data_layer) timezone exceptions in data layer on re-running messages on retrieved chats

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -3,7 +3,7 @@ import atexit
 import json
 import signal
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import aiofiles
@@ -40,6 +40,35 @@ if TYPE_CHECKING:
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
+def _parse_flexible_iso(ts: str) -> datetime:
+    """Parse ISO timestamps with or without trailing 'Z' or '+00:00'.
+
+    Accepts values like:
+    - '2025-09-03T17:16:15.147000Z'
+    - '2025-09-03T17:16:15.147000+00:00'
+    - '2025-09-03T17:16:15.147000'
+    Falls back to the legacy strict format if needed.
+    Defaults to UTC when timezone is missing.
+    """
+    try:
+        iso_in = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(iso_in)
+        # Normalize to naive UTC to match DB TIMESTAMP columns
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+    except Exception:
+        # Fallback to legacy strict parsing; ensure naive UTC
+        try:
+            dt = datetime.strptime(ts, ISO_FORMAT)
+        except Exception:
+            # Last resort: use current naive UTC time (datetime, not string)
+            dt = datetime.utcnow().replace(tzinfo=None)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+
+
 class ChainlitDataLayer(BaseDataLayer):
     def __init__(
         self,
@@ -62,7 +91,8 @@ class ChainlitDataLayer(BaseDataLayer):
             self.pool = await asyncpg.create_pool(self.database_url)
 
     async def get_current_timestamp(self) -> datetime:
-        return datetime.now()
+        # Return a naive UTC datetime object (not string)
+        return datetime.utcnow().replace(tzinfo=None)
 
     async def execute_query(
         self, query: str, params: Union[Dict, None] = None
@@ -374,7 +404,11 @@ class ChainlitDataLayer(BaseDataLayer):
         timestamp = await self.get_current_timestamp()
         created_at = step_dict.get("createdAt")
         if created_at:
-            timestamp = datetime.strptime(created_at, ISO_FORMAT)
+            try:
+                timestamp = _parse_flexible_iso(created_at)
+            except Exception:
+                # Keep current timestamp on parse failure
+                pass
 
         params = {
             "id": step_dict["id"],
@@ -583,7 +617,8 @@ class ChainlitDataLayer(BaseDataLayer):
             "userId": user_id,
             "tags": tags,
             "metadata": json.dumps(metadata or {}),
-            "updatedAt": datetime.now(),
+            # Store as naive UTC datetime to match DB TIMESTAMP
+            "updatedAt": datetime.utcnow().replace(tzinfo=None),
         }
 
         # Remove None values


### PR DESCRIPTION
While streaming reasoning chain of thoughts with step.stream_token(), i observed exceptions from chainlit_data_layer regarding timestamp format.  I do think this was caused by my app, and the on_message() processor is I believe fairly typical. Although I did not do the full clear-case minimization of the app.

Steps to reproduce the original issue:

1) Have an app that supports persistence and implements on_chat_resume()

2) Start a new thread, submit a message, get AI response

3) Navigate away 

4) Re-open and resume the thread

5) Edit an earlier user message and resubmit.

Observed exception:

```
future: <Task finished name='Task-757' coro=<ChainlitDataLayer.update_step() done, defined at /root/.local/lib/python3.13/site-packages/chainlit/data/utils.py:10> exception=ValueError("time data '2025-09-03T19:32:50.586000' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'")>
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/asyncio/tasks.py", line 304, in __step_run_and_handle_result
    result = coro.send(None)
  File "/root/.local/lib/python3.13/site-packages/chainlit/data/utils.py", line 25, in wrapper
    return await method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.13/site-packages/chainlit/data/chainlit_data_layer.py", line 397, in update_step
    await self.create_step(step_dict)
  File "/root/.local/lib/python3.13/site-packages/chainlit/data/utils.py", line 25, in wrapper
    return await method(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.13/site-packages/chainlit/data/chainlit_data_layer.py", line 377, in create_step
    timestamp = datetime.strptime(created_at, ISO_FORMAT)
  File "/usr/local/lib/python3.13/_strptime.py", line 789, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/_strptime.py", line 555, in _strptime
    raise ValueError("time data %r does not match format %r" %
                     (data_string, format))
ValueError: time data '2025-09-03T19:32:50.586000' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```
  
 The proposed fix makes timestamps handling in chainlit_data_layer more robust.
  
