### PR TITLE
Fixed issue where sidebarinset expands beyond parent causing horizontal scroll

### DIFF
--- a/frontend/src/pages/Page.tsx
+++ b/frontend/src/pages/Page.tsx
@@ -62,7 +62,9 @@ const Page = ({ children }: Props) => {
       {historyEnabled ? (
         <>
           <LeftSidebar />
-          <SidebarInset className="max-h-svh">{mainContent}</SidebarInset>
+          <SidebarInset className="max-h-svh min-w-0">
+            {mainContent}
+          </SidebarInset>
         </>
       ) : (
         <div className="h-screen w-screen flex">{mainContent}</div>


### PR DESCRIPTION
This is a know issue with the shadcn sidebar, more on this here : https://github.com/shadcn-ui/ui/issues/5545

<img width="1190" height="1047" alt="Capture d&#39;écran 2026-02-03 161121" src="https://github.com/user-attachments/assets/f7a31c21-1ee6-4946-a385-06bdbdbf5c3d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents horizontal scrolling by keeping SidebarInset within its parent. Adds min-w-0 to SidebarInset so the flex layout can shrink it and avoid overflow.

<sup>Written for commit 2271cba05eeea117efcc7fc82a1299fdfcb8c1fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

