### PR TITLE
fix: take overridden config into account in audio handlers

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -12,7 +12,7 @@ from chainlit.auth import (
     require_login,
 )
 from chainlit.chat_context import chat_context
-from chainlit.config import config, ChainlitConfig
+from chainlit.config import ChainlitConfig, config
 from chainlit.context import init_ws_context
 from chainlit.data import get_data_layer
 from chainlit.logger import logger
@@ -367,7 +367,7 @@ async def audio_end(sid):
             asyncio.create_task(context.emitter.init_thread("audio"))
 
         config: ChainlitConfig = session.get_config()
-        
+
         if config.features.audio.enabled:
             await config.code.on_audio_end()
 

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -12,7 +12,7 @@ from chainlit.auth import (
     require_login,
 )
 from chainlit.chat_context import chat_context
-from chainlit.config import config
+from chainlit.config import config, ChainlitConfig
 from chainlit.context import init_ws_context
 from chainlit.data import get_data_layer
 from chainlit.logger import logger
@@ -333,6 +333,8 @@ async def audio_start(sid):
     session = WebsocketSession.require(sid)
 
     context = init_ws_context(session)
+    config: ChainlitConfig = session.get_config()
+
     if config.features.audio.enabled:
         connected = bool(await config.code.on_audio_start())
         connection_state = "on" if connected else "off"
@@ -345,6 +347,8 @@ async def audio_chunk(sid, payload: InputAudioChunkPayload):
     session = WebsocketSession.require(sid)
 
     init_ws_context(session)
+
+    config: ChainlitConfig = session.get_config()
 
     if config.features.audio.enabled:
         asyncio.create_task(config.code.on_audio_chunk(InputAudioChunk(**payload)))
@@ -362,6 +366,8 @@ async def audio_end(sid):
             session.has_first_interaction = True
             asyncio.create_task(context.emitter.init_thread("audio"))
 
+        config: ChainlitConfig = session.get_config()
+        
         if config.features.audio.enabled:
             await config.code.on_audio_end()
 

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -330,8 +330,7 @@ async def window_message(sid, data):
 @sio.on("audio_start")  # pyright: ignore [reportOptionalCall]
 async def audio_start(sid):
     """Handle audio init."""
-    WebsocketSession.require(sid)
-    session = WebsocketSession.get_by_id(sid)
+    session = WebsocketSession.require(sid)
 
     context = init_ws_context(session)
     config: ChainlitConfig = session.get_config()
@@ -345,8 +344,7 @@ async def audio_start(sid):
 @sio.on("audio_chunk")
 async def audio_chunk(sid, payload: InputAudioChunkPayload):
     """Handle an audio chunk sent by the user."""
-    WebsocketSession.require(sid)
-    session = WebsocketSession.get_by_id(sid)
+    session = WebsocketSession.require(sid)
 
     init_ws_context(session)
 
@@ -363,8 +361,7 @@ async def audio_chunk(sid, payload: InputAudioChunkPayload):
 @sio.on("audio_end")
 async def audio_end(sid):
     """Handle the end of the audio stream."""
-    WebsocketSession.require(sid)
-    session = WebsocketSession.get_by_id(sid)
+    session = WebsocketSession.require(sid)
 
     try:
         context = init_ws_context(session)


### PR DESCRIPTION
The audio handlers were using the global config instead of the overrides from the chat_profile