### PR TITLE
feat(copilot): add openChainlitCopilot and closeChainlitCopilot functions

### DIFF
--- a/libs/copilot/index.tsx
+++ b/libs/copilot/index.tsx
@@ -30,6 +30,8 @@ declare global {
     mountChainlitWidget: (config: IWidgetConfig) => void;
     unmountChainlitWidget: () => void;
     toggleChainlitCopilot: () => void;
+    openChainlitCopilot: () => void;
+    closeChainlitCopilot: () => void;
     sendChainlitMessage: (message: IStep) => void;
     getChainlitCopilotThreadId: () => string | null;
     clearChainlitCopilotThreadId: (newThreadId?: string) => void;

--- a/libs/copilot/src/app.tsx
+++ b/libs/copilot/src/app.tsx
@@ -22,6 +22,8 @@ declare global {
   interface Window {
     cl_shadowRootElement: HTMLDivElement;
     toggleChainlitCopilot: () => void;
+    openChainlitCopilot: () => void;
+    closeChainlitCopilot: () => void;
     theme?: {
       light: Record<string, string>;
       dark: Record<string, string>;

--- a/libs/copilot/src/widget.tsx
+++ b/libs/copilot/src/widget.tsx
@@ -32,11 +32,15 @@ const Widget = ({ config, error }: Props) => {
 
   useEffect(() => {
     window.toggleChainlitCopilot = () => setIsOpen((prev) => !prev);
+    window.openChainlitCopilot = () => setIsOpen(true);
+    window.closeChainlitCopilot = () => setIsOpen(false);
     window.getChainlitCopilotThreadId = getChainlitCopilotThreadId;
     window.clearChainlitCopilotThreadId = clearChainlitCopilotThreadId;
 
     return () => {
       window.toggleChainlitCopilot = () => console.error('Widget not mounted.');
+      window.openChainlitCopilot = () => console.error('Widget not mounted.');
+      window.closeChainlitCopilot = () => console.error('Widget not mounted.');
       window.getChainlitCopilotThreadId = () => null;
 
       window.clearChainlitCopilotThreadId = () =>


### PR DESCRIPTION
## Summary

Adds two new window functions for programmatic control of the copilot widget:

- `window.openChainlitCopilot()` - explicitly opens the copilot chat window
- `window.closeChainlitCopilot()` - explicitly closes the copilot chat window

These complement the existing `window.toggleChainlitCopilot()` function by allowing host pages to set a specific open/close state without needing to track the current state of the widget.

## Motivation

As described in #2579, the toggle-only API is insufficient for common use cases like:
- Auto-opening the chat after a delay (e.g., `setTimeout(() => window.openChainlitCopilot(), 5000)`) without disturbing users who already opened it
- Closing the copilot in response to an external event without risking accidentally opening it
- Integrating with external UI components that have explicit open/close semantics

## Changes

- **`libs/copilot/index.tsx`**: Added `openChainlitCopilot` and `closeChainlitCopilot` to the global `Window` interface type declarations
- **`libs/copilot/src/app.tsx`**: Added the same type declarations to the duplicate `Window` interface
- **`libs/copilot/src/widget.tsx`**: Implemented the two functions using `setIsOpen(true)` and `setIsOpen(false)`, with proper cleanup on unmount (matching the existing pattern for `toggleChainlitCopilot`)

## Test plan

- [ ] Mount the copilot widget and call `window.openChainlitCopilot()` from the browser console - copilot should open
- [ ] Call `window.openChainlitCopilot()` when already open - should remain open (no-op)
- [ ] Call `window.closeChainlitCopilot()` - copilot should close
- [ ] Call `window.closeChainlitCopilot()` when already closed - should remain closed (no-op)
- [ ] Call `window.toggleChainlitCopilot()` - should still work as before
- [ ] Unmount widget and call `window.openChainlitCopilot()` - should log error to console

Closes #2579

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add window.openChainlitCopilot() and window.closeChainlitCopilot() to let host pages explicitly open or close the Copilot chat. This complements the existing toggle and enables safe auto-open/close flows without tracking state.

- **New Features**
  - Exposed openChainlitCopilot and closeChainlitCopilot on window; added type declarations in libs/copilot/index.tsx and libs/copilot/src/app.tsx.
  - Implemented in libs/copilot/src/widget.tsx via setIsOpen(true/false) with error logging when the widget is unmounted.

<sup>Written for commit 94a03a1bf2ac8ff9a1ce01d48bea400793bf1c29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

