### PR TITLE
fix: treat empty custom_fonts array as intent to remove default fonts

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -410,10 +410,10 @@ def get_html_template(root_path):
         js += f"""<script src="{config.ui.custom_js}" {config.ui.custom_js_attributes}></script>"""
 
     font = None
-    if custom_theme and custom_theme.get("custom_fonts"):
+    if custom_theme and "custom_fonts" in custom_theme:
         font = "\n".join(
-            f"""<link rel="stylesheet" href="{font}">"""
-            for font in custom_theme.get("custom_fonts")
+            f"""<link rel="stylesheet" href="{f}">"""
+            for f in custom_theme["custom_fonts"]
         )
 
     index_html_file_path = os.path.join(build_dir, "index.html")
@@ -425,7 +425,7 @@ def get_html_template(root_path):
             content = content.replace(JS_PLACEHOLDER, js)
         if css:
             content = content.replace(CSS_PLACEHOLDER, css)
-        if font:
+        if font is not None:
             content = replace_between_tags(
                 content, "<!-- FONT START -->", "<!-- FONT END -->", font
             )


### PR DESCRIPTION
## Problem

When `custom_fonts` is set to `[]` in `theme.json`, the user intends to manage fonts themselves (e.g., via `@font-face` in `custom_css`). However, the default Inter Google Font `<link>` tags are still injected because `[]` is falsy in Python, so the condition `custom_theme.get("custom_fonts")` evaluates to `False`.

This causes:
- Unnecessary network requests to `fonts.googleapis.com`
- Breakage in air-gapped/government environments where Google domains are blocked
- Privacy concerns (user IPs sent to Google)

## Fix

- Check for key **presence** (`"custom_fonts" in custom_theme`) instead of **truthiness**
- Use `if font is not None` instead of `if font` so an empty string properly clears the default font tags via `replace_between_tags`

When `custom_fonts` is:
- **absent** → default Inter preserved (backward-compatible)
- **`[]`** → default Inter removed (user manages fonts)
- **`[{...}]`** → custom fonts replace Inter (existing behavior)

Fixes #2804

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop injecting the default Inter font when theme.json sets custom_fonts to []. An empty array now removes the Inter links, reducing unwanted Google requests and supporting air-gapped environments. Fixes #2804.

- **Bug Fixes**
  - Check for key presence ("custom_fonts" in custom_theme) instead of truthiness so: absent → keep Inter, [] → remove Inter, [{...}] → use custom links.
  - Use if font is not None when replacing the FONT block so an empty string clears the tags.

<sup>Written for commit 0f69d69efee234f8cf86e4f6ad7cce7be54bcabe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

