### PR TITLE
feat: Add ability to fetch step from data layer

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -408,6 +408,21 @@ class ChainlitDataLayer(BaseDataLayer):
             'DELETE FROM "Step" WHERE id = $1', {"step_id": step_id}
         )
 
+    async def get_step(self, step_id: str) -> Optional[StepDict]:
+        # Get step and related feedback
+        query = """
+        SELECT  s.*,
+                f.id feedback_id,
+                f.value feedback_value,
+                f."comment" feedback_comment
+        FROM "Step" s left join "Feedback" f on s.id = f."stepId"
+        WHERE s.id = $1
+        """
+        result = await self.execute_query(query, {"step_id": step_id})
+        if not result:
+            return None
+        return self._convert_step_row_to_dict(result[0])
+
     async def get_thread_author(self, thread_id: str) -> str:
         query = """
         SELECT u.identifier


### PR DESCRIPTION
This is useful for pulling message metadata from an on_feedback callback, for instance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add get_step to the data layer to fetch a step by ID with its associated feedback. This enables pulling message metadata in on_feedback callbacks.

- **New Features**
  - chainlit_data_layer.get_step: joins Feedback and returns a StepDict or None.
  - sql_alchemy.get_step: mirrors behavior, maps fields, respects showInput, and returns optional FeedbackDict.
  - No schema changes; read-only queries only.

<sup>Written for commit 06c891d9e23e8254ee4d3c67e03c04b4cbac3df0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

