### PR TITLE
fix: convert UUID fields to strings in _extract_feedback_dict_from_step_row

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -661,8 +661,8 @@ class ChainlitDataLayer(BaseDataLayer):
     def _extract_feedback_dict_from_step_row(self, row: Dict) -> Optional[FeedbackDict]:
         if row.get("feedback_id", None) is not None:
             return FeedbackDict(
-                forId=row["id"],
-                id=row["feedback_id"],
+                forId=str(row["id"]),
+                id=str(row["feedback_id"]),
                 value=row["feedback_value"],
                 comment=row["feedback_comment"],
             )


### PR DESCRIPTION
## Summary

  `asyncpg` returns raw `uuid.UUID` objects from PostgreSQL. The sibling method
  `_convert_step_row_to_dict` already wraps UUID fields with `str()`, but
  `_extract_feedback_dict_from_step_row` was passing them through raw. This
  caused `TypeError: Object of type UUID is not JSON serializable` when
  resuming a thread via the sidebar.

  ## Changes

  - Wrapped `row["id"]` and `row["feedback_id"]` with `str()` in
    `_extract_feedback_dict_from_step_row` to match the pattern used in
    `_convert_step_row_to_dict`.

  ## Test plan

  - Verified the fix resolves the JSON serialization error when resuming
    threads with feedback in the PostgreSQL data layer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted UUID fields to strings in _extract_feedback_dict_from_step_row to prevent JSON serialization errors when resuming threads from the sidebar. Wraps row['id'] and row['feedback_id'] with str() to match _convert_step_row_to_dict.

<sup>Written for commit 87091f5033f3baf0ee3272ed03a1a2d57cbadf46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

