### PR TITLE
Restore copy button for all messages except user and ask messagesfix: restore copy button for all messages except user and ask messages

### DIFF
--- a/frontend/src/components/chat/Messages/Message/Buttons/index.tsx
+++ b/frontend/src/components/chat/Messages/Message/Buttons/index.tsx
@@ -25,7 +25,8 @@ const MessageButtons = ({ message, actions, run, contentRef }: Props) => {
   const isUser = message.type === 'user_message';
   const isAsk = message.waitForAnswer;
   const hasContent = !!message.output;
-  const showCopyButton = !!run && hasContent && !isUser && !isAsk;
+  // Show copy button for every message with content, except user messages and ask messages
+  const showCopyButton = hasContent && !isUser && !isAsk;
 
   const messageActions = actions.filter((a) => a.forId === message.id);
 


### PR DESCRIPTION
This PR updates the message button logic to restore the copy button for every message with content, except for user messages and ask messages.
Previously, only the last message had a copy button, which limited usability.
This change brings back the behavior from versions before 2.5.5, allowing users to copy any message with content.

Updated [MessageButtons](https://fantastic-space-capybara-499wjj99v7wh5g57.github.dev/) logic in [index.tsx](https://fantastic-space-capybara-499wjj99v7wh5g57.github.dev/)
Now, all non-user and non-ask messages with content display the copy button
This improves user experience and restores expected functionality.