### PR TITLE
fix: Issue with accordion requiring two clicks to close

### DIFF
--- a/frontend/src/components/chat/Messages/Message/Step.tsx
+++ b/frontend/src/components/chat/Messages/Message/Step.tsx
@@ -29,14 +29,14 @@ export default function Step({
   const isError = step.isError;
   const stepName = step.name;
 
-  const [openValue, setOpenValue] = useState<string | undefined>(
-    step.defaultOpen ? step.id : undefined
+  const [openValue, setOpenValue] = useState<string>(
+    step.defaultOpen ? step.id : ''
   );
 
   // Auto-collapse when step finishes if autoCollapse is set
   useEffect(() => {
     if (!using && step.autoCollapse) {
-      setOpenValue(undefined);
+      setOpenValue('');
     }
   }, [using, step.autoCollapse]);
 
@@ -73,7 +73,7 @@ export default function Step({
         type="single"
         collapsible
         value={openValue}
-        onValueChange={(val) => setOpenValue(val || undefined)}
+        onValueChange={(val) => setOpenValue(val)}
         className="w-full"
       >
         <AccordionItem value={step.id} className="border-none">


### PR DESCRIPTION
Accordion was not closing on the first click. it required two clicks to close.

This issue was that the controlled accordion was incorrectly handled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the step accordion so it closes on the first click by standardizing the controlled value to a string. The closed state now uses `''` instead of `undefined`, and `onValueChange` sets the value directly, making user toggles and auto-collapse work reliably.

<sup>Written for commit d3fbc94a4c4557c582eb5dd72f49d9c25df808b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

