### PR TITLE
ci: fix pnpm publish checks

### DIFF
--- a/.github/actions/pnpm-node-install/action.yaml
+++ b/.github/actions/pnpm-node-install/action.yaml
@@ -18,6 +18,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
         cache-dependency-path: '**/pnpm-lock.yaml'
     - name: Install JS dependencies

--- a/.github/workflows/publish-libs.yaml
+++ b/.github/workflows/publish-libs.yaml
@@ -50,3 +50,5 @@ jobs:
       - name: Publish packages to npm
         # --no-git-checks allows testing from non-main branches and publishing from release tags
         run: pnpm publish --recursive --no-git-checks ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REACT_CLIENT }}


### PR DESCRIPTION
Allow publishing to npm registry from release tags

This is caused by our current release process as we create release first, which then trigger publishing