### PR TITLE
fix(step): use 'is not None' guard to preserve falsy return values in @step decorator

### DIFF
--- a/backend/chainlit/message.py
+++ b/backend/chainlit/message.py
@@ -59,7 +59,7 @@ class MessageBase(ABC):
             self.id = str(uuid.uuid4())
 
     @classmethod
-    def from_dict(self, _dict: StepDict):
+    def from_dict(cls, _dict: StepDict):
         type = _dict.get("type", "assistant_message")
         return Message(
             id=_dict["id"],

--- a/backend/chainlit/step.py
+++ b/backend/chainlit/step.py
@@ -123,7 +123,7 @@ def step(
                         logger.exception(e)
                     result = await func(*args, **kwargs)
                     try:
-                        if result and not step.output:
+                        if result is not None and not step.output:
                             step.output = result
                     except Exception as e:
                         step.is_error = True
@@ -154,7 +154,7 @@ def step(
                         logger.exception(e)
                     result = func(*args, **kwargs)
                     try:
-                        if result and not step.output:
+                        if result is not None and not step.output:
                             step.output = result
                     except Exception as e:
                         step.is_error = True


### PR DESCRIPTION
## Summary

Two fixes in the messaging layer:

### 1. `step.py` — falsy-output silently dropped (primary bug)

The `@step` decorator records the decorated function's return value via:

```python
# Before
if result and not step.output:
    step.output = result
```

A plain truthiness guard (`if result`) silently drops any **falsy-but-meaningful** return value: `0`, `False`, `""`, `[]`, `{}`, etc.

**Example**:
```python
@cl.step
async def count_errors(text: str) -> int:
    # returns 0 when text is clean — this output was NEVER persisted
    return len(find_errors(text))
```

The `0` return is falsy, so `step.output` is never set. The step appears to have no output in the UI, and the value is not persisted.

**Fix**: Use `result is not None` — only skip recording when the function explicitly returns nothing.

```python
# After
if result is not None and not step.output:
    step.output = result
```

This applies to both the `async_wrapper` and `sync_wrapper` paths.

### 2. `message.py` — `@classmethod` names first parameter `self`

`MessageBase.from_dict` is decorated with `@classmethod` but its first parameter is named `self` instead of the conventional `cls`. While Python itself doesn't care about the parameter name, type-checkers (mypy, pyright) and linters flag this as an error, and it misleads readers into thinking `self` is an instance.

Renamed to `cls` following PEP 8 / Python convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `@step` decorator to keep falsy but valid return values (e.g., 0, False, "", [], {}). Ensures step outputs are saved and shown; also aligns a classmethod signature with conventions to satisfy linters.

- **Bug Fixes**
  - `backend/chainlit/step.py`: use `result is not None` in both async and sync wrappers so falsy outputs are recorded.
  - `backend/chainlit/message.py`: rename `self` to `cls` in `from_dict` to follow classmethod convention and pass type-checkers.

<sup>Written for commit 98d81cb0754d0564c19e9ecff043aa90b715028b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

