### PR TITLE
Fix inconsistent ISO timestamp formatting causing ValueError on step update

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -697,8 +697,12 @@ class ChainlitDataLayer(BaseDataLayer):
             input=row.get("input", {}),
             output=row.get("output", {}),
             metadata=json.loads(row.get("metadata", "{}")),
-            createdAt=_datetime_to_utc_iso(row["createdAt"]) if row.get("createdAt") else None,
-            start=_datetime_to_utc_iso(row["startTime"]) if row.get("startTime") else None,
+            createdAt=_datetime_to_utc_iso(row["createdAt"])
+            if row.get("createdAt")
+            else None,
+            start=_datetime_to_utc_iso(row["startTime"])
+            if row.get("startTime")
+            else None,
             showInput=row.get("showInput"),
             isError=row.get("isError"),
             end=_datetime_to_utc_iso(row["endTime"]) if row.get("endTime") else None,

--- a/backend/tests/data/test_chainlit_data_layer.py
+++ b/backend/tests/data/test_chainlit_data_layer.py
@@ -24,8 +24,7 @@ class TestParseIsoDatetime:
 
     def test_parse_without_z_raises_on_bad_format(self):
         """Test that invalid format still raises ValueError."""
-        # noqa: PT011 - _parse_iso_datetime forwards ValueError from datetime.strptime.
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="does not match format"):
             _parse_iso_datetime("2025-09-04 02:00:42")
 
     def test_roundtrip_with_z(self):


### PR DESCRIPTION
## Summary

Fixes #2491

`ChainlitDataLayer` saves timestamps with a trailing `Z` (e.g., `2025-09-04T02:00:42.164000Z`) via `ISO_FORMAT`, but reads them back using Python's `.isoformat()` which omits the `Z` (e.g., `2025-09-04T02:00:42.164000`). When `update_step` calls `create_step` with the read-back `createdAt` string, `strptime` fails with:

```
ValueError: time data '2025-09-04T02:00:42.164000' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

### Changes

- Add `_parse_iso_datetime()` helper that tolerates both with and without trailing `Z`
- Add `_datetime_to_utc_iso()` helper that ensures all datetime-to-string conversions consistently include the trailing `Z`
- Replace all bare `.isoformat()` calls with `_datetime_to_utc_iso()` across user, thread, and step serialization
- Replace `datetime.strptime(created_at, ISO_FORMAT)` with `_parse_iso_datetime(created_at)` in `create_step`
- Switch `datetime.now()` to `datetime.utcnow()` in `get_current_timestamp()` and `update_thread()` for correct UTC semantics
- Add comprehensive tests covering parse/format roundtrip and step row conversion

## Test plan

- [x] `_parse_iso_datetime` correctly parses both `"...Z"` and `"..."` formats
- [x] `_datetime_to_utc_iso` always produces strings ending with `Z`
- [x] Step row conversion produces Z-suffixed timestamps that can be re-parsed by `create_step`
- [x] None timestamps are preserved as None (not formatted)
- [x] Invalid formats still raise `ValueError`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inconsistent ISO timestamp handling to prevent ValueError during step updates (#2491). Standardizes UTC timestamps with a trailing Z and makes parsing accept both formats.

- **Bug Fixes**
  - Added tolerant ISO parsing that accepts with or without trailing Z.
  - Added UTC formatter that appends Z and strips timezone offsets; replaced isoformat/strptime in user, thread, and step serialization.
  - Switched datetime.now to datetime.utcnow for current timestamps and thread updates.
  - Added tests for parse/format roundtrip and step timestamp conversion; None timestamps remain None; aligned with ruff and strict pytest rules.

<sup>Written for commit ce9555317dbddbcb53ee3bf1bd414015fe4239d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

