### PR TITLE
Bug: Fix page blinking after login

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -73,7 +73,7 @@ export default function Login() {
     if (!config.requireLogin) {
       navigate('/');
     }
-    if (config.headerAuth) {
+    if (config.headerAuth && !user) {
       handleHeaderAuth();
     }
     if (user) {


### PR DESCRIPTION
When using the `header_auth_callback ` and another auth callback for login, the page starts to "blink" as soon as a user logged in. This is because `header_auth_callback ` always gets called when routing to the root. 

Fix: Now when a user is already authenticated, the `header_auth_callback `won't be called
Issue: #2599 