### PR TITLE
fix: on_chat_start not always firing

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -174,7 +174,11 @@ async def connection_successful(sid):
     await context.emitter.clear("clear_call_fn")
 
     if context.session.restored:
-        return
+        if config.code.on_chat_start and not context.session.has_first_interaction:
+            task = asyncio.create_task(config.code.on_chat_start())
+            context.session.current_task = task
+        else:
+            return
 
     if context.session.thread_id_to_resume and config.code.on_chat_resume:
         thread = await resume_thread(context.session)


### PR DESCRIPTION
fixes #2535

This bug only happens **some of the time** and causes chat_settings sent from on_chat_start and LLM configuration to not fire. Clicking 'New Chat' is the only sure-fire way to trigger on_chat_start.

After lots of debugging trying to reproduce this bug I noticed that `context.session.restored` conditional was hit which skips on_chat_start. I was able to fix this issue by adding an additional conditional `context.session.has_first_interaction` which can only be True when the user has actually interacted.

Like mentioned it's difficult to reliably reproduce this bug, and the root cause is still alluding me, but for the meantime this doesn't appear to fix the issue.