### PR TITLE
fix: use correct logging format specifier in OAuth state validation

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -674,7 +674,7 @@ async def oauth_callback(
     try:
         validate_oauth_state_cookie(request, state)
     except Exception as e:
-        logger.exception("Unable to validate oauth state: %1", e)
+        logger.exception("Unable to validate oauth state: %s", e)
 
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
Fix format string error in OAuth state validation logging — `%1` is not a valid
Python logging format specifier and causes a `ValueError` when the exception handler runs.

## Change

- Replace `%1` with `%s` in `logger.exception()` call in `backend/chainlit/server.py`

Fixes #2692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix logging format specifier in OAuth state validation by replacing %1 with %s to prevent a ValueError in the exception handler.

<sup>Written for commit 650cbf9fef66e36124dc4a75d6d174b752796aa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

