### PR TITLE
Fix: Resolve transparent UI issue in Copilot Light Mode

### DIFF
--- a/libs/copilot/src/index.css
+++ b/libs/copilot/src/index.css
@@ -16,7 +16,7 @@
 }
 
 @layer base {
-  #shadow-root-container {
+  #cl-shadow-root {
     --font-sans: 'Inter', sans-serif;
     --font-mono: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
     --background: 0 0% 100%;
@@ -53,7 +53,9 @@
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-  .dark {
+  #cl-shadow-root.light {
+  }
+  #cl-shadow-root.dark {
     --background: 0 0% 13%;
     --foreground: 0 0% 93%;
     --card: 0 0% 18%;


### PR DESCRIPTION
### Description:
This PR fixes an issue where the Chainlit Copilot UI appeared transparent when using Light Mode.

### Problem:
The CSS variables for the default theme (Light Mode) were targeting the #shadow-root-container ID, but the actual container element uses the ID #cl-shadow-root. As a result, the base styles were not being applied, causing transparency issues. Dark Mode was unaffected as it relies on class-specific overrides, though the selector needed refinement there as well.

<img width="559" height="676" alt="image" src="https://github.com/user-attachments/assets/bab4ebe3-3bd2-4e81-aa08-a38317ad364c" />
(before)

### Changes:

- Updated the CSS selector from #shadow-root-container to #cl-shadow-root to correctly target the Copilot container.
- Applied the base CSS variables to #cl-shadow-root as the default (Light Mode) state.
- Refactored .dark to #cl-shadow-root.dark to strictly scope the dark theme styles to the shadow root container.

### Verification:
I have verified that the UI renders correctly in both Light and Dark modes with these changes.

<img width="582" height="971" alt="image" src="https://github.com/user-attachments/assets/9bb69fb1-a9cc-46c6-8928-aa69ca93e7c3" />
(after)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Copilot transparency in Light Mode by applying base CSS variables to the correct shadow root container. Dark Mode styles are scoped to the container for consistent theming.

- **Bug Fixes**
  - Target #cl-shadow-root for base (Light Mode) variables.
  - Scope dark theme to #cl-shadow-root.dark; add #cl-shadow-root.light for explicit theming.
  - Verified correct rendering in both Light and Dark modes.

<sup>Written for commit 4cf96558c47f1a5ade1166006586a33f06ed35d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

