### PR TITLE
fix(auth): localize login error message for failed credentials

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -510,7 +510,7 @@ async def _authenticate_user(
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="credentialssignin",
+            detail="credentialsSignin",
         )
 
     # If a data layer is defined, attempt to persist user.

--- a/cypress/e2e/password_auth/spec.cy.ts
+++ b/cypress/e2e/password_auth/spec.cy.ts
@@ -29,7 +29,7 @@ describe('Password Auth', () => {
           cy.get("input[name='email']").type('user');
           cy.get("input[name='password']").type('user');
           cy.get("button[type='submit']").click();
-          cy.get('body').should('contain', 'Unauthorized');
+          cy.get('body').should('contain', 'Sign in failed');
         });
       });
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -21,6 +21,9 @@ const on401 = () => {
 };
 
 const onError = (error: ClientError) => {
+  // Don't toast 401 errors — they're handled by the login form (inline Alert)
+  // and the on401 redirect for other pages.
+  if (error.status === 401) return;
   toast.error(error.toString());
 };
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -90,10 +90,7 @@ export function LoginForm({
 
       {errorState && (
         <Alert variant="error">
-          {t([
-            `auth.login.errors.${errorState.toLowerCase()}`,
-            `auth.login.errors.default`
-          ])}
+          {t([`auth.login.errors.${errorState}`, `auth.login.errors.default`])}
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary

Fixes #2873 — follow-up to #2794.

After #2794 fixed the login form to read `err.detail` instead of `err.message`, there's still a case sensitivity mismatch that prevents the i18n lookup from working. Users see a raw toast `(!) Unauthorized: credentialssignin` instead of the translated "Sign in failed. Check the details you provided are correct".

## Root cause

Three things conspire:

1. The backend sends `detail="credentialssignin"` (all lowercase), but every translation file defines the key as `credentialsSignin` (camelCase)
2. `LoginForm.tsx` applies `.toLowerCase()` before the i18n lookup, so even a correctly-cased key gets lowercased
3. The global `onError` handler in `api/index.ts` toasts `error.toString()` for every API error — including 401s on the login page, which the `LoginForm` already handles with an inline Alert

## Changes

- **`backend/chainlit/server.py`** — send `credentialsSignin` (camelCase) to match the translation keys in all 23 locale files
- **`frontend/src/components/LoginForm.tsx`** — remove `.toLowerCase()` so the key survives to match the translation
- **`frontend/src/api/index.ts`** — skip `toast.error` for 401 responses; they're already handled by the login form's inline Alert and the `on401` redirect for other pages
- **`cypress/e2e/password_auth/spec.cy.ts`** — update the wrong-credentials assertion to check for the translated message ("Sign in failed") instead of the old raw toast text ("Unauthorized")

## Before / After

| | Before | After |
|---|---|---|
| Toast | `(!) Unauthorized: credentialssignin` | *(no toast)* |
| Inline Alert | "Unable to sign in" (generic fallback) | "Sign in failed. Check the details you provided are correct" |

## Checks run

- `uv run pytest tests/` — 783 passed
- `pnpm test` (frontend) — 32 passed
- `pnpm lint` — clean
- `pnpm format-check` — clean
- Pre-commit hooks (lint, format, type-check for Python + TS) — all passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes login error localization for failed credentials so users see the translated inline alert instead of a raw unauthorized toast. Removes the redundant 401 toast and aligns backend/Frontend keys for i18n.

- **Bug Fixes**
  - Backend: send `credentialsSignin` (camelCase) to match translation keys.
  - LoginForm: remove `.toLowerCase()` so the i18n key matches.
  - API client: skip `toast.error` for 401 responses; handled by inline Alert and `on401`.
  - Cypress: update wrong-credentials test to check for "Sign in failed".

<sup>Written for commit 3568ccde5bbfeec43020caf2c26e4d208c0553c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

