### PR TITLE
Added support for tabs in chat settings

### DIFF
--- a/backend/chainlit/chat_settings.py
+++ b/backend/chainlit/chat_settings.py
@@ -1,28 +1,37 @@
-from typing import List
+from typing import Any, List
 
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
 from chainlit.context import context
-from chainlit.input_widget import InputWidget
+from chainlit.input_widget import InputWidget, Tab
 
 
 @dataclass
 class ChatSettings:
     """Useful to create chat settings that the user can change."""
 
-    inputs: List[InputWidget] = Field(default_factory=list, exclude=True)
+    inputs: List[InputWidget] | List[Tab] = Field(default_factory=list, exclude=True)
 
     def __init__(
         self,
-        inputs: List[InputWidget],
+        inputs: List[InputWidget] | List[Tab],
     ) -> None:
         self.inputs = inputs
 
     def settings(self):
-        return dict(
-            [(input_widget.id, input_widget.initial) for input_widget in self.inputs]
-        )
+        def collect_settings(
+            values: dict[str, Any], inputs: List[InputWidget] | List[Tab]
+        ) -> None:
+            for input in inputs:
+                if isinstance(input, Tab):
+                    collect_settings(values, input.inputs)
+                else:
+                    values[input.id] = input.initial
+
+        settings: dict[str, Any] = {}
+        collect_settings(settings, self.inputs)
+        return settings
 
     async def send(self):
         settings = self.settings()

--- a/backend/chainlit/input_widget.py
+++ b/backend/chainlit/input_widget.py
@@ -300,3 +300,17 @@ class RadioGroup(InputWidget):
             "description": self.description,
             "disabled": self.disabled,
         }
+
+
+@dataclass
+class Tab:
+    id: str
+    label: str
+    inputs: list[InputWidget] = Field(default_factory=list, exclude=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "inputs": [input.to_dict() for input in self.inputs],
+        }

--- a/frontend/src/components/ChatSettings/index.tsx
+++ b/frontend/src/components/ChatSettings/index.tsx
@@ -18,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Translator } from 'components/i18n';
 
 import { chatSettingsOpenState } from 'state/project';
@@ -71,12 +72,22 @@ export default function ChatSettingsModal() {
   };
 
   const values = watch();
+  const tabInputs = chatSettingsInputs.filter(
+    (input: any) => Array.isArray(input?.inputs) && input.inputs.length > 0
+  );
+  const regularInputs = chatSettingsInputs.filter(
+    (input: any) => !Array.isArray(input?.inputs) || input.inputs.length === 0
+  );
+  const hasTabs = tabInputs.length > 0;
+  const defaultTab = tabInputs[0]?.id;
 
   return (
     <Dialog open={chatSettingsOpen} onOpenChange={handleClose}>
       <DialogContent
         id="chat-settings"
-        className="min-w-[20vw] max-h-[85vh] flex flex-col gap-6 p-6"
+        className={`flex flex-col gap-6 p-6 ${
+          hasTabs ? 'min-w-[25vw] h-[85vh]' : 'min-w-[20vw] max-h-[85vh]'
+        }`}
       >
         <DialogHeader>
           <DialogTitle>
@@ -86,19 +97,53 @@ export default function ChatSettingsModal() {
             <Translator path="chat.settings.customize" />
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col flex-grow overflow-y-auto gap-6 p-1">
-          {chatSettingsInputs.map((input: any) => (
-            <FormInput
-              key={input.id}
-              element={{
-                ...input,
-                value: values[input.id],
-                onChange: handleChange,
-                setField: setFieldValue
-              }}
-            />
-          ))}
-        </div>
+        {hasTabs ? (
+          <Tabs
+            defaultValue={defaultTab}
+            className="flex flex-col flex-grow min-h-0"
+          >
+            <TabsList className="w-full flex justify-start">
+              {tabInputs.map((tab: any) => (
+                <TabsTrigger key={tab.id} value={tab.id}>
+                  {tab.label ?? tab.id}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {tabInputs.map((tab: any) => (
+              <TabsContent
+                key={tab.id}
+                value={tab.id}
+                className="data-[state=active]:flex flex-col flex-grow overflow-y-auto gap-6 p-1 mt-4"
+              >
+                {tab.inputs?.map((input: any) => (
+                  <FormInput
+                    key={input.id}
+                    element={{
+                      ...input,
+                      value: values[input.id],
+                      onChange: handleChange,
+                      setField: setFieldValue
+                    }}
+                  />
+                ))}
+              </TabsContent>
+            ))}
+          </Tabs>
+        ) : (
+          <div className="flex flex-col flex-grow overflow-y-auto gap-6 p-1">
+            {regularInputs.map((input: any) => (
+              <FormInput
+                key={input.id}
+                element={{
+                  ...input,
+                  value: values[input.id],
+                  onChange: handleChange,
+                  setField: setFieldValue
+                }}
+              />
+            ))}
+          </div>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={handleReset}>
             <Translator path="common.actions.reset" />

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -49,4 +49,4 @@ const TabsContent = React.forwardRef<
 ));
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/libs/react-client/src/state.ts
+++ b/libs/react-client/src/state.ts
@@ -126,16 +126,35 @@ export const chatSettingsDefaultValueSelector = selector({
   key: 'ChatSettingsValue/Default',
   get: ({ get }) => {
     const chatSettings = get(chatSettingsInputsState);
-    return chatSettings.reduce(
-      (form: { [key: string]: any }, input: any) => (
-        (form[input.id] = input.initial), form
-      ),
-      {}
-    );
+
+    const collectInitialValues = (
+      inputs: any[],
+      acc: Record<string, any>
+    ): Record<string, any> => {
+      if (!Array.isArray(inputs)) {
+        return acc;
+      }
+
+      inputs.forEach((input) => {
+        if (!input) {
+          return;
+        }
+        if (Array.isArray(input?.inputs) && input.inputs.length > 0) {
+          // Handle tabs
+          collectInitialValues(input.inputs, acc);
+        } else if (input?.id !== undefined) {
+          acc[input.id] = input.initial;
+        }
+      });
+
+      return acc;
+    };
+
+    return collectInitialValues(chatSettings, {});
   }
 });
 
-export const chatSettingsValueState = atom({
+export const chatSettingsValueState = atom<Record<string, any>>({
   key: 'ChatSettingsValue',
   default: chatSettingsDefaultValueSelector
 });


### PR DESCRIPTION
This is related to this feature request :

https://github.com/Chainlit/chainlit/issues/2650

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added tabbed chat settings so apps can group inputs into tabs. Improves UX for complex forms and keeps initial values working across tabs.

- **New Features**
  - Backend: Added a Tab dataclass (id, label, inputs). ChatSettings now accepts tabs and flattens nested inputs when building settings.
  - Frontend: Render tabbed settings with Tabs/TabsList/TabsTrigger/TabsContent. Shows tab inputs separately and keeps non-tab inputs as usual. Dialog layout adjusts for tabs.
  - State: Default values selector now collects nested inputs inside tabs. Typed chatSettingsValueState as Record<string, any>.

<sup>Written for commit 225371e6d6cdacfc6b49a18fa4e0ad8e3c3b4caa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

