### PR TITLE
fix(langchain): check langchain-core version instead of langchain

### DIFF
--- a/backend/chainlit/langchain/__init__.py
+++ b/backend/chainlit/langchain/__init__.py
@@ -1,6 +1,6 @@
 from chainlit.utils import check_module_version
 
-if not check_module_version("langchain", "0.0.198"):
+if not check_module_version("langchain_core", "0.2.5"):
     raise ValueError(
-        "Expected LangChain version >= 0.0.198. Run `pip install langchain --upgrade`"
+        "Expected langchain-core version >= 0.2.5. Run `pip install langchain-core --upgrade`"
     )


### PR DESCRIPTION
## Summary

- The `chainlit/langchain` callbacks module only imports from `langchain_core`, not the `langchain` meta-package
- The old version guard (`langchain >= 0.0.198`) caused a hard failure for projects using `langchain-core` without the `langchain` meta-package (e.g. `langchain-classic` users)
- Replaced with `langchain_core >= 0.2.5`, which is the first version that introduced `AsyncBaseTracer` in `langchain_core.tracers.base` — the last API required by the callbacks module

## Test plan

- [ ] Install `langchain-core` without `langchain` and verify `import chainlit.langchain` works
- [ ] Verify the error message is raised correctly when `langchain-core < 0.2.5` is installed

Fixes #2886

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the version guard in `chainlit.langchain` to require `langchain_core >= 0.2.5` (where `AsyncBaseTracer` was introduced) instead of checking the `langchain` meta-package. This prevents import failures for users who only install `langchain-core` and updates the upgrade hint to `pip install langchain-core --upgrade`.

<sup>Written for commit 869fef06285dc7e58a8c28432de0b3d82dfb9952. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

