### PR TITLE
fix(copilot): Voice hotkey (P) incorrectly triggers when typing in chat input within Shadow DOM

### DIFF
--- a/frontend/src/components/chat/MessageComposer/VoiceButton.tsx
+++ b/frontend/src/components/chat/MessageComposer/VoiceButton.tsx
@@ -29,8 +29,38 @@ const VoiceButton = ({ disabled }: Props) => {
     'p',
     () => {
       if (!isEnabled) return;
+
+      // Double-check at execution time that we're not in a form field
+      const getDeepActiveElement = (): Element | null => {
+        let activeElement = document.activeElement;
+        while (
+          activeElement &&
+          activeElement.shadowRoot &&
+          activeElement.shadowRoot.activeElement
+        ) {
+          activeElement = activeElement.shadowRoot.activeElement;
+        }
+        return activeElement;
+      };
+
+      const activeElement = getDeepActiveElement();
+      if (activeElement) {
+        const tagName = activeElement.tagName.toLowerCase();
+        const isFormField = ['input', 'textarea', 'select'].includes(tagName);
+        const isContentEditable =
+          activeElement.getAttribute('contenteditable') === 'true';
+
+        if (isFormField || isContentEditable) {
+          return; // Don't execute the hotkey
+        }
+      }
+
       if (audioConnection === 'on') return endConversation();
       return startConversation();
+    },
+    {
+      enableOnFormTags: false,
+      preventDefault: false // Don't prevent default - let letters be typed
     },
     [isEnabled, audioConnection, startConversation, endConversation]
   );


### PR DESCRIPTION
## Bug Fix

### Problem
The voice activation hotkey ('P') was incorrectly triggering when typing in the chat input field within the copilot widget, while working correctly in the main frontend application.

### Root Cause
The copilot widget renders components inside a Shadow DOM for isolation from the host page. The `react-hotkeys-hook` library's default focus detection mechanism (`document.activeElement`) doesn't work correctly across Shadow DOM boundaries, causing it to miss when form fields inside the Shadow DOM are focused.

### Solution
Implemented Shadow DOM-aware focus detection in the `VoiceButton` component:

- **Deep Active Element Detection**: Added a recursive function `getDeepActiveElement()` that traverses through Shadow DOM boundaries to find the actually focused element
- **Runtime Focus Check**: Added a check within the hotkey callback to verify the focused element type before executing the voice action
- **Preserved Default Behavior**: Set `preventDefault: false` to allow normal letter typing in form fields
- **Consistent Behavior**: Ensured both main frontend and copilot widget have identical hotkey behavior

### Changes
- Modified `frontend/src/components/chat/MessageComposer/VoiceButton.tsx` to handle Shadow DOM context
- Added Shadow DOM-aware active element detection
- Maintained backward compatibility with regular DOM usage

### Testing
- ✅ Main frontend: Hotkey works outside input, disabled when typing in input
- ✅ Copilot widget: Hotkey works outside input, disabled when typing in input  
- ✅ Normal typing functionality preserved in both contexts
- ✅ Voice activation works correctly in both contexts

### Technical Details
The fix uses a recursive approach to drill down through `shadowRoot.activeElement` until finding the deepest focused element, then checks if it's a form field (`input`, `textarea`, `select`) or has `contenteditable="true"` before allowing hotkey execution.

This approach maintains the shared component architecture while ensuring consistent behavior across both regular DOM and Shadow DOM contexts.

---

**Related**: This issue affects any hotkey functionality within copilot widgets due to Shadow DOM isolation.