### PR TITLE
Added raw response from OAuthProviders

### DIFF
--- a/backend/chainlit/oauth_providers.py
+++ b/backend/chainlit/oauth_providers.py
@@ -9,6 +9,8 @@ from fastapi import HTTPException
 from chainlit.secret import random_secret
 from chainlit.user import User
 
+ACCESS_TOKEN_MISSING = "Access token missing in the response"
+
 
 class OAuthProvider:
     id: str
@@ -21,6 +23,9 @@ class OAuthProvider:
 
     def is_configured(self):
         return all([os.environ.get(env) for env in self.env])
+
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
+        raise NotImplementedError
 
     async def get_token(self, code: str, url: str) -> str:
         raise NotImplementedError
@@ -67,7 +72,7 @@ class GithubOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> Dict[str, List[str]]:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -79,13 +84,14 @@ class GithubOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            content = urllib.parse.parse_qs(response.text)
-            token = content.get("access_token", [""])[0]
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            return token
+            return urllib.parse.parse_qs(response.text)
+
+    async def get_token(self, code: str, url: str):
+        content = await self.get_raw_token_response(code, url)
+        token = content.get("access_token", [""])[0]
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -128,7 +134,7 @@ class GoogleOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -142,15 +148,14 @@ class GoogleOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json = response.json()
-            token = json.get("access_token")
-            if not token:
-                raise httpx.HTTPStatusError(
-                    "Failed to get the access token",
-                    request=response.request,
-                    response=response,
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str):
+        json = await self.get_raw_token_response(code, url)
+        token = json.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -198,7 +203,7 @@ class AzureADOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -212,16 +217,17 @@ class AzureADOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json = response.json()
+            return response.json()
 
-            token = json["access_token"]
-            refresh_token = json.get("refresh_token")
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            self._refresh_token = refresh_token
-            return token
+    async def get_token(self, code: str, url: str):
+        json = await self.get_raw_token_response(code, url)
+
+        token = json["access_token"]
+        refresh_token = json.get("refresh_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        self._refresh_token = refresh_token
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -291,7 +297,7 @@ class AzureADHybridOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -305,16 +311,17 @@ class AzureADHybridOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json = response.json()
+            return response.json()
 
-            token = json["access_token"]
-            refresh_token = json.get("refresh_token")
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            self._refresh_token = refresh_token
-            return token
+    async def get_token(self, code: str, url: str):
+        json = await self.get_raw_token_response(code, url)
+
+        token = json["access_token"]
+        refresh_token = json.get("refresh_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        self._refresh_token = refresh_token
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -386,7 +393,7 @@ class OktaOAuthProvider(OAuthProvider):
             return ""
         return f"/{self.authorization_server_id}"
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -400,16 +407,14 @@ class OktaOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json_data = response.json()
+            return response.json()
 
-            token = json_data.get("access_token")
-            if not token:
-                raise httpx.HTTPStatusError(
-                    "Failed to get the access token",
-                    request=response.request,
-                    response=response,
-                )
-            return token
+    async def get_token(self, code: str, url: str):
+        json_data = await self.get_raw_token_response(code, url)
+        token = json_data.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -453,7 +458,7 @@ class Auth0OAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -467,13 +472,14 @@ class Auth0OAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json_content = response.json()
-            token = json_content.get("access_token")
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str):
+        json_content = await self.get_raw_token_response(code, url)
+        token = json_content.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -513,7 +519,7 @@ class DescopeOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -527,15 +533,14 @@ class DescopeOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json_content = response.json()
-            token = json_content.get("access_token")
-            if not token:
-                raise httpx.HTTPStatusError(
-                    "Failed to get the access token",
-                    request=response.request,
-                    response=response,
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str):
+        json_content = await self.get_raw_token_response(code, url)
+        token = json_content.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -575,7 +580,7 @@ class AWSCognitoOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -589,14 +594,14 @@ class AWSCognitoOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json = response.json()
+            return response.json()
 
-            token = json.get("access_token")
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            return token
+    async def get_token(self, code: str, url: str):
+        json = await self.get_raw_token_response(code, url)
+        token = json.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         user_info_url = (
@@ -646,7 +651,7 @@ class GitlabOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -660,13 +665,14 @@ class GitlabOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json_content = response.json()
-            token = json_content.get("access_token")
-            if not token:
-                raise HTTPException(
-                    status_code=400, detail="Failed to get the access token"
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str):
+        json_content = await self.get_raw_token_response(code, url)
+        token = json_content.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -696,6 +702,7 @@ class KeycloakOAuthProvider(OAuthProvider):
     id = os.environ.get("OAUTH_KEYCLOAK_NAME", "keycloak")
 
     def __init__(self):
+        self.refresh_token = None
         self.client_id = os.environ.get("OAUTH_KEYCLOAK_CLIENT_ID")
         self.client_secret = os.environ.get("OAUTH_KEYCLOAK_CLIENT_SECRET")
         self.realm = os.environ.get("OAUTH_KEYCLOAK_REALM")
@@ -712,7 +719,7 @@ class KeycloakOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -726,15 +733,16 @@ class KeycloakOAuthProvider(OAuthProvider):
                 data=payload,
             )
             response.raise_for_status()
-            json = response.json()
-            token = json.get("access_token")
-            if not token:
-                raise httpx.HTTPStatusError(
-                    "Failed to get the access token",
-                    request=response.request,
-                    response=response,
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str):
+        json = await self.get_raw_token_response(code, url)
+        token = json.get("access_token")
+        refresh_token = json.get("refresh_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        self.refresh_token = refresh_token
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:
@@ -779,7 +787,7 @@ class GenericOAuthProvider(OAuthProvider):
         if prompt := self.get_prompt():
             self.authorize_params["prompt"] = prompt
 
-    async def get_token(self, code: str, url: str):
+    async def get_raw_token_response(self, code: str, url: str) -> dict:
         payload = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
@@ -790,15 +798,14 @@ class GenericOAuthProvider(OAuthProvider):
         async with httpx.AsyncClient() as client:
             response = await client.post(self.token_url, data=payload)
             response.raise_for_status()
-            json = response.json()
-            token = json.get("access_token")
-            if not token:
-                raise httpx.HTTPStatusError(
-                    "Failed to get the access token",
-                    request=response.request,
-                    response=response,
-                )
-            return token
+            return response.json()
+
+    async def get_token(self, code: str, url: str) -> str:
+        json = await self.get_raw_token_response(code, url)
+        token = json.get("access_token")
+        if not token:
+            raise HTTPException(status_code=400, detail=ACCESS_TOKEN_MISSING)
+        return token
 
     async def get_user_info(self, token: str):
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Suggested fix for #2581 

**Changes to oauth_providers.py**

- Added get_raw_token_response() to every provider
- get_token() still remains and uses the get_raw_token_response()
- Generalized the exception when token is missing 