### PR TITLE
fix(socket): re-raise CancelledError instead of silently swallowing

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -309,7 +309,7 @@ async def process_message(session: WebsocketSession, payload: MessagePayload):
             await asyncio.sleep(0.001)
             await config.code.on_message(message)
     except asyncio.CancelledError:
-        pass
+        raise
     except Exception as e:
         logger.exception(e)
         await ErrorMessage(
@@ -344,7 +344,7 @@ async def edit_message(sid, payload: MessagePayload):
         try:
             await config.code.on_message(orig_message)
         except asyncio.CancelledError:
-            pass
+            raise
         finally:
             await context.emitter.task_end()
 
@@ -423,7 +423,7 @@ async def window_message(sid, data):
         try:
             await config.code.on_window_message(data)
         except asyncio.CancelledError:
-            pass
+            raise
 
 
 @sio.on("audio_start")  # pyright: ignore [reportOptionalCall]
@@ -476,7 +476,7 @@ async def audio_end(sid):
             await config.code.on_audio_end()
 
     except asyncio.CancelledError:
-        pass
+        raise
     except Exception as e:
         logger.exception(e)
         await ErrorMessage(


### PR DESCRIPTION
Re-raise CancelledError instead of silently catching and passing in four SocketIO event handlers. This ensures tasks are properly marked as cancelled while still allowing finally blocks to execute for cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-raise asyncio.CancelledError in SocketIO event handlers so cancellation propagates and tasks are correctly marked as cancelled. Cleanup in finally blocks is unaffected.

- **Bug Fixes**
  - Updated handlers: `process_message`, `edit_message`, `window_message`, `audio_end`.
  - Prevents masked cancellations; callers using `task.cancelled()` now get accurate state.

<sup>Written for commit f1c49cc363a895b85c8a929df2a8bf41215358f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

