### PR TITLE
refactor: Reorder Message Composer Elements

### DIFF
--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -177,16 +177,12 @@ export default function MessageComposer({
       />
       <div className="flex items-center justify-between">
         <div className="flex items-center -ml-1.5">
+          <VoiceButton disabled={disabled} />
           <UploadButton
             disabled={disabled}
             fileSpec={fileSpec}
             onFileUploadError={onFileUploadError}
             onFileUpload={onFileUpload}
-          />
-          <CommandButton
-            disabled={disabled}
-            selectedCommandId={selectedCommand?.id}
-            onCommandSelect={setSelectedCommand}
           />
           {chatSettingsInputs.length > 0 && (
             <Button
@@ -201,7 +197,11 @@ export default function MessageComposer({
             </Button>
           )}
           <McpButton disabled={disabled} />
-          <VoiceButton disabled={disabled} />
+          <CommandButton
+            disabled={disabled}
+            selectedCommandId={selectedCommand?.id}
+            onCommandSelect={setSelectedCommand}
+          />
           <CommandButtons
             disabled={disabled}
             selectedCommandId={selectedCommand?.id}


### PR DESCRIPTION
Moved Audio to the far-left and Commands to the far-right

**Before**
<img width="246" height="113" alt="image" src="https://github.com/user-attachments/assets/7eeddc04-b623-43db-a1d7-37cad82999a0" />

**After**
<img width="248" height="104" alt="image" src="https://github.com/user-attachments/assets/be541a21-93b0-4f75-94fb-d547659d3753" />
