### PR TITLE
fix: initialize user_can_view before conditional check

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1005,6 +1005,7 @@ async def get_shared_thread(
     if not isinstance(metadata, dict):
         metadata = {}
 
+    user_can_view = False
     if getattr(config.code, "on_shared_thread_view", None):
         try:
             user_can_view = await config.code.on_shared_thread_view(


### PR DESCRIPTION
## Summary

Fixes `UnboundLocalError` when the `@cl.on_shared_thread_view` hook is not defined.

## Problem

In `backend/chainlit/server.py`, the `user_can_view` variable was only assigned inside the optional `on_shared_thread_view` hook block, but was used unconditionally in the subsequent check at line 1019:

```python
if (not user_can_view) and (not is_shared):
```

When the hook is not defined/registered, this caused:
```
UnboundLocalError: cannot access local variable 'user_can_view' where it is not associated with a value
```

## Solution

Initialize `user_can_view = False` before the conditional block, ensuring the variable is always defined regardless of whether the hook exists.

## Changes

```diff
+    user_can_view = False
     if getattr(config.code, "on_shared_thread_view", None):
```

## Testing

1. Create a minimal Chainlit app without defining `@cl.on_shared_thread_view`
2. Start the server
3. Access a shared thread URL
4. Verify no `UnboundLocalError` is raised

## Related Issue

Fixes #2766

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize user_can_view to False before the shared-thread access check to prevent UnboundLocalError when @cl.on_shared_thread_view is not defined. This ensures apps without the hook handle shared thread views without crashing.

<sup>Written for commit 5e5e00c6b9fbc813e75bee13f7c39b117087deff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

