### PR TITLE
fix(useUpload): handle "*/*" accept value as accept-any-file

### DIFF
--- a/frontend/src/hooks/useUpload.tsx
+++ b/frontend/src/hooks/useUpload.tsx
@@ -36,11 +36,17 @@ const useUpload = ({ onError, onResolved, options, spec }: useUploadProps) => {
   const accept = spec.accept;
 
   if (Array.isArray(accept)) {
-    accept.forEach((a) => {
-      if (typeof a === 'string') {
-        dzAccept[a] = [];
-      }
-    });
+    // "*/*" means "any file" but react-dropzone treats it as a literal
+    // MIME and rejects it; an empty accept map falls back to accept-all.
+    if (accept.includes('*/*')) {
+      dzAccept = {};
+    } else {
+      accept.forEach((a) => {
+        if (typeof a === 'string') {
+          dzAccept[a] = [];
+        }
+      });
+    }
   } else if (typeof accept === 'object') {
     dzAccept = accept;
   }


### PR DESCRIPTION
## Problem

Setting `accept = ["*/*"]` in `[features.spontaneous_file_upload]` — the same syntax shown in chainlit's own [default config.toml example comments](https://github.com/Chainlit/chainlit/blob/main/backend/chainlit/config.py) — silently rejects every uploaded file with the browser console warning:

```
Skipped "*/*" because it is not a valid MIME type. Check ... for a list of valid MIME types.
```

react-dropzone treats MIME strings literally; `"*/*"` is not a real MIME type, so the entire accept map is invalidated and no files match.

## Fix

When the configured `accept` array contains the wildcard `"*/*"`, pass an empty accept map (`{}`) to react-dropzone instead. react-dropzone's accept-anything default behavior kicks in.

The minimum change is in `frontend/src/hooks/useUpload.tsx` — about 11 added / 5 removed lines, scoped to the existing `Array.isArray(accept)` branch.

## Repro before the fix

1. In `.chainlit/config.toml`:
   ```toml
   [features.spontaneous_file_upload]
       enabled = true
       accept = ["*/*"]
   ```
2. Run `chainlit run app.py`, open the app, drag any file into the chat input.
3. File silently rejected; browser console shows the "Skipped '*/*'" warning.

## After the fix

Same config, drag any file in → file uploads, no warning.

## Related

- Issue #1678 (the original bug report — same browser warning)
- Closed PR #1709 (a prior attempt; closed for unrelated reasons, and the patch in that PR did not actually change behavior for `"*/*"` — it split and reconstructed the same literal string. This PR uses a different approach that actually fixes the case.)

## Scope

Single-file change, no tests added (the hook isn't covered today and `useDropzone` mocking would be a much larger PR). Verified manually with the repro above against `chainlit==2.11.1` editable install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle `*/*` in `accept` as “accept any file” for spontaneous file uploads by updating `useUpload` to pass an empty accept map to `react-dropzone`. This fixes silent rejections and removes the "Skipped '*/*'" console warning.

<sup>Written for commit eb9f31ebed3988f7d326b35f745ac8a82fbae3d1. Summary will update on new commits. <a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2926?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

