### PR TITLE
fix(auth): rename `dict` variable to avoid shadowing built-in

### DIFF
--- a/backend/chainlit/auth/jwt.py
+++ b/backend/chainlit/auth/jwt.py
@@ -32,11 +32,11 @@ def decode_jwt(token: str) -> User:
     secret = get_jwt_secret()
     assert secret
 
-    dict = pyjwt.decode(
+    decoded_token = pyjwt.decode(
         token,
         secret,
         algorithms=["HS256"],
         options={"verify_signature": True},
     )
-    del dict["exp"]
-    return User(**dict)
+    del decoded_token["exp"]
+    return User(**decoded_token)


### PR DESCRIPTION
## Summary

- Rename the local variable `dict` to `decoded_token` in `decode_jwt()` to avoid shadowing the Python built-in `dict` type.

## Why

In `backend/chainlit/auth/jwt.py:35`, the `decode_jwt` function assigns the decoded JWT payload to a variable named `dict`, which shadows Python's built-in `dict` type. While this doesn't currently cause a runtime error, it is a code clarity issue and could lead to subtle bugs if the built-in `dict` were needed later in the function (e.g., for type checking or casting).

## Test plan

- [ ] Verify the existing JWT tests pass (`uv run pytest tests/ -k jwt` from `backend/`)
- [ ] Verify login/auth flows still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the local variable `dict` to `decoded_token` in `decode_jwt()` to avoid shadowing the Python built-in and improve code clarity. No behavior change; JWT payload handling remains the same.

<sup>Written for commit 9ca50ef8d546776935d1ef603280201f1d63bb5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

