### PR TITLE
fix(socket): guard on_chat_start against duplicate dispatch on reconnect

### DIFF
--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -105,6 +105,7 @@ class BaseSession:
     thread_id_to_resume: Optional[str] = None
     client_type: ClientType
     current_task: Optional[asyncio.Task] = None
+    chat_started: bool = False
 
     def __init__(
         self,
@@ -131,6 +132,7 @@ class BaseSession:
         self.client_type = client_type
         self.token = token
         self.has_first_interaction = False
+        self.chat_started = False
         self.user_env = user_env or {}
         self.environ = environ or {}
         self.chat_profile = chat_profile

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -213,7 +213,8 @@ async def connection_successful(sid):
     await context.emitter.clear("clear_call_fn")
 
     if context.session.restored and not context.session.has_first_interaction:
-        if config.code.on_chat_start:
+        if config.code.on_chat_start and not context.session.chat_started:
+            context.session.chat_started = True
             task = asyncio.create_task(config.code.on_chat_start())
             context.session.current_task = task
         return
@@ -237,7 +238,8 @@ async def connection_successful(sid):
         else:
             await context.emitter.send_resume_thread_error("Thread not found.")
 
-    if config.code.on_chat_start:
+    if config.code.on_chat_start and not context.session.chat_started:
+        context.session.chat_started = True
         task = asyncio.create_task(config.code.on_chat_start())
         context.session.current_task = task
 

--- a/backend/tests/test_socket.py
+++ b/backend/tests/test_socket.py
@@ -9,6 +9,7 @@ from chainlit.socket import (
     _get_token,
     _get_token_from_cookie,
     clean_session,
+    connection_successful,
     load_user_env,
     persist_user_session,
     restore_existing_session,
@@ -524,3 +525,108 @@ class TestSocketEdgeCases:
                 # Should propagate the exception
                 with pytest.raises(Exception, match="Auth error"):
                     await _authenticate_connection(environ)
+
+
+class TestConnectionSuccessfulIdempotency:
+    """Regression tests: on_chat_start must fire exactly once per
+    WebsocketSession, even when connection_successful is dispatched multiple
+    times (Socket.IO reconnect, React StrictMode double-mount, reverse-proxy
+    WS 101 retry).
+
+    Refs chainlit#2535, chainlit#2549, chainlit#2228.
+    """
+
+    @pytest.mark.asyncio
+    async def test_on_chat_start_not_duplicated_on_reconnect(
+        self, mock_session_factory
+    ):
+        """Reconnect path (session.restored=True): on_chat_start scheduled once."""
+        on_chat_start = AsyncMock()
+
+        session = mock_session_factory(has_first_interaction=False)
+        session.restored = True
+        session.chat_started = False
+        session.current_task = None
+        session.thread_id_to_resume = None
+
+        mock_context = Mock()
+        mock_context.session = session
+        mock_context.emitter = AsyncMock()
+
+        mock_config = Mock()
+        mock_config.code.on_chat_start = on_chat_start
+        mock_config.code.on_chat_resume = None
+
+        with (
+            patch("chainlit.socket.init_ws_context", return_value=mock_context),
+            patch("chainlit.socket.config", mock_config),
+        ):
+            await connection_successful("sid-1")
+            # Simulate reconnect: same session object, chat_started now True.
+            await connection_successful("sid-1")
+
+        assert on_chat_start.call_count == 1, (
+            "on_chat_start must be scheduled exactly once per WebsocketSession"
+        )
+        assert session.chat_started is True
+
+    @pytest.mark.asyncio
+    async def test_on_chat_start_fires_once_on_fresh_session(
+        self, mock_session_factory
+    ):
+        """Normal one-connect path still greets exactly once."""
+        on_chat_start = AsyncMock()
+
+        session = mock_session_factory(has_first_interaction=False)
+        session.restored = False
+        session.chat_started = False
+        session.current_task = None
+        session.thread_id_to_resume = None
+
+        mock_context = Mock()
+        mock_context.session = session
+        mock_context.emitter = AsyncMock()
+
+        mock_config = Mock()
+        mock_config.code.on_chat_start = on_chat_start
+        mock_config.code.on_chat_resume = None
+
+        with (
+            patch("chainlit.socket.init_ws_context", return_value=mock_context),
+            patch("chainlit.socket.config", mock_config),
+        ):
+            await connection_successful("sid-1")
+
+        assert on_chat_start.call_count == 1
+        assert session.chat_started is True
+
+    @pytest.mark.asyncio
+    async def test_on_chat_start_not_duplicated_on_fresh_then_reconnect(
+        self, mock_session_factory
+    ):
+        """Fresh connect followed by a reconnect still fires exactly once."""
+        on_chat_start = AsyncMock()
+
+        session = mock_session_factory(has_first_interaction=False)
+        session.restored = False
+        session.chat_started = False
+        session.current_task = None
+        session.thread_id_to_resume = None
+
+        mock_context = Mock()
+        mock_context.session = session
+        mock_context.emitter = AsyncMock()
+
+        mock_config = Mock()
+        mock_config.code.on_chat_start = on_chat_start
+        mock_config.code.on_chat_resume = None
+
+        with (
+            patch("chainlit.socket.init_ws_context", return_value=mock_context),
+            patch("chainlit.socket.config", mock_config),
+        ):
+            await connection_successful("sid-1")
+            session.restored = True
+            await connection_successful("sid-1")
+
+        assert on_chat_start.call_count == 1


### PR DESCRIPTION
## Summary

Guard `connection_successful` against duplicate `on_chat_start` dispatch by adding a `chat_started` idempotency flag on `BaseSession`. Completes the root-cause fix started in #2549.

## Root cause

`backend/chainlit/socket.py::connection_successful` schedules `config.code.on_chat_start` at two independent sites:

1. The restored-session branch added by #2549 (fixes #2535), firing when `session.restored and not session.has_first_interaction`.
2. The original fallthrough at the bottom, firing on a fresh session.

A single `WebsocketSession` can reach both sites before `has_first_interaction` flips true whenever `connection_successful` is dispatched more than once. Triggers observed in the wild:

- Socket.IO auto-reconnect after a transient network blip
- React 18 StrictMode double-mounting the provider in development
- Reverse-proxy (nginx, Traefik) retrying the WS `101` upgrade — same class of bug as #2228
- `chainlit run -w` hot-restart
- Closing both browser tab and dev server, restarting server, reopening tab

Result: `on_chat_start` runs twice for the same session, so whatever initialisation it performs — setting up memory, chains, state, or any side-effects — happens twice.

PR #2549's author explicitly noted "the root cause is still alluding me" — this PR supplies the missing idempotency piece.

## Fix

- Add `chat_started: bool = False` class attribute on `BaseSession`.
- Guard both schedule sites in `connection_successful` with `not context.session.chat_started`, flipping the flag synchronously before `asyncio.create_task(...)`. The check+set is atomic under asyncio's single-thread scheduler.
- `chat_started` is never reset within a `WebsocketSession` lifetime; genuine new chats allocate a fresh session object, so the normal path is unaffected.
- `WebsocketSession.restore()` is intentionally NOT modified — `chat_started` must persist across reconnect so the reconnected session does not re-run `on_chat_start`.

## Testing

New `TestConnectionSuccessfulIdempotency` in `backend/tests/test_socket.py`:

- `test_on_chat_start_not_duplicated_on_reconnect` — drives `connection_successful` twice against a restored session and asserts `on_chat_start.call_count == 1`.
- `test_on_chat_start_fires_once_on_fresh_session` — regression guard that the normal one-connect path still fires exactly once.
- `test_on_chat_start_not_duplicated_on_fresh_then_reconnect` — fresh dispatch followed by a reconnect dispatch still fires once.

```
uv run pytest tests/test_socket.py::TestConnectionSuccessfulIdempotency -xvs
uv run pytest tests/test_socket.py -q   # 35 passed
```

## Issues referenced

- Refs #2535 — original "on_chat_start not firing after 2.8" report.
- Refs #2549 — symptom fix that introduced the second schedule site.
- Refs #2228 — related WS-reconnect lifecycle double-fire behind nginx.

## Backwards compatibility

Purely additive — new attribute on `BaseSession`, new conditional on existing schedule sites. No public API change, no migration required.