### PR TITLE
feat: add missing tooltip to settings icon

### DIFF
--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -22,6 +22,12 @@ import { modesState } from '@chainlit/react-client';
 
 import { Settings } from '@/components/icons/Settings';
 import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip';
 import { useTranslation } from 'components/i18n/Translator';
 
 import { useQuery } from '@/hooks/query';
@@ -284,16 +290,25 @@ export default function MessageComposer({
             onFileUpload={onFileUpload}
           />
           {showSettingsInComposer && (
-            <Button
-              id="chat-settings-open-modal"
-              disabled={disabled}
-              onClick={() => setChatSettingsOpen(true)}
-              className="hover:bg-muted rounded-full"
-              variant="ghost"
-              size="icon"
-            >
-              <Settings className="!size-6" />
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    id="chat-settings-open-modal"
+                    disabled={disabled}
+                    onClick={() => setChatSettingsOpen(true)}
+                    className="hover:bg-muted rounded-full"
+                    variant="ghost"
+                    size="icon"
+                  >
+                    <Settings className="!size-6" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t('navigation.user.menu.settings')}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <McpButton disabled={disabled} />
           {modes.map((mode) => (


### PR DESCRIPTION
Small fix to add the missing tooltip to the settings ("cog") icon.
<img width="917" height="279" alt="Bildschirmfoto 2026-04-22 um 11 52 39" src="https://github.com/user-attachments/assets/d8b66de3-a912-4b16-89c2-5c716dbba866" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a localized tooltip to the Settings (cog) button in the chat composer to clarify its action and improve UX. Implemented with `TooltipProvider`, `Tooltip`, `TooltipTrigger`, and `TooltipContent`, showing t('navigation.user.menu.settings') on hover.

<sup>Written for commit 05a2d7465dc5aad0ea669d3e8528ba14cb9dcd21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

