### PR TITLE
Fix: Invalid data type for the value of `modes`

### DIFF
--- a/backend/chainlit/data/sql_alchemy.py
+++ b/backend/chainlit/data/sql_alchemy.py
@@ -399,6 +399,7 @@ class SQLAlchemyDataLayer(BaseDataLayer):
         }
         parameters["metadata"] = json.dumps(step_dict.get("metadata", {}))
         parameters["generation"] = json.dumps(step_dict.get("generation", {}))
+        parameters["modes"] = json.dumps(step_dict.get("modes", {}))
         columns = ", ".join(f'"{key}"' for key in parameters.keys())
         values = ", ".join(f":{key}" for key in parameters.keys())
         updates = ", ".join(


### PR DESCRIPTION
**Summary**

This PR addresses the issue where the modes parameter was being passed as a dictionary rather than a JSON string. This caused a data type mismatch when inserting/updating the step in the database, leading to an error. This resolves issue #2930.

**Problem Identification:** 
The existing code was passing the modes field directly without serializing it to a JSON string. Causing the step insert queries to fail.

**Solution:**
A single line of code (line 402) has been added in `backend/chainlit/sql_alchemy.py::SQLAlchemyDataLayer` to serialize the modes parameter to a JSON formatted string before being inserted into the database:

```python
parameters["modes"] = json.dumps(step_dict.get("modes", {}))
```
**Impact:**
Fixed the data type issue when interacting with the database.
Ensured that the modes parameter is correctly stored and can be queried in the future.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize the `modes` field to a JSON string before DB insert/update to fix the data type mismatch that caused step writes to fail.

<sup>Written for commit 5430cb17381fe4b0a768116d61a2e47af6a4c3bb. Summary will update on new commits. <a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2931?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

