### PR TITLE
Fix Sqlalchemy Datalayer issues 

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -881,7 +881,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 FROM steps s
                          JOIN threads t ON s."threadId" = t.id
                 WHERE t."userId" = :user_id
-                  AND s."metadata" LIKE :favorite_pattern
+                  AND CAST(s."metadata" AS TEXT) LIKE :favorite_pattern
                 ORDER BY s."createdAt" DESC \
                 """
 


### PR DESCRIPTION
closes #2750, #2751 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two SQLAlchemy data layer bugs that broke step creation and favorite filtering. We now store modes as JSON and cast metadata to text so LIKE queries work.

- **Bug Fixes**
  - Serialize step_dict["modes"] to JSON during create_step to persist correctly (#2750).
  - Cast s.metadata to TEXT in the favorite steps query so LIKE matches work (#2751).

<sup>Written for commit 2b96db400b9818fa52c861de6894bfecbab4d312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

