### PR TITLE
chore: make hello.py debugger friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,12 @@ Start by running `backend/hello.py` as an example.
 
 ```sh
 cd backend
-uv run chainlit run chainlit/hello.py
+uv run chainlit run hello.py
 ```
 
 You should now be able to access the Chainlit app you just launched on `http://127.0.0.1:8000`.
 
-If you've made it this far, you can now replace `chainlit/hello.py` by your own target. 😎
+If you've made it this far, you can now replace `hello.py` by your own target. 😎
 
 ## Start the UI from source
 

--- a/backend/hello.py
+++ b/backend/hello.py
@@ -10,3 +10,9 @@ async def main():
         await Message(
             content=f"Your name is: {res['output']}.\nChainlit installation is working!\nYou can now start building your own chainlit apps!",
         ).send()
+
+
+if __name__ == "__main__":
+    from chainlit.cli import run_chainlit
+
+    run_chainlit(__file__)


### PR DESCRIPTION
This PR

* Moves `hello.py` out of the project directory
  * Fixes an issue with certain debuggers (such as PyCharm’s) where project file names shadow module names (e.g., `mcp.py` → `mcp` module), causing failures
  * Excludes the demo from the project distribution package
* Adds logic allowing it to be run directly, without requiring `chainlit run`