### PR TITLE
Feature/Support GitHub Enterprise 

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -47,9 +47,15 @@ class OAuthProvider:
 class GithubOAuthProvider(OAuthProvider):
     id = "github"
     env = ["OAUTH_GITHUB_CLIENT_ID", "OAUTH_GITHUB_CLIENT_SECRET"]
-    authorize_url = os.environ.get("OAUTH_GITHUB_AUTH_URL", "https://github.com/login/oauth/authorize")
-    token_url = os.environ.get("OAUTH_GITHUB_TOKEN_URL", "https://github.com/login/oauth/access_token")
-    user_info_url = os.environ.get("OAUTH_GITHUB_USER_INFO_URL", "https://api.github.com/user")
+    authorize_url = os.environ.get(
+        "OAUTH_GITHUB_AUTH_URL", "https://github.com/login/oauth/authorize"
+    )
+    token_url = os.environ.get(
+        "OAUTH_GITHUB_TOKEN_URL", "https://github.com/login/oauth/access_token"
+    )
+    user_info_url = os.environ.get(
+        "OAUTH_GITHUB_USER_INFO_URL", "https://api.github.com/user"
+    )
 
     def __init__(self):
         self.client_id = os.environ.get("OAUTH_GITHUB_CLIENT_ID")


### PR DESCRIPTION
### Context
This is a known issue, but it seems to be no longer actively managed.  
- https://github.com/Chainlit/chainlit/issues/1484  
- https://github.com/Chainlit/chainlit/pull/1486  

### Changes
- Added support for **GitHub Enterprise** in `GithubOAuthProvider` by allowing configuration through environment variables.

### Notes
- Maintains backward compatibility.  
- Preserves environment variable naming conventions consistent with `GenericOAuthProvider`: 

| GenericOAuthProvider | GithubOAuthProvider |
| --------------------- | ------------------- |
| `OAUTH_GENERIC_AUTH_URL` | `OAUTH_GITHUB_AUTH_URL` |
| `OAUTH_GENERIC_TOKEN_URL` | `OAUTH_GITHUB_TOKEN_URL` |
| `OAUTH_GENERIC_USER_INFO_URL` | `OAUTH_GITHUB_USER_INFO_URL` |
