### PR TITLE
feat: Use watermark in welcome chat

### DIFF
--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -17,6 +17,7 @@ import {
 
 import { Logo } from '@/components/Logo';
 import { Markdown } from '@/components/Markdown';
+import WaterMark from '@/components/WaterMArk';
 
 import MessageComposer from './MessageComposer';
 import Starters from './Starters';
@@ -89,6 +90,7 @@ export default function WelcomeScreen(props: Props) {
     >
       {logo}
       <MessageComposer {...props} />
+      <WaterMark />
       <Starters />
     </div>
   );


### PR DESCRIPTION
Closes #2848

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the app watermark on the empty chat welcome screen. Adds the `WaterMark` component to `WelcomeScreen` below the message composer.

<sup>Written for commit cb89683d855617a84134632962c7c2ddf4766b6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

