### PR TITLE
feat: add selected option to commands for pre-selection

### DIFF
--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -336,6 +336,8 @@ class CommandDict(TypedDict):
     button: Optional[bool]
     # Whether the command will be persistent unless the user toggles it
     persistent: Optional[bool]
+    # Whether the command should be pre-selected when loaded
+    selected: Optional[bool]
 
 
 class FeedbackDict(TypedDict):

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -5,12 +5,13 @@ import {
   useRef,
   useState
 } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
   FileSpec,
   IStep,
+  commandsState,
   useAuth,
   useChatData,
   useChatInteract,
@@ -62,7 +63,16 @@ export default function MessageComposer({
   const [selectedCommand, setSelectedCommand] = useRecoilState(
     persistentCommandState
   );
+  const commands = useRecoilValue(commandsState);
   const setChatSettingsOpen = useSetRecoilState(chatSettingsOpenState);
+
+  // Pre-select the command marked as selected by the backend
+  useEffect(() => {
+    const defaultSelected = commands.find((c) => c.selected);
+    if (defaultSelected && !selectedCommand) {
+      setSelectedCommand(defaultSelected);
+    }
+  }, [commands]);
   const [attachments, setAttachments] = useRecoilState(attachmentsState);
   const { t } = useTranslation();
 

--- a/libs/react-client/src/types/command.ts
+++ b/libs/react-client/src/types/command.ts
@@ -4,4 +4,5 @@ export interface ICommand {
   description: string;
   button?: boolean;
   persistent?: boolean;
+  selected?: boolean;
 }


### PR DESCRIPTION
## What
Add a `selected` boolean option to commands that enables pre-selecting a command when the page loads.

Closes #2141

## Why
Command selection resets on page refresh. Developers need a way to persist the selected command state by setting it from the backend (e.g. from a cached value).

## Changes
- `backend/chainlit/types.py`: Add `selected: Optional[bool]` to `CommandDict`
- `libs/react-client/src/types/command.ts`: Add `selected?: boolean` to `ICommand`
- `frontend/src/components/chat/MessageComposer/index.tsx`: Add `useEffect` that auto-selects the command marked `selected: True` when commands are received (only if no command is already selected)

## Usage
```python
commands = [
    {"id": "Search", "icon": "globe", "description": "Web search", "button": True, "persistent": True, "selected": True}
]
```

## Testing
Backward compatible — commands without `selected` work exactly as before. The `selected` flag is only honored when no command is already user-selected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a selected option to commands to pre-select a command on load. This lets the backend persist command state across refreshes, addressing #2141.

- **New Features**
  - Backend: CommandDict now supports selected: Optional[bool].
  - React client: ICommand now supports selected?: boolean.
  - UI: MessageComposer auto-selects the command with selected=true when commands load, only if no command is already selected.

<sup>Written for commit 0bccfa2dbd741208eb93fad54fb841f069d74b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

