### PR TITLE
fix(data): use UTC for timestamps in SQLAlchemy data layer

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -2,7 +2,7 @@ import json
 import ssl
 import uuid
 from dataclasses import asdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import aiofiles
@@ -103,7 +103,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
                 return None
 
     async def get_current_timestamp(self) -> str:
-        return datetime.now().isoformat() + "Z"
+        return datetime.now(timezone.utc).isoformat() + "Z"
 
     def clean_result(self, obj):
         """Recursively change UUID -> str and serialize dictionaries"""


### PR DESCRIPTION
## Summary

- Fix `get_current_timestamp()` in `SQLAlchemyDataLayer` to use `datetime.now(timezone.utc)` instead of `datetime.now()`.

## Why

The method `get_current_timestamp()` used `datetime.now()` which returns **local time**, but then appended `"Z"` (the ISO 8601 UTC designator). This resulted in timestamps that claimed to be UTC but were actually in the server's local timezone.

For example, on a server running in UTC+8 (China Standard Time), a timestamp at 2pm local would be stored as `2026-05-10T14:00:00.000000Z`, implying 2pm UTC when it should be 6am UTC.

This bug affects:
- User creation timestamps (`createdAt`)
- Thread creation timestamps

Related issue: #2491 (time handling mismatch causes exceptions)

## Test plan

- [ ] Verify existing tests pass: `uv run pytest tests/` from `backend/`
- [ ] Verify that timestamps stored in the database are correctly in UTC
- [ ] Test on a server running in a non-UTC timezone to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix timestamp timezone handling in the SQLAlchemy data layer by generating UTC-aware ISO strings in `get_current_timestamp()`. Ensures `createdAt` and thread timestamps are true UTC instead of local time labeled as Z, addressing #2491.

<sup>Written for commit 07bbb40a215552bc56437a86fb762ef6b1b7b59a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

