### PR TITLE
fix: show error toast when streamable-http MCP connection fails (fixes #2823)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -57,8 +57,18 @@ class ExtendedChainlitAPI extends ChainlitAPI {
         ...(headers ? { headers } : {})
       })
     }).then(async (res) => {
+      if (!res.ok) {
+        let detail: string | undefined;
+        try {
+          const data = await res.json();
+          detail = data.detail;
+        } catch {
+          // Response body is not JSON (e.g. proxy HTML error page)
+        }
+        throw new ClientError(detail || res.statusText, res.status);
+      }
       const data = await res.json();
-      return { success: res.ok, mcp: data.mcp, error: data.detail };
+      return { success: true, mcp: data.mcp, error: undefined };
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2823 — Frontend shows "MCP added!" success toast when a streamable-http MCP connection fails with HTTP 400, while SSE correctly shows an error toast.

## Root Cause


However, the frontend's `ExtendedChainlitAPI.connectStreamableHttpMCP()` overrides the base method with a raw `fetch()` that does **not** throw on non-OK responses — it returns `{ success: res.ok, ... }`. The promise always resolves, so `toast.promise()` always shows the success toast.

## Fix


```typescript
  throw new ClientError(res.statusText, res.status, data.detail);
}
```

## Result

| Connection type | Invalid URL before | Invalid URL after |
|---|---|---|
| SSE | ❌ Error toast | ❌ Error toast |
| Streamable HTTP | ✅
| Stdio | ❌ Error toast | ❌ Error toast |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an error toast when a streamable-http MCP connection fails. We now throw a `ClientError` on non-OK responses, use `detail` when present, and skip JSON parsing for HTML errors so `toast.promise` shows the real message (fixes #2823).

<sup>Written for commit 3f15d962db55861f7dc85fc46f4f43c82a14f407. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

