### PR TITLE
refactor: remove redundant message sending in process_slack_message

### DIFF
--- a/backend/chainlit/slack/app.py
+++ b/backend/chainlit/slack/app.py
@@ -318,8 +318,6 @@ async def process_slack_message(
         author=user.metadata.get("real_name"),
     )
 
-    await msg.send()
-
     if on_message := config.code.on_message:
         await on_message(msg)
 


### PR DESCRIPTION
When a picture is sent on Slack, the application responds with the same picture before processing the message.  I'm not sure why this line was added to the code, but it appears to offer no benefit.