### PR TITLE
fix: use correct URL scheme when SSL is configured

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -95,11 +95,12 @@ async def lifespan(app: FastAPI):
     host = config.run.host
     port = config.run.port
     root_path = os.getenv("CHAINLIT_ROOT_PATH", "")
+    scheme = "https" if config.run.ssl_cert else "http"
 
     if host == DEFAULT_HOST:
-        url = f"http://localhost:{port}{root_path}"
+        url = f"{scheme}://localhost:{port}{root_path}"
     else:
-        url = f"http://{host}:{port}{root_path}"
+        url = f"{scheme}://{host}:{port}{root_path}"
 
     logger.info(f"Your app is available at {url}")
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -3,7 +3,9 @@ import { toast } from 'sonner';
 
 import { ChainlitAPI, ClientError } from '@chainlit/react-client';
 
-const devServer = 'http://localhost:8000' + getRouterBasename();
+const devServer =
+  (import.meta.env.VITE_API_URL || 'http://localhost:8000') +
+  getRouterBasename();
 const url = import.meta.env.DEV
   ? devServer
   : window.origin + getRouterBasename();


### PR DESCRIPTION
## What
Fix the startup URL to use `https://` when SSL certificates are configured, and make the frontend dev server URL configurable.

Closes #1766

## Why
The startup message always shows `http://` even when `--ssl-cert` and `--ssl-key` are provided. The frontend also hardcodes `http://localhost:8000` for dev mode, preventing HTTPS development.

## Changes
- `backend/chainlit/server.py`: Detect `config.run.ssl_cert` to choose `https` or `http` scheme in startup URL
- `frontend/src/api/index.ts`: Use `VITE_API_URL` env var (falling back to `http://localhost:8000`) for configurable dev server URL

## Usage
```bash
# Backend
chainlit run app.py --ssl-cert cert.pem --ssl-key key.pem
# Now shows: Your app is available at https://localhost:8000

# Frontend dev with HTTPS backend
VITE_API_URL=https://localhost:8000 pnpm dev
```

## Testing
Without SSL: behavior unchanged. With SSL: correct `https://` URL displayed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the startup URL to use https when SSL certs are provided and makes the frontend dev API URL configurable. This enables HTTPS development and avoids misleading http links.

- **Bug Fixes**
  - Backend now picks http/https for the startup message based on ssl_cert.

- **New Features**
  - Frontend dev API URL configurable via VITE_API_URL (defaults to http://localhost:8000).

<sup>Written for commit 0793b5fb62c08e84a535affee77b3e2e1d38530c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

