### PR TITLE
fix: use error detail for login credential error messages

### DIFF
--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -8,6 +8,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import Translator, { useTranslation } from 'components/i18n/Translator';
 
+import { ClientError } from '@chainlit/react-client';
+
 import Alert from './Alert';
 import { ProviderButton } from './ProviderButton';
 
@@ -63,7 +65,9 @@ export function LoginForm({
     try {
       await onPasswordSignIn(data.email, data.password, callbackUrl);
     } catch (err) {
-      if (err instanceof Error) {
+      if (err instanceof ClientError && err.detail) {
+        setErrorState(err.detail);
+      } else if (err instanceof Error) {
         setErrorState(err.message);
       }
     } finally {


### PR DESCRIPTION
## Summary
Fixes #2787

The login form displayed the wrong error message for incorrect credentials because it read `error.message` (HTTP status text like "Unauthorized") instead of `error.detail` (the actual error reason like "credentialsSignin").

## Changes
- Import `ClientError` from `@chainlit/react-client` in `LoginForm.tsx`
- Updated the catch block to check for `ClientError.detail` first, which contains the meaningful error reason (e.g., "credentialsSignin")
- Falls back to `Error.message` when `detail` is not available, preserving backward compatibility

## How it works

When the `/login` endpoint returns an error, the `fetch` wrapper in `api/index.tsx` creates a `ClientError` with:
- `message` = HTTP status text (e.g., "Unauthorized")
- `detail` = parsed response body detail (e.g., "credentialsSignin")

Previously, `LoginForm` used `err.message` for the translation key lookup (`auth.login.errors.unauthorized`), which didn't match any translation. Now it uses `err.detail` (`auth.login.errors.credentialssignin`), which correctly maps to the intended error message.

## Test Plan
- [x] Enter incorrect credentials on the login screen -> proper translated error message is displayed
- [x] Non-ClientError exceptions still display `error.message` as before
- [x] ClientError without detail falls back to `error.message`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2787. Use ClientError.detail in LoginForm so invalid credential attempts display the correct translated error, falling back to Error.message when detail is missing.

<sup>Written for commit 18a81871ba08e5faf964b29ca82fc2ba4a0c7a60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

