### PR TITLE
fix: move useEffect hooks before early return in ChatProfiles

### DIFF
--- a/frontend/src/components/header/ChatProfiles.tsx
+++ b/frontend/src/components/header/ChatProfiles.tsx
@@ -41,21 +41,20 @@ export default function ChatProfiles({ navigate }: Props) {
   const [newChatProfile, setNewChatProfile] = useState<string | null>(null);
   const [openDialog, setOpenDialog] = useState(false);
 
-  // Early return check to prevent unnecessary renders and resource waste
-  if (!config?.chatProfiles?.length || config.chatProfiles.length <= 1) {
-    return null;
-  }
-
   // Handle case when no profile is selected
   useEffect(() => {
-    if (!chatProfile) {
+    if (
+      !chatProfile &&
+      config?.chatProfiles &&
+      config.chatProfiles.length > 1
+    ) {
       setChatProfile(config.chatProfiles[0].name);
     }
-  }, [chatProfile, config.chatProfiles, setChatProfile]);
+  }, [chatProfile, config?.chatProfiles, setChatProfile]);
 
   // Handle case when selected profile becomes invalid
   useEffect(() => {
-    if (chatProfile) {
+    if (chatProfile && config?.chatProfiles && config.chatProfiles.length > 1) {
       const profileExists = config.chatProfiles.some(
         (profile) => profile.name === chatProfile
       );
@@ -63,7 +62,11 @@ export default function ChatProfiles({ navigate }: Props) {
         setChatProfile(config.chatProfiles[0].name);
       }
     }
-  }, [chatProfile, config.chatProfiles, setChatProfile]);
+  }, [chatProfile, config?.chatProfiles, setChatProfile]);
+
+  if (!config?.chatProfiles?.length || config.chatProfiles.length <= 1) {
+    return null;
+  }
 
   const handleClose = () => {
     setOpenDialog(false);


### PR DESCRIPTION
## Summary

- Fix React Rules of Hooks violation in `ChatProfiles.tsx` where two `useEffect` hooks were placed after an early return
- When `config` loads asynchronously (`undefined` → populated), the hook count changes between renders (8 → 10), causing React to throw *"Rendered more hooks than during the previous render"*
- Move the early return below both `useEffect` calls and add optional chaining guards so they no-op when `config.chatProfiles` is missing

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` (frontend unit tests) — 32/32 pass
- [ ] Manual: verify chat profiles load correctly when config has 2+ profiles
- [ ] Manual: verify component returns null gracefully when 0-1 profiles configured

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a React Rules of Hooks violation in `ChatProfiles` by moving both `useEffect` hooks above the early return so hook order stays stable as `config` loads. Prevents the "Rendered more hooks than during the previous render" error and keeps the component idle unless there are at least 2 profiles.

- **Bug Fixes**
  - Moved early return below the `useEffect` hooks to stabilize hook count.
  - Added optional chaining and guards in effects and deps to safely no-op when `config.chatProfiles` is missing or has 0–1 items.

<sup>Written for commit ecbf2751c741b318c53e150d396bf2cbde76bcbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

