### PR TITLE
feat: Toggle Chat Settings for Sidebar

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -171,6 +171,12 @@ name = "Assistant"
 
 # default_sidebar_state = "open"
 
+# Chat settings display location: "message_composer" (default) or "sidebar" (header)
+# chat_settings_location = "message_composer"
+
+# Default state of chat settings sidebar when location is "sidebar"
+# default_chat_settings_open = false
+
 # Whether to prompt user confirmation on clicking 'New Chat'
 confirm_new_chat = true
 
@@ -341,32 +347,27 @@ class UISettings(BaseModel):
     language: Optional[str] = None
     layout: Optional[Literal["default", "wide"]] = "default"
     default_sidebar_state: Optional[Literal["open", "closed"]] = "open"
+    chat_settings_location: Optional[Literal["message_composer", "sidebar"]] = (
+        "message_composer"
+    )
+    default_chat_settings_open: bool = False
     confirm_new_chat: bool = True
     github: Optional[str] = None
-    # Optional custom CSS file that allows you to customize the UI
     custom_css: Optional[str] = None
     custom_css_attributes: Optional[str] = ""
-    # Optional custom JS file that allows you to customize the UI
     custom_js: Optional[str] = None
 
     alert_style: Optional[Literal["classic", "modern"]] = "classic"
     custom_js_attributes: Optional[str] = "defer"
-    # Optional custom background image for login page
     login_page_image: Optional[str] = None
     login_page_image_filter: Optional[str] = None
     login_page_image_dark_filter: Optional[str] = None
 
-    # Optional custom meta tag for URL preview
     custom_meta_url: Optional[str] = None
-    # Optional custom meta tag for image preview
     custom_meta_image_url: Optional[str] = None
-    # Optional logo file url
     logo_file_url: Optional[str] = None
-    # Optional avatar image file url
     default_avatar_file_url: Optional[str] = None
-    # Optional custom build directory for the frontend
     custom_build: Optional[str] = None
-    # Optional header links
     header_links: Optional[List[HeaderLink]] = None
 
 

--- a/frontend/src/components/ChatSettings/ChatSettingsSidebar.tsx
+++ b/frontend/src/components/ChatSettings/ChatSettingsSidebar.tsx
@@ -1,0 +1,221 @@
+import mapValues from 'lodash/mapValues';
+import { ArrowLeft } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+
+import {
+    chatSettingsValueState,
+    useChatData,
+    useChatInteract,
+    useConfig
+} from '@chainlit/react-client';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { ResizableHandle, ResizablePanel } from '@/components/ui/resizable';
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle
+} from '@/components/ui/sheet';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Translator } from 'components/i18n';
+
+import { useIsMobile } from '@/hooks/use-mobile';
+
+import { chatSettingsSidebarOpenState } from '@/state/project';
+
+import { FormInput, TFormInputValue } from './FormInput';
+
+export default function ChatSettingsSidebar() {
+    const { config } = useConfig();
+    const { chatSettingsValue, chatSettingsInputs, chatSettingsDefaultValue } =
+        useChatData();
+    const { updateChatSettings } = useChatInteract();
+    const [sidebarOpen, setSidebarOpen] = useRecoilState(
+        chatSettingsSidebarOpenState
+    );
+    const isMobile = useIsMobile();
+    const [isVisible, setIsVisible] = useState(false);
+
+    const { handleSubmit, setValue, reset, watch } = useForm({
+        defaultValues: chatSettingsValue
+    });
+    const setChatSettingsValue = useSetRecoilState(chatSettingsValueState);
+
+    useEffect(() => {
+        reset(chatSettingsValue);
+    }, [chatSettingsValue, reset]);
+
+    useEffect(() => {
+        if (config?.ui?.default_chat_settings_open && chatSettingsInputs.length > 0) {
+            setSidebarOpen(true);
+        }
+    }, [config?.ui?.default_chat_settings_open, chatSettingsInputs.length, setSidebarOpen]);
+
+    useEffect(() => {
+        if (sidebarOpen) {
+            requestAnimationFrame(() => {
+                setIsVisible(true);
+            });
+        } else {
+            setIsVisible(false);
+        }
+    }, [sidebarOpen]);
+
+    const handleClose = () => {
+        reset(chatSettingsValue);
+        setSidebarOpen(false);
+    };
+
+    const handleConfirm = handleSubmit((data) => {
+        const processedValues = mapValues(data, (x: TFormInputValue) =>
+            x !== '' ? x : null
+        );
+        updateChatSettings(processedValues);
+        setChatSettingsValue(processedValues);
+        setSidebarOpen(false);
+    });
+
+    const handleReset = () => {
+        reset(chatSettingsDefaultValue);
+    };
+
+    const handleChange = () => { };
+
+    const setFieldValue = (field: string, value: any) => {
+        setValue(field, value);
+    };
+
+    const values = watch();
+    const tabInputs = chatSettingsInputs.filter(
+        (input: any) => Array.isArray(input?.inputs) && input.inputs.length > 0
+    );
+    const regularInputs = chatSettingsInputs.filter(
+        (input: any) => !Array.isArray(input?.inputs) || input.inputs.length === 0
+    );
+    const hasTabs = tabInputs.length > 0;
+    const defaultTab = tabInputs[0]?.id;
+
+    if (!sidebarOpen || chatSettingsInputs.length === 0) return null;
+
+    const settingsContent = (
+        <>
+            {hasTabs ? (
+                <Tabs
+                    defaultValue={defaultTab}
+                    className="flex flex-col flex-grow min-h-0"
+                >
+                    <TabsList className="w-full flex justify-start flex-wrap h-auto">
+                        {tabInputs.map((tab: any) => (
+                            <TabsTrigger key={tab.id} value={tab.id}>
+                                {tab.label ?? tab.id}
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+                    {tabInputs.map((tab: any) => (
+                        <TabsContent
+                            key={tab.id}
+                            value={tab.id}
+                            className="data-[state=active]:flex flex-col flex-grow overflow-y-auto gap-4 p-1 mt-4"
+                        >
+                            {tab.inputs?.map((input: any) => (
+                                <FormInput
+                                    key={input.id}
+                                    element={{
+                                        ...input,
+                                        value: values[input.id],
+                                        onChange: handleChange,
+                                        setField: setFieldValue
+                                    }}
+                                />
+                            ))}
+                        </TabsContent>
+                    ))}
+                </Tabs>
+            ) : (
+                <div className="flex flex-col flex-grow overflow-y-auto gap-4 p-1">
+                    {regularInputs.map((input: any) => (
+                        <FormInput
+                            key={input.id}
+                            element={{
+                                ...input,
+                                value: values[input.id],
+                                onChange: handleChange,
+                                setField: setFieldValue
+                            }}
+                        />
+                    ))}
+                </div>
+            )}
+            <div className="flex gap-2 pt-4 border-t">
+                <Button variant="outline" size="sm" onClick={handleReset}>
+                    <Translator path="common.actions.reset" />
+                </Button>
+                <div className="flex-1" />
+                <Button variant="ghost" size="sm" onClick={handleClose}>
+                    <Translator path="common.actions.cancel" />
+                </Button>
+                <Button size="sm" onClick={handleConfirm} id="confirm-sidebar">
+                    <Translator path="common.actions.confirm" />
+                </Button>
+            </div>
+        </>
+    );
+
+    if (isMobile) {
+        return (
+            <Sheet open onOpenChange={(open) => !open && handleClose()}>
+                <SheetContent className="flex flex-col md:hidden">
+                    <SheetHeader>
+                        <SheetTitle id="chat-settings-sidebar-title">
+                            <Translator path="chat.settings.title" />
+                        </SheetTitle>
+                    </SheetHeader>
+                    <div className="overflow-y-auto flex-grow flex flex-col gap-4 mt-4">
+                        {settingsContent}
+                    </div>
+                </SheetContent>
+            </Sheet>
+        );
+    }
+
+    return (
+        <>
+            <ResizableHandle className="sm:hidden md:block bg-transparent" />
+            <ResizablePanel
+                minSize={15}
+                defaultSize={25}
+                className={`md:flex flex-col flex-grow sm:hidden transform transition-transform duration-300 ease-in-out ${isVisible ? 'translate-x-0' : 'translate-x-full'
+                    }`}
+            >
+                <aside className="relative flex-grow overflow-y-auto mr-4 mb-4">
+                    <Card className="overflow-y-auto h-full relative flex flex-col">
+                        <div
+                            id="chat-settings-sidebar-title"
+                            className="text-lg font-semibold text-foreground px-6 py-4 flex items-center"
+                        >
+                            <Button
+                                className="-ml-2"
+                                onClick={handleClose}
+                                size="icon"
+                                variant="ghost"
+                            >
+                                <ArrowLeft />
+                            </Button>
+                            <Translator path="chat.settings.title" />
+                        </div>
+                        <CardContent
+                            id="chat-settings-sidebar-content"
+                            className="flex flex-col flex-grow gap-4 overflow-y-auto"
+                        >
+                            {settingsContent}
+                        </CardContent>
+                    </Card>
+                </aside>
+            </ResizablePanel>
+        </>
+    );
+}

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -13,7 +13,8 @@ import {
   IStep,
   useAuth,
   useChatData,
-  useChatInteract
+  useChatInteract,
+  useConfig
 } from '@chainlit/react-client';
 import type { IMode, IModeOption } from '@chainlit/react-client';
 import { modesState } from '@chainlit/react-client';
@@ -70,6 +71,11 @@ export default function MessageComposer({
   const { askUser, chatSettingsInputs, disabled: _disabled } = useChatData();
 
   const disabled = _disabled || !!attachments.find((a) => !a.uploaded);
+
+  const { config } = useConfig();
+  const showSettingsInComposer =
+    config?.ui?.chat_settings_location !== 'sidebar' &&
+    chatSettingsInputs.length > 0;
 
   const isMobile = useIsMobile();
 
@@ -267,7 +273,7 @@ export default function MessageComposer({
             onFileUploadError={onFileUploadError}
             onFileUpload={onFileUpload}
           />
-          {chatSettingsInputs.length > 0 && (
+          {showSettingsInComposer && (
             <Button
               id="chat-settings-open-modal"
               disabled={disabled}

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -1,11 +1,22 @@
 import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
-import { useAudio, useAuth, useConfig } from '@chainlit/react-client';
+import { useAudio, useAuth, useChatData, useConfig } from '@chainlit/react-client';
 
 import AudioPresence from '@/components/AudioPresence';
 import ButtonLink from '@/components/ButtonLink';
+import { Settings } from '@/components/icons/Settings';
+import { Button } from '@/components/ui/button';
 import { useSidebar } from '@/components/ui/sidebar';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
+import { Translator } from 'components/i18n';
+
+import { chatSettingsSidebarOpenState } from '@/state/project';
 
 import ApiKeys from './ApiKeys';
 import ChatProfiles from './ChatProfiles';
@@ -21,13 +32,21 @@ const Header = memo(() => {
   const navigate = useNavigate();
   const { data } = useAuth();
   const { config } = useConfig();
+  const { chatSettingsInputs } = useChatData();
   const { open, openMobile, isMobile } = useSidebar();
+  const setChatSettingsSidebarOpen = useSetRecoilState(
+    chatSettingsSidebarOpenState
+  );
 
   const sidebarOpen = isMobile ? openMobile : open;
 
   const historyEnabled = data?.requireLogin && config?.dataPersistence;
 
   const links = config?.ui?.header_links || [];
+
+  const showSettingsInHeader =
+    config?.ui?.chat_settings_location === 'sidebar' &&
+    chatSettingsInputs.length > 0;
 
   return (
     <div
@@ -75,6 +94,24 @@ const Header = memo(() => {
               target={link.target}
             />
           ))}
+        {showSettingsInHeader && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                id="chat-settings-header-button"
+                onClick={() => setChatSettingsSidebarOpen(true)}
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:text-muted-foreground"
+              >
+                <Settings className="!size-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <Translator path="chat.settings.title" />
+            </TooltipContent>
+          </Tooltip>
+        )}
         <ThemeToggle />
         <UserNav />
       </div>

--- a/frontend/src/pages/Page.tsx
+++ b/frontend/src/pages/Page.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { sideViewState, useAuth, useConfig } from '@chainlit/react-client';
 
+import ChatSettingsSidebar from '@/components/ChatSettings/ChatSettingsSidebar';
 import ElementSideView from '@/components/ElementSideView';
 import LeftSidebar from '@/components/LeftSidebar';
 import { TaskList } from '@/components/Tasklist';
@@ -28,6 +29,8 @@ const Page = ({ children }: Props) => {
     }
   }
 
+  const showSettingsSidebar = config?.ui?.chat_settings_location === 'sidebar';
+
   const mainContent = (
     <div className="flex flex-col h-full w-full">
       <Header />
@@ -45,6 +48,7 @@ const Page = ({ children }: Props) => {
           </div>
         </ResizablePanel>
         {sideView ? <ElementSideView /> : <TaskList isMobile={false} />}
+        {showSettingsSidebar && <ChatSettingsSidebar />}
       </ResizablePanelGroup>
     </div>
   );

--- a/frontend/src/state/project.ts
+++ b/frontend/src/state/project.ts
@@ -4,3 +4,8 @@ export const chatSettingsOpenState = atom<boolean>({
   key: 'chatSettingsOpen',
   default: false
 });
+
+export const chatSettingsSidebarOpenState = atom<boolean>({
+  key: 'chatSettingsSidebarOpen',
+  default: false
+});

--- a/libs/react-client/src/types/config.ts
+++ b/libs/react-client/src/types/config.ts
@@ -36,6 +36,8 @@ export interface IChainlitConfig {
     default_theme?: 'light' | 'dark';
     layout?: 'default' | 'wide';
     default_sidebar_state?: 'open' | 'closed';
+    chat_settings_location?: 'message_composer' | 'sidebar';
+    default_chat_settings_open?: boolean;
     confirm_new_chat?: boolean;
     cot: 'hidden' | 'tool_call' | 'full';
     github?: string;


### PR DESCRIPTION
### Feature: Chat Settings Sidebar

This PR adds a configuration option to display chat settings in a dedicated sidebar instead of the default message composer modal.

#### Changes
- **Backend**: Added `chat_settings_location` and `default_chat_settings_open` options to [UISettings](cci:2://file:///c:/Users/Haze/Desktop/chainlit/backend/chainlit/config.py:341:0-370:51).
- **Frontend**: Implemented [ChatSettingsSidebar](cci:1://file:///c:/Users/Haze/Desktop/chainlit/frontend/src/components/ChatSettings/ChatSettingsSidebar.tsx:31:0-220:1) using the `ResizablePanel` pattern.
- **UI**: Added a settings gear icon to the header (left of theme toggle) that toggles the sidebar.

#### Configuration
To enable the sidebar mode:

```toml
[UI]
chat_settings_location = "sidebar"
default_chat_settings_open = true
```

<img width="2864" height="1531" alt="image" src="https://github.com/user-attachments/assets/1af8ef3d-5b1e-4a73-ac2c-c2b99744eb54" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional chat settings sidebar with a header toggle. When enabled, settings move from the message composer modal to a resizable right sidebar that can open by default.

- **New Features**
  - Backend: Added UISettings options chat_settings_location ("message_composer" | "sidebar") and default_chat_settings_open; updated react-client config types.
  - Frontend: New ChatSettingsSidebar (resizable on desktop, Sheet on mobile).
  - Header: Added gear button to toggle the sidebar (shown only when settings exist).
  - Composer: Hides the settings modal trigger when sidebar mode is enabled.

- **Migration**
  - To enable: UI.chat_settings_location = "sidebar".
  - Optional: UI.default_chat_settings_open = true to open the sidebar on load.

<sup>Written for commit 5bf65eeec77675ce079c14c7176917cb8a96be0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

