### PR TITLE
fix: confirm when enter

### DIFF
--- a/frontend/src/components/header/NewChat.tsx
+++ b/frontend/src/components/header/NewChat.tsx
@@ -32,9 +32,20 @@ export const NewChatDialog = ({
   handleClose,
   handleConfirm
 }: NewChatDialogProps) => {
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    event.preventDefault();
+    if (event.key === 'Enter') {
+      handleConfirm();
+    }
+  };
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent id="new-chat-dialog" className="sm:max-w-md">
+      <DialogContent
+        id="new-chat-dialog"
+        className="sm:max-w-md"
+        onKeyDown={handleKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>
             <Translator path="navigation.newChat.dialog.title" />


### PR DESCRIPTION
before #2525  
After 

https://github.com/user-attachments/assets/2c4d22d1-326d-4ba4-87bc-22ee6fa2c507

mapped the enter key to confirm a new chat 

