### PR TITLE
fix(data): prevent empty string from overwriting step content on upsert

### DIFF
--- a/backend/chainlit/data/chainlit_data_layer.py
+++ b/backend/chainlit/data/chainlit_data_layer.py
@@ -351,13 +351,13 @@ class ChainlitDataLayer(BaseDataLayer):
         )
         ON CONFLICT (id) DO UPDATE SET
             "parentId" = COALESCE(EXCLUDED."parentId", "Step"."parentId"),
-            input = COALESCE(EXCLUDED.input, "Step".input),
+            input = COALESCE(NULLIF(EXCLUDED.input, ''), "Step".input),
             metadata = CASE
                 WHEN EXCLUDED.metadata <> '{}' THEN EXCLUDED.metadata
                 ELSE "Step".metadata
             END,
             name = COALESCE(EXCLUDED.name, "Step".name),
-            output = COALESCE(EXCLUDED.output, "Step".output),
+            output = COALESCE(NULLIF(EXCLUDED.output, ''), "Step".output),
             type = CASE
                 WHEN EXCLUDED.type = 'run' THEN "Step".type
                 ELSE EXCLUDED.type


### PR DESCRIPTION
## Problem

When using `cl.Step`, content within steps occasionally disappears or appears empty when reloading a thread from history. This is caused by a race condition between the initial `step.send()` and the subsequent `step.update()`.

`cl.Step` initializes `input` and `output` as empty strings (`""`). In `ChainlitDataLayer.create_step`, the SQL uses:

```sql
output = COALESCE(EXCLUDED.output, "Step".output)
```

Since empty string is not `NULL`, `COALESCE` accepts it as a valid value. If the background task for the initial `send()` (with empty output) finishes after the final `update()` (with actual content), the empty string overwrites the content.

## Fix

Wrap `EXCLUDED.output` and `EXCLUDED.input` with `NULLIF(..., '')`:

```sql
output = COALESCE(NULLIF(EXCLUDED.output, ''), "Step".output)
input = COALESCE(NULLIF(EXCLUDED.input, ''), "Step".input)
```

This treats empty strings as `NULL`, so `COALESCE` falls back to the existing database content.

## Test

Added `test_create_step_uses_nullif_for_output_and_input` that verifies the SQL contains the `NULLIF` protection.

Fixes #2789

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent empty-string input/output from overwriting step content during upsert. Fixes a race where initial Step.send() could erase content saved by Step.update(), so step content persists when reloading threads.

- **Bug Fixes**
  - Use NULLIF(EXCLUDED.input/output, '') in ON CONFLICT updates so COALESCE keeps existing non-empty values.
  - Add regression test to verify NULLIF is applied to both fields.

<sup>Written for commit 80954109e70a57738e03c78bc948ef600bbcba00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

