### PR TITLE
fix(teams): support single-tenant bots via TEAMS_APP_TENANT_ID env var

### DIFF
--- a/backend/chainlit/teams/app.py
+++ b/backend/chainlit/teams/app.py
@@ -129,6 +129,7 @@ class TeamsEmitter(BaseChainlitEmitter):
 adapter_settings = BotFrameworkAdapterSettings(
     app_id=os.environ.get("TEAMS_APP_ID"),
     app_password=os.environ.get("TEAMS_APP_PASSWORD"),
+    channel_auth_tenant=os.environ.get("TEAMS_APP_TENANT_ID"),
 )
 adapter = BotFrameworkAdapter(adapter_settings)
 

--- a/backend/tests/test_teams_adapter.py
+++ b/backend/tests/test_teams_adapter.py
@@ -1,0 +1,58 @@
+import importlib
+from unittest.mock import MagicMock, call, patch
+
+
+def _reload_teams_app(monkeypatch, env_vars: dict):
+    """Reload chainlit.teams.app with the given environment variables set."""
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+    # Remove keys not in env_vars so tests are independent
+    for key in ("TEAMS_APP_ID", "TEAMS_APP_PASSWORD", "TEAMS_APP_TENANT_ID"):
+        if key not in env_vars:
+            monkeypatch.delenv(key, raising=False)
+
+    teams_mod = importlib.import_module("chainlit.teams.app")
+    return importlib.reload(teams_mod)
+
+
+def test_teams_adapter_without_tenant(monkeypatch):
+    """Omitting TEAMS_APP_TENANT_ID leaves channel_auth_tenant as None (multi-tenant)."""
+    with (
+        patch("botbuilder.core.BotFrameworkAdapterSettings") as mock_settings,
+        patch("botbuilder.core.BotFrameworkAdapter"),
+    ):
+        mock_settings.return_value = MagicMock()
+        _reload_teams_app(
+            monkeypatch,
+            {"TEAMS_APP_ID": "app-id", "TEAMS_APP_PASSWORD": "app-secret"},
+        )
+        assert mock_settings.call_count >= 1
+        assert mock_settings.call_args_list[-1] == call(
+            app_id="app-id",
+            app_password="app-secret",
+            channel_auth_tenant=None,
+        )
+
+
+def test_teams_adapter_with_tenant(monkeypatch):
+    """Setting TEAMS_APP_TENANT_ID forwards the tenant to BotFrameworkAdapterSettings."""
+    tenant_id = "00000000-0000-0000-0000-000000000001"
+    with (
+        patch("botbuilder.core.BotFrameworkAdapterSettings") as mock_settings,
+        patch("botbuilder.core.BotFrameworkAdapter"),
+    ):
+        mock_settings.return_value = MagicMock()
+        _reload_teams_app(
+            monkeypatch,
+            {
+                "TEAMS_APP_ID": "app-id",
+                "TEAMS_APP_PASSWORD": "app-secret",
+                "TEAMS_APP_TENANT_ID": tenant_id,
+            },
+        )
+        assert mock_settings.call_count >= 1
+        assert mock_settings.call_args_list[-1] == call(
+            app_id="app-id",
+            app_password="app-secret",
+            channel_auth_tenant=tenant_id,
+        )


### PR DESCRIPTION
## Summary

- `BotFrameworkAdapterSettings` now receives `channel_auth_tenant` from the `TEAMS_APP_TENANT_ID` environment variable, enabling single-tenant Azure Bot registrations.
- When `TEAMS_APP_TENANT_ID` is unset the value is `None`, preserving the existing multi-tenant behaviour.
- Two new unit tests cover both code paths (with and without tenant id).

## Related issue

Closes #2919 — _MS Teams integration supports only deprecated multi tenant bots_

## Local verification

```
=== LOCAL_TEST_PASSED ===
$ cd backend && CYPRESS_INSTALL_BINARY=0 uv sync --extra tests
$ uv run pytest tests/test_teams_adapter.py -v
PASSED tests/test_teams_adapter.py::test_teams_adapter_without_tenant
PASSED tests/test_teams_adapter.py::test_teams_adapter_with_tenant
2 passed in 0.35s
$ uv run ruff check chainlit/teams/app.py tests/test_teams_adapter.py
All checks passed!
$ uv run ruff format --check chainlit/teams/app.py tests/test_teams_adapter.py
All checks passed!
```

## Risk

Low. One-line change; the new parameter is optional and defaults to `None` (same as the previous implicit default). No behaviour change for existing multi-tenant deployments.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable single-tenant Microsoft Teams bots by wiring `TEAMS_APP_TENANT_ID` to `BotFrameworkAdapterSettings.channel_auth_tenant` (closes #2919). When unset, behavior stays multi-tenant; tests cover both paths.

<sup>Written for commit 1c86d6455a5e6fcd67838ed56106628c08d70b0c. Summary will update on new commits. <a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

