### PR TITLE
ci: libs publishing workflow

### DIFF
--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -13,10 +13,12 @@ runs:
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        run_install: true
+        run_install: false
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
+    - name: Install JS dependencies
+      run: pnpm install

--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -6,10 +6,6 @@ inputs:
     description: Node.js version
     required: true
     default: '24.3.0' # Switch to 'lts' as soon as Node 24 reaches LTS status.
-  pnpm-skip-install:
-    description: Skip install.
-    required: false
-    default: 'false'
 
 runs:
   using: composite
@@ -17,15 +13,10 @@ runs:
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        run_install: false
+        run_install: true
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
-    - name: Install JS dependencies
-      run: pnpm install
-      shell: bash
-      # Skip install if pnpm-skip-install is true
-      if: ${{ inputs.pnpm-skip-install != 'true' }}

--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -22,3 +22,4 @@ runs:
         cache-dependency-path: '**/pnpm-lock.yaml'
     - name: Install JS dependencies
       run: pnpm install
+      shell: bash

--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -10,9 +10,6 @@ inputs:
     description: Skip install.
     required: false
     default: 'false'
-  pnpm-install-args:
-    description: Extra arguments for pnpm install, e.g. --no-frozen-lockfile.
-    default: '--frozen-lockfile'
 
 runs:
   using: composite
@@ -28,7 +25,7 @@ runs:
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
     - name: Install JS dependencies
-      run: pnpm install ${{ inputs.pnpm-install-args }}
+      run: pnpm install
       shell: bash
       # Skip install if pnpm-skip-install is true
       if: ${{ inputs.pnpm-skip-install != 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,14 @@ on:
   merge_group:
   pull_request:
     branches: [main, dev, 'release/**']
+    paths-ignore:
+      - '*.md'
+      - LICENSE
   push:
     branches: [main, dev, 'release/**']
+    paths-ignore:
+      - '*.md'
+      - LICENSE
 
 permissions: read-all
 

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -32,9 +32,6 @@ jobs:
 
       - name: Install Node.js, pnpm and dependencies
         uses: ./.github/actions/pnpm-node-install
-        with:
-          node-version: "24.3.0"
-          pnpm-install-args: "--frozen-lockfile"
 
       - name: Install Python, uv and dependencies
         uses: ./.github/actions/uv-python-install

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-node-install
         name: Install Node, pnpm and dependencies.
-        with:
-          pnpm-install-args: "--frozen-lockfile"
       - name: Install Cypress
         uses: cypress-io/github-action@v6
         with:

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -8,8 +8,6 @@ on:
         required: false
         default: false
         type: boolean
-  push:
-    branches: ["feat/publish-libs-workflow"]
   release:
     types: [published]
 
@@ -30,14 +28,14 @@ jobs:
             fi
           fi
           echo "✅ Validation passed"
-#   ci:
-#     needs: [validate]
-#     uses: ./.github/workflows/ci.yaml
-#     secrets: inherit
+  ci:
+    needs: [validate]
+    uses: ./.github/workflows/ci.yaml
+    secrets: inherit
   build-n-publish:
     name: Upload libs release to npm registry
     runs-on: ubuntu-latest
-    #needs: [ci]
+    needs: [ci]
     permissions:
       contents: read
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
@@ -50,4 +48,4 @@ jobs:
         run: pnpm build:libs
 
       - name: Publish packages to npm
-        run: pnpm publish --recursive ${{ inputs.dry_run && '--dry-run --no-git-checks' || '--dry-run --no-git-checks' }}
+        run: pnpm publish --recursive ${{ inputs.dry_run && '--dry-run --no-git-checks' || '' }} # --no-git-checks allows testing from non-main branches

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -50,9 +50,4 @@ jobs:
         run: pnpm build:libs
 
       - name: Publish packages to npm
-        run: |
-          for lib in libs/*/; do
-            cd "$lib"
-            pnpm publish ${{ inputs.dry_run && '--dry-run' || '--dry-run' }}
-            cd -
-          done
+        run: pnpm publish --recursive ${{ inputs.dry_run && '--dry-run --no-git-checks' || '--dry-run --no-git-checks' }}

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -6,8 +6,10 @@ on:
       dry_run:
         description: 'Dry run (test publishing)'
         required: false
-        default: false
+        default: true
         type: boolean
+  push:
+    branches: ["feat/publish-libs-workflow"]
   release:
     types: [published]
 

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry run (test publishing)'
         required: false
-        default: true
+        default: false
         type: boolean
   push:
     branches: ["feat/publish-libs-workflow"]
@@ -54,6 +54,6 @@ jobs:
         run: |
           for lib in libs/*/; do
             cd "$lib"
-            pnpm publish ${{ inputs.dry_run && '--dry-run' || '' }}
+            pnpm publish ${{ inputs.dry_run && '--dry-run' || '--dry-run' }}
             cd -
           done

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -37,7 +37,6 @@ jobs:
   build-n-publish:
     name: Upload libs release to npm registry
     runs-on: ubuntu-latest
-    needs: [validate]
     #needs: [ci]
     permissions:
       contents: read

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -1,0 +1,57 @@
+name: Publish libs
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (test publishing)'
+        required: false
+        default: false
+        type: boolean
+  release:
+    types: [published]
+
+permissions: read-all
+
+jobs:
+  validate:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate publishing branch and destination package index
+        run: |
+          if [[ "${{ github.ref_name }}" != "main" && "${{ github.event_name }}" != "release" ]]; then
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              echo "❌ Error: Only build from main branch or release tag can be published to npm registry."
+              echo "Please check 'Dry run (test publishing)' when running from branch: ${{ github.ref_name }}"
+              exit 1
+            fi
+          fi
+          echo "✅ Validation passed"
+#   ci:
+#     needs: [validate]
+#     uses: ./.github/workflows/ci.yaml
+#     secrets: inherit
+  build-n-publish:
+    name: Upload libs release to npm registry
+    runs-on: ubuntu-latest
+    needs: [validate]
+    #needs: [ci]
+    permissions:
+      contents: read
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pnpm-node-install
+        name: Install Node, pnpm and dependencies.
+
+      - name: Build libs
+        run: pnpm build:libs
+
+      - name: Publish packages to npm
+        run: |
+          for lib in libs/*/; do
+            cd "$lib"
+            pnpm publish ${{ inputs.dry_run && '--dry-run' || '' }}
+            cd -
+          done

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,8 +47,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-node-install
         name: Install Node, pnpm and dependencies.
-        with:
-          pnpm-install-args: --no-frozen-lockfile
       - uses: ./.github/actions/uv-python-install
         name: Install Python, uv and Python dependencies
         with:

--- a/RELENG.md
+++ b/RELENG.md
@@ -17,6 +17,7 @@ This document outlines the steps for maintainers to create a new release of the 
 2. **Bump the package version**:
 
    - Update `version` in `backend/chainlit/version.py`.
+   - Update  `version` in `libs/*/package.json` if there were any changes in the corresponding directories.
 
 3. **Update the changelog**:
 

--- a/libs/react-client/package.json
+++ b/libs/react-client/package.json
@@ -7,8 +7,7 @@
     "dev": "tsup src/index.ts --clean --format esm,cjs --dts  --external react --external recoil --minify --sourcemap --treeshake",
     "lint": "eslint ./src --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && tsc --noemit",
     "format": "prettier '**/*.{ts,tsx}' --write",
-    "test": "echo no tests yet",
-    "prepublishOnly": "pnpm run build"
+    "test": "echo no tests yet"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "formatUi": "pnpm run --parallel format",
     "lintPython": "cd backend && uv run dmypy run -- chainlit/ tests/",
     "formatPython": "black `git ls-files | grep '.py$'` && isort --profile=black .",
-    "buildUi": "cd libs/react-client && pnpm run build && cd ../copilot && pnpm run build && cd ../../frontend && pnpm run build"
+    "build:libs": "cd libs/react-client && pnpm run build && cd ../copilot && pnpm run build",
+    "buildUi": "pnpm build:libs && cd ../../frontend && pnpm run build"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lintPython": "cd backend && uv run dmypy run -- chainlit/ tests/",
     "formatPython": "black `git ls-files | grep '.py$'` && isort --profile=black .",
     "build:libs": "cd libs/react-client && pnpm run build && cd ../copilot && pnpm run build",
-    "buildUi": "pnpm build:libs && cd ../../frontend && pnpm run build"
+    "buildUi": "pnpm build:libs && cd frontend && pnpm run build"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
Closes #2550

This PR enables automatic publishing of the `@chainlit/react-client` (and any other non-private package in `libs/*` if we will add them) to the **npm** registry.

To test the publishing process, use the **Dry run (test publishing)** option, similar to the **Publish to TestPyPI instead of PyPI** feature introduced in #2483.

### Other changes:

- Removed `pnpm install` arguments, since CI **must always use a frozen lockfile**.
  * **Updating the lockfile during CI runs is bad practice**, as changes are not committed back to the repository and resolved dependency versions may differ from those declared in the source code.
  * If you encounter an error where `pnpm` indicates that the lockfile needs to be updated, run `pnpm install` or `pnpm install --lockfile-only` locally and commit the resulting changes to the PR where the CI failure occurred.
- Removed `pnpm-skip-install` from `pnpm-node-install` action since no longer used anywhere
- CI will be skipped if the PR or commit includes only markdown files located at the repository root or the `LICENSE` file.