### PR TITLE
fix - persist custom_elements to data layer without cloud storage

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -189,7 +189,7 @@ class ChainlitDataLayer(BaseDataLayer):
             elif not element.url:
                 raise ValueError("Element url, path or content must be provided")
 
-            if content is not None and not isinstance(content, str):
+            if content is not None:
                 if element.thread_id:
                     path = f"threads/{element.thread_id}/files/{element.id}"
                 else:
@@ -213,11 +213,7 @@ class ChainlitDataLayer(BaseDataLayer):
 
         else:
             # Log warning only if element has file content that needs uploading
-            if (
-                element.path
-                or element.url
-                or (element.content and isinstance(element.content, bytes))
-            ):
+            if element.path or element.url or element.content:
                 logger.warning(
                     "Data Layer: No storage client configured. "
                     "File will not be uploaded."

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -336,7 +336,7 @@ async def audio_start(sid):
     session = WebsocketSession.require(sid)
 
     context = init_ws_context(session)
-    config: ChainlitConfig = session.get_config()
+    config: ChainlitConfig = session.get_config()  # type: ignore
 
     if config.features.audio and config.features.audio.enabled:
         connected = bool(await config.code.on_audio_start())
@@ -374,7 +374,7 @@ async def audio_end(sid):
             session.has_first_interaction = True
             asyncio.create_task(context.emitter.init_thread("audio"))
 
-        config: ChainlitConfig = session.get_config()
+        config: ChainlitConfig = session.get_config()  # type: ignore
 
         if config.features.audio and config.features.audio.enabled:
             await config.code.on_audio_end()


### PR DESCRIPTION
Suggested fix for #2588.

## Changes to chainlit_data_layer:
 - Remove storage client guard statement
 - Change it to a warning if element has byte content but no storage

## Additional incremental mypy change to a unrelated file to allow the CI to run
 - adds # type: ignore to a couple of type declaration lines in functions without type declarations
 
## Not included in this PR
 - a fix to allow custom elements with URL metadata, but no cloud storage to persist to the data layer.
 - tests for relevant cases
 - fixes for mirrored logic in some of the other data layer wrappers (like [sql_alchemy.py:create_element](https://github.com/Chainlit/chainlit/blob/5a6c3c972bb95cdcda9bfe4126b88543a5970216/backend/chainlit/data/sql_alchemy.py#L487)) which contain similarly restrictive logic in their create_element functions.