### PR TITLE
fix: initialize user_can_view before conditional hook check

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1012,6 +1012,7 @@ async def get_shared_thread(
     if not isinstance(metadata, dict):
         metadata = {}
 
+    user_can_view = False
     if getattr(config.code, "on_shared_thread_view", None):
         try:
             user_can_view = await config.code.on_shared_thread_view(


### PR DESCRIPTION
## Summary

- Fixes `UnboundLocalError: cannot access local variable 'user_can_view'` when `@cl.on_shared_thread_view` hook is not defined
- Initializes `user_can_view = False` before the conditional block that checks for the hook, ensuring the variable always has a value when evaluated on the subsequent guard check

Fixes #2766

## Root Cause

In `get_shared_thread()`, the variable `user_can_view` is only assigned inside the `if getattr(config.code, "on_shared_thread_view", None):` block. When the hook is not defined, this block is skipped entirely, but `user_can_view` is still referenced on the next line:

```python
if (not user_can_view) and (not is_shared):
```

This raises an `UnboundLocalError`.

## Fix

Add `user_can_view = False` as a safe default before the conditional hook check. This is consistent with the behavior inside the `except` block which also defaults to `False`.

## Test plan

- [ ] Start a Chainlit app **without** defining `@cl.on_shared_thread_view`
- [ ] Access a shared thread endpoint (`/project/share/{thread_id}`)
- [ ] Verify no `UnboundLocalError` is raised
- [ ] Verify that shared threads with `is_shared=True` metadata are still accessible
- [ ] Verify that non-shared threads correctly return 404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize user_can_view to False before checking for on_shared_thread_view in get_shared_thread. This avoids UnboundLocalError when the hook is missing and keeps shared vs. non-shared access checks working as expected.

<sup>Written for commit 1f7a0cedd2c6d715f2dc301e55eef46b694d28e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

