### PR TITLE
Add support for custom_meta_url

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -191,6 +191,8 @@ alert_style = "classic"
 # login_page_image_filter = "brightness-50 grayscale"
 # login_page_image_dark_filter = "contrast-200 blur-sm"
 
+# Specify a custom meta URL (used for meta tags like og:url)
+# custom_meta_url = "https://github.com/Chainlit/chainlit"
 
 # Specify a custom meta image url.
 # custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
@@ -335,6 +337,8 @@ class UISettings(BaseModel):
     login_page_image_filter: Optional[str] = None
     login_page_image_dark_filter: Optional[str] = None
 
+    # Optional custom meta tag for URL preview
+    custom_meta_url: Optional[str] = None
     # Optional custom meta tag for image preview
     custom_meta_image_url: Optional[str] = None
     # Optional logo file url

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -374,7 +374,7 @@ def get_html_template(root_path):
     JS_PLACEHOLDER = "<!-- JS INJECTION PLACEHOLDER -->"
     CSS_PLACEHOLDER = "<!-- CSS INJECTION PLACEHOLDER -->"
 
-    default_url = "https://github.com/Chainlit/chainlit"
+    default_url = config.ui.custom_meta_url or "https://github.com/Chainlit/chainlit"
     default_meta_image_url = (
         "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
     )


### PR DESCRIPTION
This PR introduces a new optional field `custom_meta_url` in `UISettings` and the default config.

* Adds `custom_meta_url` to `config.py` and default TOML.
* Updates `server.py` `get_html_template` to use: `default_url = config.ui.custom_meta_url or "https://github.com/Chainlit/chainlit"`

Currently the Chainlit GitHub link is hard-coded into meta tags. This means it always shows up in link previews (e.g. iMessage/Twitter). This patch makes it configurable, in line with other UI metadata (title, description, image).