### PR TITLE
fix: initialize user_can_view before conditional block

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1005,6 +1005,7 @@ async def get_shared_thread(
     if not isinstance(metadata, dict):
         metadata = {}
 
+    user_can_view = False
     if getattr(config.code, "on_shared_thread_view", None):
         try:
             user_can_view = await config.code.on_shared_thread_view(


### PR DESCRIPTION
Fixes #2766

When `@cl.on_shared_thread_view` hook is not defined, `user_can_view` was never initialized, causing an `UnboundLocalError` when the variable was referenced.

This initializes `user_can_view = False` before the conditional block to provide a safe default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize user_can_view = False in get_shared_thread to avoid UnboundLocalError when on_shared_thread_view isn’t defined.

<sup>Written for commit f145ceb3fbc78dfe915df71087f71bd4d8bac6f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

