### PR TITLE
fix: make send_toast an async function

### DIFF
--- a/backend/chainlit/emitter.py
+++ b/backend/chainlit/emitter.py
@@ -151,7 +151,7 @@ class BaseChainlitEmitter:
         """Stub method to send custom data to the host window."""
         pass
 
-    def send_toast(self, message: str, type: Optional[ToastType] = "info"):
+    async def send_toast(self, message: str, type: Optional[ToastType] = "info"):
         """Stub method to send a toast message to the UI."""
         pass
 
@@ -465,9 +465,9 @@ class ChainlitEmitter(BaseChainlitEmitter):
         """Send custom data to the host window."""
         return self.emit("window_message", data)
 
-    def send_toast(self, message: str, type: Optional[ToastType] = "info"):
+    async def send_toast(self, message: str, type: Optional[ToastType] = "info"):
         """Send a toast message to the UI."""
         # check that the type is valid using ToastType
         if type not in get_args(ToastType):
             raise ValueError(f"Invalid toast type: {type}")
-        return self.emit("toast", {"message": message, "type": type})
+        await self.emit("toast", {"message": message, "type": type})


### PR DESCRIPTION
## What
Make `send_toast` an `async` method in both `BaseChainlitEmitter` and `ChainlitEmitter`.

Closes #2803

## Why
`send_toast` calls `self.emit()` which is async, but was not declared `async` itself. This means the coroutine returned by `emit()` was never awaited. The existing tests already expect `send_toast` to be awaitable (`await emitter.send_toast(...)`).

## Changes
- `backend/chainlit/emitter.py`: Added `async` to both `send_toast` definitions and `await` the `emit()` call

## Testing
- All 3 existing `test_send_toast*` tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make send_toast async in BaseChainlitEmitter and ChainlitEmitter, and await emit() to prevent unawaited coroutine errors. Aligns with existing tests that await send_toast and ensures toast messages are properly emitted.

<sup>Written for commit fb81652a2a5433226d8b38213e0c2342d337d8c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

