### PR TITLE
fix: prevent NOT NULL violation in update_thread when metadata is None

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -262,7 +262,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
             "userId": user_id,
             "userIdentifier": user_identifier,
             "tags": tags,
-            "metadata": json.dumps(metadata) if metadata else None,
+            "metadata": json.dumps(metadata if metadata is not None else {}),
         }
         parameters = {
             key: value for key, value in data.items() if value is not None


### PR DESCRIPTION
Fixes #2851

`create_step` calls `update_thread(thread_id)` without passing `metadata`, so it defaults to `None`. The old expression `json.dumps(metadata) if metadata else None` then produced `None`, which got filtered out of the INSERT parameters — violating the NOT NULL constraint on the `metadata` column when the thread didn't exist yet.

Changed to always serialize metadata, falling back to `{}` when `None`.

\u2014 saschabuehrle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent NOT NULL violations in `update_thread` by always serializing `metadata` to a JSON object, defaulting to `{}` when `None`. This fixes thread creation failures triggered by `create_step` calling `update_thread` without `metadata`.

- **Bug Fixes**
  - In `update_thread`, use `json.dumps(metadata if metadata is not None else {})` so `metadata` is never `None` and isn’t dropped from INSERT parameters.

<sup>Written for commit 9a4181bf62d7b41abe75fdfc814d751cd84ffcb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

