### PR TITLE
feat: ORM SQLAlchemyDataLayer

### DIFF
--- a/backend/chainlit/data/models.py
+++ b/backend/chainlit/data/models.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import Boolean, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON, TypeDecorator
+
+
+class CrossDialectJSON(TypeDecorator):
+    """JSON type that uses JSONB on PostgreSQL and JSON on other databases."""
+
+    impl = JSON
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(JSONB())
+        return dialect.type_descriptor(JSON())
+
+
+class Base(DeclarativeBase):
+    """Shared base for all ORM models. Required so Base.metadata.create_all() discovers all tables."""
+
+    pass
+
+
+class UserModel(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    identifier: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    metadata_: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        "metadata", CrossDialectJSON, nullable=True, default=dict
+    )
+    createdAt: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
+    threads: Mapped[list[ThreadModel]] = relationship(
+        back_populates="user", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+
+class ThreadModel(Base):
+    __tablename__ = "threads"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    createdAt: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    userId: Mapped[Optional[str]] = mapped_column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=True
+    )
+    userIdentifier: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    tags: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    metadata_: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        "metadata", CrossDialectJSON, nullable=True
+    )
+
+    user: Mapped[Optional[UserModel]] = relationship(back_populates="threads")
+    steps: Mapped[list[StepModel]] = relationship(
+        back_populates="thread", cascade="all, delete-orphan", passive_deletes=True
+    )
+    elements: Mapped[list[ElementModel]] = relationship(
+        back_populates="thread",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        foreign_keys="ElementModel.threadId",
+    )
+
+
+class StepModel(Base):
+    __tablename__ = "steps"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    threadId: Mapped[str] = mapped_column(
+        String(36), ForeignKey("threads.id", ondelete="CASCADE"), nullable=False
+    )
+    parentId: Mapped[Optional[str]] = mapped_column(String(36), nullable=True)
+    disableFeedback: Mapped[Optional[bool]] = mapped_column(
+        Boolean, nullable=True, default=False
+    )
+    streaming: Mapped[Optional[bool]] = mapped_column(
+        Boolean, nullable=True, default=False
+    )
+    waitForAnswer: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    isError: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    metadata_: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        "metadata", CrossDialectJSON, nullable=True
+    )
+    tags: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    input: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    output: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    createdAt: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    start: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    end: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    generation: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        CrossDialectJSON, nullable=True
+    )
+    showInput: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    language: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    indent: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    thread: Mapped[ThreadModel] = relationship(back_populates="steps")
+    feedbacks: Mapped[list[FeedbackModel]] = relationship(
+        back_populates="step", cascade="all, delete-orphan", passive_deletes=True
+    )
+    elements: Mapped[list[ElementModel]] = relationship(
+        back_populates="step",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+        foreign_keys="ElementModel.forId",
+    )
+
+
+class ElementModel(Base):
+    __tablename__ = "elements"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    threadId: Mapped[Optional[str]] = mapped_column(
+        String(36), ForeignKey("threads.id", ondelete="CASCADE"), nullable=True
+    )
+    type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    chainlitKey: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    display: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    objectKey: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    size: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    page: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    language: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    forId: Mapped[Optional[str]] = mapped_column(
+        String(36), ForeignKey("steps.id", ondelete="CASCADE"), nullable=True
+    )
+    mime: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    props: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    autoPlay: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    playerConfig: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    thread: Mapped[Optional[ThreadModel]] = relationship(
+        back_populates="elements", foreign_keys=[threadId]
+    )
+    step: Mapped[Optional[StepModel]] = relationship(
+        back_populates="elements", foreign_keys=[forId]
+    )
+
+
+class FeedbackModel(Base):
+    __tablename__ = "feedbacks"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    forId: Mapped[str] = mapped_column(
+        String(36), ForeignKey("steps.id", ondelete="CASCADE"), nullable=False
+    )
+    threadId: Mapped[str] = mapped_column(String(36), nullable=False)
+    value: Mapped[int] = mapped_column(Integer, nullable=False)
+    comment: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    step: Mapped[StepModel] = relationship(back_populates="feedbacks")

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -612,7 +612,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
             "forId": element.for_id,
             "mime": element.mime,
             "props": json.dumps(element_dict.get("props", {})),
-            "autoPlay": getattr(element, "autoPlay", None),
+            "autoPlay": element_dict.get("autoPlay"),
             "playerConfig": getattr(element, "playerConfig", None),
         }
         values = {k: v for k, v in values.items() if v is not None}

--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -613,7 +613,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
             "mime": element.mime,
             "props": json.dumps(element_dict.get("props", {})),
             "autoPlay": element_dict.get("autoPlay"),
-            "playerConfig": getattr(element, "playerConfig", None),
+            "playerConfig": element_dict.get("playerConfig"),
         }
         values = {k: v for k, v in values.items() if v is not None}
         if "name" not in values:

--- a/backend/tests/data/test_sql_alchemy.py
+++ b/backend/tests/data/test_sql_alchemy.py
@@ -2,8 +2,6 @@ import uuid
 from pathlib import Path
 
 import pytest
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import create_async_engine
 
 from chainlit import User
 from chainlit.data.sql_alchemy import SQLAlchemyDataLayer
@@ -16,109 +14,10 @@ async def data_layer(mock_storage_client: BaseStorageClient, tmp_path: Path):
     db_file = tmp_path / "test_db.sqlite"
     conninfo = f"sqlite+aiosqlite:///{db_file}"
 
-    # Create async engine
-    engine = create_async_engine(conninfo)
-
-    # Execute initialization statements
-    # Ref: https://docs.chainlit.io/data-persistence/custom#sql-alchemy-data-layer
-    async with engine.begin() as conn:
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE users (
-                    "id" UUID PRIMARY KEY,
-                    "identifier" TEXT NOT NULL UNIQUE,
-                    "metadata" JSONB NOT NULL,
-                    "createdAt" TEXT
-                );
-        """
-            )
-        )
-
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS threads (
-                    "id" UUID PRIMARY KEY,
-                    "createdAt" TEXT,
-                    "name" TEXT,
-                    "userId" UUID,
-                    "userIdentifier" TEXT,
-                    "tags" TEXT[],
-                    "metadata" JSONB,
-                    FOREIGN KEY ("userId") REFERENCES users("id") ON DELETE CASCADE
-                );
-        """
-            )
-        )
-
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS steps (
-                    "id" UUID PRIMARY KEY,
-                    "name" TEXT NOT NULL,
-                    "type" TEXT NOT NULL,
-                    "threadId" UUID NOT NULL,
-                    "parentId" UUID,
-                    "disableFeedback" BOOLEAN NOT NULL,
-                    "streaming" BOOLEAN NOT NULL,
-                    "waitForAnswer" BOOLEAN,
-                    "isError" BOOLEAN,
-                    "metadata" JSONB,
-                    "tags" TEXT[],
-                    "input" TEXT,
-                    "output" TEXT,
-                    "createdAt" TEXT,
-                    "start" TEXT,
-                    "end" TEXT,
-                    "generation" JSONB,
-                    "showInput" TEXT,
-                    "language" TEXT,
-                    "indent" INT
-                );
-        """
-            )
-        )
-
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS elements (
-                    "id" UUID PRIMARY KEY,
-                    "threadId" UUID,
-                    "type" TEXT,
-                    "url" TEXT,
-                    "chainlitKey" TEXT,
-                    "name" TEXT NOT NULL,
-                    "display" TEXT,
-                    "objectKey" TEXT,
-                    "size" TEXT,
-                    "page" INT,
-                    "language" TEXT,
-                    "forId" UUID,
-                    "mime" TEXT
-                );
-        """
-            )
-        )
-
-        await conn.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS feedbacks (
-                    "id" UUID PRIMARY KEY,
-                    "forId" UUID NOT NULL,
-                    "threadId" UUID NOT NULL,
-                    "value" INT NOT NULL,
-                    "comment" TEXT
-                );
-        """
-            )
-        )
-
-    # Create SQLAlchemyDataLayer instance
-    data_layer = SQLAlchemyDataLayer(conninfo, storage_provider=mock_storage_client)
+    # Create SQLAlchemyDataLayer instance with automatic table creation
+    data_layer = SQLAlchemyDataLayer(
+        conninfo, storage_provider=mock_storage_client, create_tables=True
+    )
 
     return data_layer
 


### PR DESCRIPTION
## Refactor SQLAlchemyDataLayer to use ORM

### Summary

Refactors [sql_alchemy.py](cci:7://file:///c:/Users/Haze/Desktop/chainlit/backend/chainlit/data/sql_alchemy.py:0:0-0:0) from raw SQL queries to SQLAlchemy ORM, improving maintainability and adding multi-dialect database support.

### Benefits

- **Multi-dialect support**: Now works with PostgreSQL, SQLite, and MySQL/MariaDB out of the box
- **Type safety**: ORM models provide better IDE autocompletion and type checking
- **Reduced code duplication**: Removed ~200 lines of repetitive SQL string construction
- **Automatic schema creation**: New `create_tables=True` parameter auto-creates tables on first use
- **Easier testing**: Test fixtures reduced from 100+ lines of manual SQL to 4 lines

### What's New

| File | Description |
|------|-------------|
| [chainlit/data/models.py](cci:7://file:///c:/Users/Haze/Desktop/chainlit/backend/chainlit/data/models.py:0:0-0:0) | New ORM models with [CrossDialectJSON](cci:2://file:///c:/Users/Haze/Desktop/chainlit/backend/chainlit/data/models.py:10:0-19:46) type for PostgreSQL/SQLite/MySQL compatibility |
| [chainlit/data/sql_alchemy.py](cci:7://file:///c:/Users/Haze/Desktop/chainlit/backend/chainlit/data/sql_alchemy.py:0:0-0:0) | Refactored to use ORM operations instead of raw SQL |

### Migration

**No breaking changes** - the public API remains identical.

**Optional**: Users can now enable automatic table creation:

```python
from chainlit.data.sql_alchemy import SQLAlchemyDataLayer

data_layer = SQLAlchemyDataLayer(
    conninfo="sqlite+aiosqlite:///data.db",
    create_tables=True,  # NEW: Auto-creates tables if they don't exist
)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors SQLAlchemyDataLayer to use SQLAlchemy ORM, adding multi-dialect support and optional automatic table creation. Improves maintainability and type safety, keeps the public API unchanged, and simplifies tests.

- **New Features**
  - Works with PostgreSQL, SQLite, and MySQL/MariaDB.
  - Optional create_tables=True to auto-create tables.
  - CrossDialectJSON for JSONB on Postgres and JSON elsewhere.

- **Refactors**
  - Replaced raw SQL with ORM models and session-based operations; unified per-dialect upsert.
  - Removed SQL helpers and duplicated query code.
  - Simplified tests by enabling automatic schema creation.

<sup>Written for commit 469274c210d66b2a46129c4f6e6d5de0a514bed0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

