### PR TITLE
fix(server): add timeout to MCP connection initialization

### DIFF
--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1482,7 +1482,20 @@ async def connect_mcp(
     )
 
     # Wait for the background task to finish initialisation.
-    await ready_event.wait()
+    try:
+        await asyncio.wait_for(ready_event.wait(), timeout=30)
+    except asyncio.TimeoutError:
+        task.cancel()
+        try:
+            await task
+        except BaseException:
+            pass
+        return JSONResponse(
+            status_code=504,
+            content={
+                "detail": f"MCP connection to '{payload.name}' timed out during initialization"
+            },
+        )
 
     if "error" in result_holder:
         # The task already exited and cleaned up its exit stack.


### PR DESCRIPTION
## Summary

- Add a 30-second timeout to `ready_event.wait()` in the MCP connection handler to prevent indefinite hangs when an MCP server is unresponsive.

## Why

When establishing an MCP connection (SSE, stdio, or HTTP transport), the handler calls `await ready_event.wait()` to wait for the background task to finish initialization. If the MCP server hangs or is unresponsive, this wait is indefinite, effectively blocking the server handler.

While the `finally` block in the background task does set `ready_event` on errors, a hung transport connection (e.g. TCP connection that never completes) would never reach the `finally` block, causing the wait to hang forever.

On timeout, the background task is cancelled and a 504 Gateway Timeout response is returned.

## Test plan

- [ ] Verify MCP connections to responsive servers still work normally
- [ ] Test with an MCP server that is unreachable to confirm the 504 timeout response
- [ ] Verify existing backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 30-second timeout to MCP connection initialization (SSE, stdio, HTTP) to prevent hangs when the MCP server is unresponsive. On timeout, cancel the background task and return a 504 Gateway Timeout to the client.

<sup>Written for commit a895c6cea5eb5d7f5c089ce9de0f16410c7715bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

