### PR TITLE
feat: updated UI from select to multi buttons

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 
 import { ChainlitAPI, ClientError } from '@chainlit/react-client';
 
-const devServer = 'http://localhost:8000' + getRouterBasename();
+const devServer = 'http://localhost:7000' + getRouterBasename();
 const url = import.meta.env.DEV
   ? devServer
   : window.origin + getRouterBasename();
@@ -41,20 +41,28 @@ class ExtendedChainlitAPI extends ChainlitAPI {
     headers?: Record<string, string>
   ) {
     // Assumes the backend expects { clientType, name, url }
-    return fetch(new URL("mcp", this.httpEndpoint.endsWith("/") ? this.httpEndpoint : `${this.httpEndpoint}/`), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(sessionId ? { 'x-session-id': sessionId } : {})
-      },
-      body: JSON.stringify({
-        clientType: 'streamable-http',
-        name,
-        url,
-        sessionId,
-        ...(headers ? { headers } : {})
-      })
-    }).then(async (res) => {
+    return fetch(
+      new URL(
+        'mcp',
+        this.httpEndpoint.endsWith('/')
+          ? this.httpEndpoint
+          : `${this.httpEndpoint}/`
+      ),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(sessionId ? { 'x-session-id': sessionId } : {})
+        },
+        body: JSON.stringify({
+          clientType: 'streamable-http',
+          name,
+          url,
+          sessionId,
+          ...(headers ? { headers } : {})
+        })
+      }
+    ).then(async (res) => {
       const data = await res.json();
       return { success: res.ok, mcp: data.mcp, error: data.detail };
     });

--- a/frontend/src/components/header/ChatProfiles.tsx
+++ b/frontend/src/components/header/ChatProfiles.tsx
@@ -9,18 +9,12 @@ import {
 } from '@chainlit/react-client';
 
 import { Markdown } from '@/components/Markdown';
+import { Button } from '@/components/ui/button';
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger
 } from '@/components/ui/hover-card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select';
 
 import { NewChatDialog } from './NewChat';
 
@@ -79,65 +73,59 @@ export default function ChatProfiles({ navigate }: Props) {
 
   return (
     <div className="relative">
-      <Select
-        value={chatProfile || ''}
-        onValueChange={(value) => {
-          setNewChatProfile(value);
-          if (firstInteraction) {
-            setOpenDialog(true);
-          } else {
-            handleConfirm(value);
-          }
-        }}
-      >
-        <SelectTrigger
-          id="chat-profiles"
-          className="w-fit border-none bg-transparent text-muted-foreground font-semibold text-lg hover:bg-accent"
-        >
-          <SelectValue placeholder="Select profile" />
-        </SelectTrigger>
-        <SelectContent>
-          {config.chatProfiles.map((profile) => {
-            const icon = profile.icon?.includes('/public')
-              ? apiClient.buildEndpoint(profile.icon)
-              : profile.icon;
+      <div id="chat-profiles" className="flex items-center gap-2">
+        {config.chatProfiles.map((profile) => {
+          const icon = profile.icon?.includes('/public')
+            ? apiClient.buildEndpoint(profile.icon)
+            : profile.icon;
 
-            return (
-              <HoverCard openDelay={0} closeDelay={0} key={profile.name}>
-                <HoverCardTrigger asChild>
-                  <SelectItem
-                    data-test={`select-item:${profile.name}`}
-                    value={profile.name}
-                    className="cursor-pointer"
-                  >
-                    <div className="flex items-center gap-2">
-                      {icon && (
-                        <img
-                          src={icon}
-                          alt={profile.display_name || profile.name}
-                          className="w-6 h-6 rounded-md object-cover"
-                        />
-                      )}
-                      <span>{profile.display_name || profile.name}</span>
-                    </div>
-                  </SelectItem>
-                </HoverCardTrigger>
-                <HoverCardContent
-                  side="right"
-                  id="chat-profile-description"
-                  align="start"
-                  className="w-80 overflow-visible"
-                  sideOffset={10}
+          const isSelected = profile.name === chatProfile;
+
+          return (
+            <HoverCard openDelay={0} closeDelay={0} key={profile.name}>
+              <HoverCardTrigger asChild>
+                <Button
+                  type="button"
+                  data-test={`select-item:${profile.name}`}
+                  onClick={() => {
+                    const value = profile.name;
+                    setNewChatProfile(value);
+                    if (firstInteraction) {
+                      setOpenDialog(true);
+                    } else {
+                      handleConfirm(value);
+                    }
+                  }}
+                  variant={isSelected ? 'secondary' : 'ghost'}
+                  className="h-9 px-3 text-sm font-semibold text-muted-foreground"
                 >
-                  <Markdown allowHtml={allowHtml} latex={latex}>
-                    {profile.markdown_description}
-                  </Markdown>
-                </HoverCardContent>
-              </HoverCard>
-            );
-          })}
-        </SelectContent>
-      </Select>
+                  <div className="flex items-center gap-2">
+                    {icon && (
+                      <img
+                        src={icon}
+                        alt={profile.display_name || profile.name}
+                        className="w-6 h-6 rounded-md object-cover"
+                      />
+                    )}
+                    <span>{profile.display_name || profile.name}</span>
+                  </div>
+                </Button>
+              </HoverCardTrigger>
+              <HoverCardContent
+                side="right"
+                id="chat-profile-description"
+                align="start"
+                className="w-80 overflow-visible"
+                sideOffset={10}
+              >
+                <Markdown allowHtml={allowHtml} latex={latex}>
+                  {profile.markdown_description}
+                </Markdown>
+              </HoverCardContent>
+            </HoverCard>
+          );
+        })}
+      </div>
       <NewChatDialog
         open={openDialog}
         handleClose={handleClose}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the chat profile selector from a dropdown to individual buttons with hover previews to make profiles easier to scan and faster to switch, while keeping the first-interaction confirmation flow.

- **New Features**
  - Replaced Select with Button-based picker; each profile shows icon, name, and a HoverCard Markdown preview.
  - Highlights the active profile; click switches immediately or opens NewChatDialog on first interaction.
  - Preserved data-test attributes (select-item:...) to avoid breaking tests.

- **Migration**
  - Dev server endpoint updated to http://localhost:7000. Run the backend on port 7000 or adjust your local config.

<sup>Written for commit 0e3d4e14614845a7f36c7c90b5013883fb358936. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

