### PR TITLE
Add explicit false fallback to image mime check

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Attachment.tsx
+++ b/frontend/src/components/chat/MessageComposer/Attachment.tsx
@@ -22,7 +22,7 @@ const Attachment: React.FC<AttachmentProps> = ({
   children,
   file
 }) => {
-  const isImage = useMemo(() => mime.startsWith('image/'), [mime]);
+  const isImage = useMemo(() => mime.startsWith('image/') || false, [mime]);
   const imageUrl = useMemo(() => {
     if (isImage && file) {
       return URL.createObjectURL(file);


### PR DESCRIPTION
Solves https://github.com/Chainlit/chainlit/issues/2897
Add explicit false fallback to image mime check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit false fallback to the image MIME check in `Attachment.tsx` so `isImage` is always boolean and we avoid triggering image preview logic on invalid input.

<sup>Written for commit 4f7491f49994038a07aba6e8d7b395de4cf2a44a. Summary will update on new commits. <a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2913?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

