### PR TITLE
fix(elements): render file elements with null mime instead of crashing

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -241,6 +241,12 @@ class Element:
                 file_type = filetype.guess(self.path or self.content)
                 if file_type:
                     self.mime = file_type.mime
+                else:
+                    # filetype.guess detects by magic bytes only, so text-based
+                    # files (.md, .csv, .txt, source code, ...) return None.
+                    # Fall back to filename-based detection so they still get a
+                    # sensible mime instead of being persisted as NULL.
+                    self.mime = mimetypes.guess_type(self.path or self.name)[0]
             elif self.url:
                 self.mime = mimetypes.guess_type(self.url)[0]
 

--- a/backend/tests/test_element.py
+++ b/backend/tests/test_element.py
@@ -313,6 +313,31 @@ class TestFileElement:
 
             assert file.content == content
 
+    async def test_file_mime_falls_back_to_filename(self, mock_chainlit_context):
+        """Text-based content has no magic bytes, so filetype.guess() returns
+        None. send() should fall back to filename-based detection instead of
+        persisting a null mime (which crashed thread rendering, see #2938)."""
+        async with mock_chainlit_context:
+            file = File(name="notes.md", content=b"# hello\nmarkdown content")
+
+            await file.send(for_id="message_123")
+
+            assert file.mime == "text/markdown"
+
+    async def test_file_mime_falls_back_to_path_filename(
+        self, mock_chainlit_context, tmp_path
+    ):
+        """When only a path is provided, the filename fallback uses the path."""
+        csv_path = tmp_path / "export.csv"
+        csv_path.write_text("a,b\n1,2\n")
+
+        async with mock_chainlit_context:
+            file = File(name="data", path=str(csv_path))
+
+            await file.send(for_id="message_123")
+
+            assert file.mime == "text/csv"
+
 
 @pytest.mark.asyncio
 class TestTaskListElement:

--- a/frontend/src/components/Elements/File.tsx
+++ b/frontend/src/components/Elements/File.tsx
@@ -14,7 +14,7 @@ const FileElement = ({ element }: { element: IFileElement }) => {
       href={element.url}
       target="_blank"
     >
-      <Attachment name={element.name} mime={element.mime!} />
+      <Attachment name={element.name} mime={element.mime} />
     </a>
   );
 };

--- a/frontend/src/components/chat/MessageComposer/Attachment.tsx
+++ b/frontend/src/components/chat/MessageComposer/Attachment.tsx
@@ -11,7 +11,7 @@ import {
 
 interface AttachmentProps {
   name: string;
-  mime: string;
+  mime?: string;
   children?: React.ReactNode;
   file?: File;
 }
@@ -22,7 +22,7 @@ const Attachment: React.FC<AttachmentProps> = ({
   children,
   file
 }) => {
-  const isImage = useMemo(() => mime.startsWith('image/'), [mime]);
+  const isImage = useMemo(() => !!mime?.startsWith('image/'), [mime]);
   const imageUrl = useMemo(() => {
     if (isImage && file) {
       return URL.createObjectURL(file);


### PR DESCRIPTION
## Summary

Opening or resuming a thread that contains a persisted **file element with a `null` mime** crashes the entire thread view with `Cannot read properties of null (reading 'startsWith')`. Because the error is thrown during render, the whole conversation becomes unviewable.

This is a regression from #2783 ("add image preview") and is easy to hit with any text-based file (`.md`, `.csv`, `.txt`, source code, …): `filetype.guess()` detects by magic bytes only, so those files are persisted with `mime = NULL`.

Fixes #2938

## Changes

**Frontend (the crash fix)**
- `Attachment.tsx` — `mime` is now optional and the dereference is guarded: `mime.startsWith('image/')` → `!!mime?.startsWith('image/')`.
- `Elements/File.tsx` — dropped the unsafe `element.mime!` non-null assertion that masked the runtime null.

**Backend (defense-in-depth)**
- `Element.send()` — added a filename-based mime fallback (`mimetypes.guess_type(path or name)`) when `filetype.guess()` returns `None`, so text-based files get a sensible mime instead of being persisted as `NULL`.

**Tests**
- Added two tests covering the mime fallback for content-based and path-based text files.

## Verification
- Backend: `pytest tests/test_element.py` — 45 passed (incl. 2 new)
- Frontend: `tsc --noEmit` clean
- Lint/format: ruff, eslint, prettier all clean on changed files

The frontend guard alone repairs already-broken threads (no data backfill required); the backend fallback prevents new text-file elements from being stored with a null mime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the thread view when rendering file elements with a null `mime`. Adds a frontend guard and a backend filename-based fallback so existing threads open and new text files get a correct mime.

- **Bug Fixes**
  - Frontend: Make `mime` optional in `Attachment.tsx` and guard `startsWith`; remove the non-null assertion in `File.tsx`.
  - Backend: In `Element.send()`, fall back to `mimetypes.guess_type()` when `filetype.guess()` returns `None` (covers `.md`, `.csv`, `.txt`, source files).
  - Tests: Add two tests for the filename-based mime fallback (content and path cases).

<sup>Written for commit 7631a5c95b694c2984006d7741330457831ac39c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

