### PR TITLE
Update chainlit data layer with metadata merging

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -578,7 +578,8 @@ class ChainlitDataLayer(BaseDataLayer):
         # Merge incoming metadata with existing metadata, deleting incoming keys with None values
         if metadata is not None:
             existing = await self.execute_query(
-                'SELECT "metadata" FROM "Thread" WHERE id = $1', {"thread_id": thread_id}
+                'SELECT "metadata" FROM "Thread" WHERE id = $1',
+                {"thread_id": thread_id},
             )
             base = {}
             if isinstance(existing, list) and existing:


### PR DESCRIPTION
This fixes the bug where threads would not be shared anymore as soon as we would leave the context of the shared thread (e.g. refresh, or going to a different conversation) because the session metadata would overwrite the entire thread metadata.

Incoming metadata is now merged with the existing one, and if any incoming key has a None value, we remove that key from the merged metadata.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge incoming thread metadata instead of overwriting, so shared threads stay shared after refresh or when switching conversations. Incoming keys set to None are treated as deletes.

- **Bug Fixes**
  - Preserve existing metadata by merging updates; handle JSON string or dict formats.
  - Remove keys when incoming value is None to allow unsetting metadata.

<sup>Written for commit 6adf15c5df76f4979edea9df7a70df6e71997931. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



