### PR TITLE
Support markdown in watermark

### DIFF
--- a/frontend/src/components/WaterMark.tsx
+++ b/frontend/src/components/WaterMark.tsx
@@ -1,6 +1,9 @@
-import { Translator } from 'components/i18n';
+import { Markdown } from '@/components/Markdown';
+import { useTranslation } from '@/components/i18n/Translator';
 
 export default function WaterMark() {
+  const { t } = useTranslation();
+
   return (
     <div
       className="watermark"
@@ -10,9 +13,9 @@ export default function WaterMark() {
         textDecoration: 'none'
       }}
     >
-      <div className="text-xs text-muted-foreground">
-        <Translator path="chat.watermark" />
-      </div>
+      <Markdown className="[&_p]:m-0 [&_p]:leading-snug [&_div]:leading-snug [&_div]:mt-0 [&_strong]:font-semibold text-xs text-muted-foreground">
+        {t('chat.watermark')}
+      </Markdown>
     </div>
   );
 }


### PR DESCRIPTION
Small adjustment to allow for markdown in watermark text. This allows to e.g. add links to usage notes, data protection info etc. 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The chat watermark now renders translated Markdown, so you can include links and basic formatting. Replaced the Translator component with useTranslation + Markdown in WaterMark.tsx to render the localized Markdown text.

<sup>Written for commit c6fcaebe178c10ebf3e242b7d5bdb7ffae6171d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



