### PR TITLE
fix: tiny error avatar for long messages

### DIFF
--- a/frontend/src/components/chat/Messages/Message/Avatar.tsx
+++ b/frontend/src/components/chat/Messages/Message/Avatar.tsx
@@ -44,7 +44,9 @@ const MessageAvatar = ({ author, hide, isError }: Props) => {
 
   if (isError) {
     return (
-      <AlertCircle className="h-5 w-5 fill-destructive mt-[5px] text-destructive-foreground" />
+      <span className={cn('inline-block', hide && 'invisible')}>
+        <AlertCircle className="h-5 w-5 fill-destructive mt-[5px] text-destructive-foreground" />
+      </span>
     );
   }
 


### PR DESCRIPTION
Before:

<img width="757" height="337" alt="image" src="https://github.com/user-attachments/assets/276a7b4f-88d7-43d3-87b7-2779acfc6985" />

After:

<img width="752" height="356" alt="image" src="https://github.com/user-attachments/assets/828810f8-7d41-49af-bc5c-e48574bf6c0d" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tiny error avatar that appears in long messages by wrapping the AlertCircle in an inline-block container. This keeps the icon size and alignment consistent and uses invisible to respect the hide state without collapsing layout.

<sup>Written for commit 15ff6b1aa05397420177890329eba963320deb19. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

