### PR TITLE
fix: Removing a favorite overwrites live message state with stale snapshot

### DIFF
--- a/libs/react-client/src/useChatInteract.ts
+++ b/libs/react-client/src/useChatInteract.ts
@@ -93,17 +93,23 @@ const useChatInteract = () => {
   const toggleMessageFavorite = useCallback(
     (message: IStep) => {
       const favorite = !(message.metadata?.favorite ?? false);
-      const nextMessage: IStep = {
-        ...message,
-        metadata: {
-          ...(message.metadata || {}),
-          favorite
-        }
+      const updatedMetadata = {
+        ...(message.metadata || {}),
+        favorite
       };
 
       setMessages((oldMessages) =>
-        oldMessages.map((item) => (item.id === message.id ? nextMessage : item))
+        oldMessages.map((item) =>
+          item.id === message.id
+            ? { ...item, metadata: { ...(item.metadata || {}), favorite } }
+            : item
+        )
       );
+
+      const nextMessage: IStep = {
+        ...message,
+        metadata: updatedMetadata
+      };
 
       setFavoriteMessages((oldFavorites) => {
         if (favorite) {


### PR DESCRIPTION
This fixes this issue : https://github.com/Chainlit/chainlit/issues/2836

update only metadata on the current item from state instead of replacing it wholesale.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where toggling a favorite could overwrite a live message with a stale snapshot (Fixes #2836). We now update only the `favorite` flag in `metadata` within `useChatInteract`, preserving all other message fields.

<sup>Written for commit 7fdd751bdee4db30970b7d37defc1327f6614c78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

