### PR TITLE
Fix: DatePickerInput sends date-only strings instead of ISO datetime with timezone

### DIFF
--- a/frontend/src/components/ChatSettings/DatePickerInput.tsx
+++ b/frontend/src/components/ChatSettings/DatePickerInput.tsx
@@ -24,7 +24,8 @@ import { InputStateHandler } from './InputStateHandler';
 const parseDate = (dateStr: string | undefined | null): Date | undefined => {
   if (!dateStr) return undefined;
   try {
-    const date = new Date(dateStr);
+    // Append T00:00:00 to force local timezone parsing instead of UTC
+    const date = new Date(dateStr + 'T00:00:00');
     // Check if date is valid (Invalid Date has NaN time)
     if (isNaN(date.getTime())) {
       console.warn(`Invalid date string provided: "${dateStr}"`);
@@ -38,7 +39,10 @@ const parseDate = (dateStr: string | undefined | null): Date | undefined => {
 
 const formatDateValue = (date: Date | undefined): string | undefined => {
   if (!date) return undefined;
-  return date.toISOString();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 const formatRangeValue = (


### PR DESCRIPTION
The DatePickerInput component was sending full ISO 8601 datetime strings (e.g. 2025-11-26T00:00:00.000Z) to the backend. For date-only fields, this could cause off-by-one day errors when the UTC conversion shifted the date.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
DatePickerInput now sends date-only strings (YYYY-MM-DD) instead of ISO datetimes with timezone to prevent off-by-one day shifts in UTC.

- **Bug Fixes**
  - `formatDateValue` now outputs `YYYY-MM-DD` instead of `toISOString()`.
  - `parseDate` appends `T00:00:00` to force local timezone parsing and avoid UTC conversion.

<sup>Written for commit fbdee38e3410457a653510ffedd2855a5362c548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

