### PR TITLE
feat: make avatar size configurable via config.toml

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -210,6 +210,9 @@ logo_file_url = ""
 # Load assistant avatar image directly from URL.
 default_avatar_file_url = ""
 
+# Avatar size in pixels.
+# avatar_size = 20
+
 # Specify a custom build directory for the frontend.
 # This can be used to customize the frontend code.
 # Be careful: If this is a relative path, it should not start with a slash.
@@ -356,6 +359,8 @@ class UISettings(BaseModel):
     logo_file_url: Optional[str] = None
     # Optional avatar image file url
     default_avatar_file_url: Optional[str] = None
+    # Avatar size in pixels (default: 20)
+    avatar_size: int = 20
     # Optional custom build directory for the frontend
     custom_build: Optional[str] = None
     # Optional header links

--- a/frontend/src/components/chat/Messages/Message/Avatar.tsx
+++ b/frontend/src/components/chat/Messages/Message/Avatar.tsx
@@ -23,10 +23,14 @@ interface Props {
   isError?: boolean;
 }
 
+const DEFAULT_AVATAR_SIZE = 20;
+
 const MessageAvatar = ({ author, hide, isError }: Props) => {
   const apiClient = useContext(ChainlitContext);
   const { chatProfile } = useChatSession();
   const { config } = useConfig();
+
+  const avatarSize = config?.ui?.avatar_size ?? DEFAULT_AVATAR_SIZE;
 
   const selectedChatProfile = useMemo(() => {
     return config?.chatProfiles.find((profile) => profile.name === chatProfile);
@@ -45,7 +49,10 @@ const MessageAvatar = ({ author, hide, isError }: Props) => {
   if (isError) {
     return (
       <span className={cn('inline-block', hide && 'invisible')}>
-        <AlertCircle className="h-5 w-5 fill-destructive mt-[5px] text-destructive-foreground" />
+        <AlertCircle
+          className="fill-destructive text-destructive-foreground"
+          style={{ width: avatarSize, height: avatarSize, marginTop: 5 }}
+        />
       </span>
     );
   }
@@ -55,7 +62,7 @@ const MessageAvatar = ({ author, hide, isError }: Props) => {
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Avatar className="h-5 w-5 mt-[3px]">
+            <Avatar style={{ width: avatarSize, height: avatarSize, marginTop: 3 }}>
               <AvatarImage
                 src={avatarUrl}
                 alt={`Avatar for ${author || 'default'}`}

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -48,6 +48,7 @@ export interface IChainlitConfig {
     custom_meta_image_url?: string;
     logo_file_url?: string;
     default_avatar_file_url?: string;
+    avatar_size?: number;
     header_links?: {
       name: string;
       display_name: string;


### PR DESCRIPTION
## Summary

- Adds `avatar_size` option to the `[UI]` section of `config.toml` to allow users to customize the message avatar size in pixels
- Default remains 20px for backwards compatibility
- Users can now set any pixel value (e.g., 32, 40) for larger, more detailed avatars

## Usage

```toml
[UI]
# Avatar size in pixels (default: 20)
avatar_size = 32
```

## Test plan

- [ ] Verify default avatar size (20px) works without config change
- [ ] Verify custom avatar size (e.g., 32px) applies correctly
- [ ] Verify error avatar icon also respects the configured size
- [ ] Verify config change triggers UI update

Closes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make avatar size configurable via [UI].avatar_size in config.toml. Default stays 20px and the size applies to message avatars and the error icon.

- New Features
  - Add UI.avatar_size (pixels) to config.toml; default 20.
  - Frontend uses the value for avatars and the AlertCircle error icon.
  - Update backend UISettings and react-client types.

<sup>Written for commit 7f0c8d241f0754c579c41256beea2cafe011e279. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

