### PR TITLE
Workaround for thread deletion race condition issue

### DIFF
--- a/frontend/src/components/LeftSidebar/ThreadList.tsx
+++ b/frontend/src/components/LeftSidebar/ThreadList.tsx
@@ -149,6 +149,7 @@ export function ThreadList({
       threadIdToDelete === currentThreadId
     ) {
       clear();
+      navigate('/');
       await new Promise((resolve) => setTimeout(resolve, 300));
     }
 
@@ -161,7 +162,6 @@ export function ThreadList({
           ...prev,
           threads: prev?.threads?.filter((t) => t.id !== threadIdToDelete)
         }));
-        navigate('/');
         return (
           <Translator path="threadHistory.thread.actions.delete.success" />
         );


### PR DESCRIPTION
When deleting an active thread, a race condition occurs where update_thread is called on a thread that was already deleted, causing errors and potentially recreating incomplete thread data.

See details here : https://github.com/Chainlit/chainlit/issues/2713

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition when deleting the active thread by navigating away immediately after clearing state. This prevents updates on a deleted thread and avoids recreating partial thread data.

- **Bug Fixes**
  - In ThreadList.tsx, call navigate('/') right after clear() when deleting the current thread, and remove the later navigate call.

<sup>Written for commit 24a8b13ac6cc49d5397fc84490ebae6aad37bce7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

