### PR TITLE
Update useChatSession.ts

### DIFF
--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -146,7 +146,8 @@ const useChatSession = () => {
               promise = client.connectStreamableHttpMCP(
                 sessionId,
                 mcp.name,
-                mcp.url!
+                mcp.url!,
+                mcp.headers || {}
               );
             } else {
               promise = client.connectStdioMCP(


### PR DESCRIPTION
Use the headers when reconnecting to the MCP streamable-http server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include MCP headers when reconnecting to streamable-http MCP servers. This preserves auth and custom headers and prevents reconnection failures.

<sup>Written for commit c49cd6be5aeddb4ea912cfea902c8a6aa2a87522. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

