### PR TITLE
chore: update uv.lock after watchfiles changes

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -889,7 +889,7 @@ requires-dist = [
     { name = "types-aiofiles", marker = "extra == 'mypy'", specifier = ">=23.1.0.5,<24.0.0" },
     { name = "types-requests", marker = "extra == 'mypy'", specifier = ">=2.31.0.2,<3.0.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
-    { name = "watchfiles", specifier = ">=1.0.0,<2.0.0" },
+    { name = "watchfiles", specifier = ">=1.1.1,<2.0.0" },
 ]
 provides-extras = ["custom-data", "dev", "mypy", "tests"]
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align uv.lock with the watchfiles dependency update by raising the minimum version to 1.1.1 (<2.0.0). This prevents mismatched installs and keeps dev file watching stable.

<sup>Written for commit 06fa47e539f376e0d4b7c083c132fec4f004a0ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

