### PR TITLE
fix: show error toast when streamable-http MCP connection fails

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -34,31 +34,6 @@ class ExtendedChainlitAPI extends ChainlitAPI {
     return res.json();
   }
 
-  connectStreamableHttpMCP(
-    sessionId: string,
-    name: string,
-    url: string,
-    headers?: Record<string, string>
-  ) {
-    // Assumes the backend expects { clientType, name, url }
-    return fetch(new URL("mcp", this.httpEndpoint.endsWith("/") ? this.httpEndpoint : `${this.httpEndpoint}/`), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(sessionId ? { 'x-session-id': sessionId } : {})
-      },
-      body: JSON.stringify({
-        clientType: 'streamable-http',
-        name,
-        url,
-        sessionId,
-        ...(headers ? { headers } : {})
-      })
-    }).then(async (res) => {
-      const data = await res.json();
-      return { success: res.ok, mcp: data.mcp, error: data.detail };
-    });
-  }
 }
 
 export const apiClient = new ExtendedChainlitAPI(


### PR DESCRIPTION
## Summary

Fixes #2823

When connecting a streamable-http MCP server with an invalid URL, the frontend incorrectly shows a green "MCP added!" success toast even though the backend returns HTTP 400. SSE and stdio connections correctly display an error toast in the same scenario.

**Root cause:** `ExtendedChainlitAPI` in `frontend/src/api/index.ts` overrode `connectStreamableHttpMCP()` using raw `fetch()` instead of the inherited `this.post()` method. The raw `fetch` call never threw on HTTP errors — it always resolved the promise with `{ success: false, ... }`. Since `toast.promise()` only shows an error when the promise rejects, the success toast was always displayed.

**Fix:** Remove the unnecessary override. The base class `ChainlitAPI` (in `@chainlit/react-client`) already provides a correct `connectStreamableHttpMCP()` implementation that uses `this.post()` → `this.fetch()`, which throws a `ClientError` on non-ok HTTP responses. This is the same pattern used by `connectSseMCP()` and `connectStdioMCP()`, which already work correctly.

## Changes

- **`frontend/src/api/index.ts`**: Removed the `connectStreamableHttpMCP()` override from `ExtendedChainlitAPI`, letting the base class implementation handle error propagation correctly.

## Test plan

- [ ] Open the MCP Servers dialog, select "streamable-http", enter an invalid URL (e.g., "abc"), and click Confirm — should now show a **red error toast** instead of a green "MCP added!" toast
- [ ] Repeat with a valid streamable-http MCP URL — should show a green "MCP added!" toast and list the server under "My MCPs"
- [ ] Verify SSE and stdio connections still work correctly (no regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed streamable-http MCP connections now show a red error toast instead of a success message. Fixes #2823.

- **Bug Fixes**
  - Removed ExtendedChainlitAPI.connectStreamableHttpMCP override to use the ChainlitAPI implementation.
  - Non-OK HTTP responses now reject (ClientError), so toast.promise shows the error.
  - SSE and stdio connection flows unchanged.

<sup>Written for commit 760944586a4beca9043c6bfa9276499b3a487e75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

