### PR TITLE
fix(socket): handle missing user env

### DIFF
--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -102,6 +102,7 @@ async def resume_thread(session: WebsocketSession):
 
 
 def load_user_env(user_env):
+    user_env_dict = {}
     if user_env:
         user_env_dict = json.loads(user_env)
     # Check user env

--- a/backend/tests/test_socket.py
+++ b/backend/tests/test_socket.py
@@ -403,10 +403,9 @@ class TestLoadUserEnv:
         with patch("chainlit.socket.config") as mock_config:
             mock_config.project.user_env = ["API_KEY"]
 
-            # The function has a bug - it raises UnboundLocalError instead of ConnectionRefusedError
-            # Python 3.10: "referenced before assignment"
-            # Python 3.11+: "cannot access local variable"
-            with pytest.raises(UnboundLocalError, match="user_env_dict"):
+            with pytest.raises(
+                ConnectionRefusedError, match="Missing user environment variables"
+            ):
                 load_user_env(None)
 
     def test_load_user_env_none_without_required_keys(self):
@@ -414,10 +413,9 @@ class TestLoadUserEnv:
         with patch("chainlit.socket.config") as mock_config:
             mock_config.project.user_env = []
 
-            # The function has a bug - it raises NameError when user_env is None
-            # even when no required keys are configured
-            with pytest.raises(NameError, match="user_env_dict"):
-                load_user_env(None)
+            result = load_user_env(None)
+
+            assert result == {}
 
 
 class TestCleanSession:


### PR DESCRIPTION
## Summary
- initialize websocket user env parsing with an empty dict when the client sends no userEnv payload
- keep required user env validation on the intended ConnectionRefusedError path
- update socket tests that previously pinned the NameError/UnboundLocalError behavior

## Validation
- `uv run --no-sync ruff check chainlit/socket.py tests/test_socket.py`
- `uv run --no-sync ruff format --check chainlit/socket.py tests/test_socket.py`
- `uv run --no-sync pytest tests/test_socket.py`

Note: local pytest required temporary empty `chainlit/frontend/dist` and `chainlit/copilot/dist` directories because importing `chainlit.server` expects built UI directories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix WebSocket user env parsing to default to an empty dict when the client sends no payload, while keeping required-key validation. This avoids NameError/UnboundLocalError and raises ConnectionRefusedError only when required vars are missing.

- **Bug Fixes**
  - Initialize `user_env_dict = {}` in `chainlit.socket.load_user_env` when `userEnv` is absent.
  - Update tests to expect `{}` when no keys are required and `ConnectionRefusedError` when required keys are missing.

<sup>Written for commit df30c9b0bfee72fb878b6e8c13a109ab0cb69a8c. Summary will update on new commits. <a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2927?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

