### PR TITLE
chore: test

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -117,3 +117,5 @@ For detailed information on how to contribute, see [here](/CONTRIBUTING.md).
 ## 📃 License
 
 Chainlit is open-source and licensed under the [Apache 2.0](LICENSE) license.
+
+Test


### PR DESCRIPTION
GitHub protection rules test for the future 3.0 preview branches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-op doc change to `backend/README.md` by appending “Test” to verify GitHub protection rules for 3.0 preview branches. No code or behavior changes.

<sup>Written for commit 76fd5921710957d0a428fe0b104a566ece6da655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

