### PR TITLE
fix: sidebar title disappears when switching between two sidebars

### DIFF
--- a/backend/chainlit/sidebar.py
+++ b/backend/chainlit/sidebar.py
@@ -53,3 +53,53 @@ class ElementSidebar:
             "set_sidebar_elements",
             {"elements": [el.to_dict() for el in elements], "key": key},
         )
+
+    @staticmethod
+    async def set(
+        title: str,
+        elements: List[ElementBased],
+        key: Optional[str] = None,
+    ):
+        """
+        Atomically set the sidebar title, elements, and key in a single event.
+
+        Prefer this over calling set_title followed by set_elements: the
+        two-call variant relies on the client reassembling state across two
+        socket events, which is racy under React 18 + Recoil -- the second
+        event's updater can observe the atom as unset even though the first
+        event just wrote to it, causing the title to render as an empty
+        string. Emitting one combined event avoids that race entirely.
+
+        Passing an empty elements list will close the sidebar, matching the
+        behaviour of set_elements([]).
+
+        Args:
+            title (str): The title to display at the top of the sidebar.
+            elements (List[ElementBased]): A list of ElementBased objects to
+                display in the sidebar.
+            key (Optional[str], optional): If the sidebar is already opened
+                with the same key and title, elements will not be replaced.
+
+        Returns:
+            None: This method does not return anything.
+        """
+        if not elements:
+            await context.emitter.emit(
+                "set_sidebar",
+                {"title": title, "elements": [], "key": None},
+            )
+            return
+
+        coros = [
+            element.send(for_id=element.for_id or "", persist=False)
+            for element in elements
+        ]
+        await asyncio.gather(*coros)
+        await context.emitter.emit(
+            "set_sidebar",
+            {
+                "title": title,
+                "elements": [el.to_dict() for el in elements],
+                "key": key,
+            },
+        )

--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -411,6 +411,41 @@ const useChatSession = () => {
         }
       );
 
+      // Atomic sidebar update: title + elements + key in one payload.
+      // Avoids the set_sidebar_title -> set_sidebar_elements coordination
+      // race where the second handler observes the Recoil atom as still
+      // undefined (under React 18 + Recoil batching) and falls back to
+      // title: '' -- rendering a headerless sidebar.
+      socket.on(
+        'set_sidebar',
+        ({
+          title,
+          elements,
+          key
+        }: {
+          title: string;
+          elements: IMessageElement[];
+          key?: string;
+        }) => {
+          if (!elements.length) {
+            setSideView(undefined);
+            return;
+          }
+          elements.forEach((element) => {
+            if (!element.url && element.chainlitKey) {
+              element.url = client.getElementUrl(
+                element.chainlitKey,
+                sessionId
+              );
+            }
+          });
+          setSideView((prev) => {
+            if (prev?.key === key && prev?.title === title) return prev;
+            return { title, elements, key };
+          });
+        }
+      );
+
       socket.on('element', (element: IElement) => {
         if (!element.url && element.chainlitKey) {
           element.url = client.getElementUrl(element.chainlitKey, sessionId);


### PR DESCRIPTION
I have buttons in the header which are used to switch between two sidebars (or rather, switch out the contents of the one `cl.ElementSidebar` to make it look like two sidebars). I observer visual artefacts and inconsistency when doing this, specifically I replace the contents of it and its title regularly, yet sometimes only half of the replacement sticks, often the title replacement is ignored.

To reproduce:

Open sidebar A with `ElementSidebar.set_title("A")` followed by `set_elements([a])`, then open sidebar B with `set_title("B")` followed by `set_elements([b], key="b")`. Click back and forth between the two. Steady state: `#side-view-title` contains only the back-arrow button, no title text node after it. During each switch the title flashes for a render frame then vanishes. Body content renders fine; only the header title is lost.

The `set_title` handler writes the sideView atom, then the `set_elements` handler reads `prev` in its updater and falls back to `title: prev?.title || ''` when prev is undefined. Instrumenting the updater with a `console.log` shows `prev` observed as undefined on every `set_elements` call even though the preceding `set_title` handler just wrote to the atom synchronously in the same tick. Something in React 18 + Recoil 0.7.7's nextTree/Batcher interaction drops the staged write across socket.io event callbacks; I did not isolate the Recoil-internals bug.

It's hard to finesse the Recoil to coordinate state across two events so I Add `ElementSidebar.set(title, elements, key=None)` that emits a single `set_sidebar` frame carrying all three fields, and a frontend handler that writes the atom from the payload alone and never reading `prev` for state it did not produce. The existing `set_title` and `set_elements` APIs and handlers are untouched for back-compat; callers that migrate to `.set()` stop seeing the title loss.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the disappearing sidebar title when switching between sidebars by sending a single atomic update. Adds a new backend API and client handler to set title, elements, and key together without relying on prior state.

- **Bug Fixes**
  - Added `ElementSidebar.set(title, elements, key=None)` to emit one `set_sidebar` payload; empty `elements` closes the sidebar.
  - Client listens to `set_sidebar` and sets `sideView` directly, avoiding the React 18 + Recoil batching race that dropped the title.
  - Keeps `set_title` and `set_elements` for back-compat; callers can migrate to `.set()` to prevent the flicker.
  - Skips redundant updates when `key` and `title` match; element URL hydration is preserved.

<sup>Written for commit a58f84de1550e5e0723ffad9394312303abacc58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

