### PR TITLE
feat: allow to skip new chat confirmation

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -171,6 +171,9 @@ name = "Assistant"
 
 # default_sidebar_state = "open"
 
+# Whether to prompt user confirmation on clicking 'New Chat'
+confirm_new_chat = true
+
 # Description of the assistant. This is used for HTML tags.
 # description = ""
 
@@ -338,6 +341,7 @@ class UISettings(BaseModel):
     language: Optional[str] = None
     layout: Optional[Literal["default", "wide"]] = "default"
     default_sidebar_state: Optional[Literal["open", "closed"]] = "open"
+    confirm_new_chat: bool = True
     github: Optional[str] = None
     # Optional custom CSS file that allows you to customize the UI
     custom_css: Optional[str] = None

--- a/frontend/src/components/header/NewChat.tsx
+++ b/frontend/src/components/header/NewChat.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { useChatInteract } from '@chainlit/react-client';
+import { useChatInteract, useConfig } from '@chainlit/react-client';
 
 import { Translator } from '@/components/i18n';
 import { Button } from '@/components/ui/button';
@@ -75,9 +75,14 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const NewChatButton = ({ navigate, onConfirm, ...buttonProps }: Props) => {
   const [open, setOpen] = useState(false);
   const { clear } = useChatInteract();
+  const { config } = useConfig();
 
   const handleClickOpen = () => {
-    setOpen(true);
+    if (config?.ui?.confirm_new_chat === false) {
+      handleConfirm();
+    } else {
+      setOpen(true);
+    }
   };
 
   const handleClose = () => {

--- a/frontend/tests/NewChat.spec.tsx
+++ b/frontend/tests/NewChat.spec.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import NewChatButton from '@/components/header/NewChat';
+
+const mockClear = vi.fn();
+const mockUseConfig = vi.fn();
+
+vi.mock('@chainlit/react-client', () => ({
+  useChatInteract: () => ({ clear: mockClear }),
+  useConfig: () => mockUseConfig()
+}));
+
+vi.mock('@/components/i18n', () => ({
+  Translator: ({ path }: { path: string }) => <span>{path}</span>
+}));
+
+describe('NewChatButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConfig.mockReturnValue({ config: {} });
+  });
+
+  it('renders the button correctly', () => {
+    render(<NewChatButton />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('opens dialog by default when config is undefined', () => {
+    mockUseConfig.mockReturnValue({ config: undefined });
+
+    render(<NewChatButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(
+      screen.getByText('navigation.newChat.dialog.title')
+    ).toBeInTheDocument();
+  });
+
+  it('opens dialog by default when ui config is missing', () => {
+    mockUseConfig.mockReturnValue({ config: { project: {} } });
+
+    render(<NewChatButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(
+      screen.getByText('navigation.newChat.dialog.title')
+    ).toBeInTheDocument();
+  });
+
+  it('clears chat and navigates when confirmed via Dialog', () => {
+    mockUseConfig.mockReturnValue({ config: {} });
+    const mockNavigate = vi.fn();
+
+    render(<NewChatButton navigate={mockNavigate} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const confirmBtn = screen.getByText('common.actions.confirm');
+    fireEvent.click(confirmBtn);
+
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('skips dialog and activates immediately when confirm_new_chat is false', () => {
+    mockUseConfig.mockReturnValue({
+      config: { ui: { confirm_new_chat: false } }
+    });
+
+    const mockNavigate = vi.fn();
+    render(<NewChatButton navigate={mockNavigate} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(
+      screen.queryByText('navigation.newChat.dialog.title')
+    ).not.toBeInTheDocument();
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('opens dialog explicitly when confirm_new_chat is true', () => {
+    mockUseConfig.mockReturnValue({
+      config: { ui: { confirm_new_chat: true } }
+    });
+
+    render(<NewChatButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(
+      screen.getByText('navigation.newChat.dialog.title')
+    ).toBeInTheDocument();
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('uses custom onConfirm handler if provided', () => {
+    mockUseConfig.mockReturnValue({
+      config: { ui: { confirm_new_chat: false } }
+    });
+
+    const customOnConfirm = vi.fn();
+    render(<NewChatButton onConfirm={customOnConfirm} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(customOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+});

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -36,6 +36,7 @@ export interface IChainlitConfig {
     default_theme?: 'light' | 'dark';
     layout?: 'default' | 'wide';
     default_sidebar_state?: 'open' | 'closed';
+    confirm_new_chat?: boolean;
     cot: 'hidden' | 'tool_call' | 'full';
     github?: string;
     custom_css?: string;


### PR DESCRIPTION
- adds a new config flag to skip the confirmation dialog when creating a new chat
- default value for `confirm_new_chat` is `true` to not break existing configs 
<img width="448" height="165" alt="Bildschirmfoto 2026-01-16 um 10 46 04" src="https://github.com/user-attachments/assets/3cf03639-404d-44a6-bceb-d4d34b398beb" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI config flag to optionally skip the “New Chat” confirmation dialog. When disabled, clicking New Chat clears the chat and navigates immediately; default behavior remains unchanged.

- **New Features**
  - Backend: adds confirm_new_chat to UISettings.
  - Frontend: NewChat reads config.ui.confirm_new_chat to decide whether to show the dialog.
  - Types: adds confirm_new_chat to react-client config interface.
  - Tests: covers default behavior, true/false config, and custom onConfirm.

- **Migration**
  - To skip the dialog, set ui.confirm_new_chat: false in the config.

<sup>Written for commit 0087f44abb7ed8bc7adb25d758f4fc6b7ce6fa32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

