### PR TITLE
refactor: allow Thread Sharing by user-defined callback

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1001,8 +1001,8 @@ async def get_shared_thread(
 
     is_shared = bool(metadata.get("is_shared"))
 
-    # Proceed only if both conditions are True.
-    if not (user_can_view and is_shared):
+    # Proceed only raise an error if both conditions are False.
+    if (not user_can_view) and (not is_shared):
         raise HTTPException(status_code=404, detail="Thread not found")
 
     metadata.pop("chat_profile", None)


### PR DESCRIPTION
I want to allow admins to view any threads.  I determine if a user is an admin using custom RBAC roles and saving in the user.metadata. Presumably other developers will have other ways of doing this.

This change makes it so that as long as the `@cl.on_shared_thread_view` returns True then the thread can be viewed, instead of requiring the user to share the thread. Developers can customize the logic within this callback however they see fit.