### PR TITLE
fix: guard against missing 'generated_by' in meta config

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -633,7 +633,7 @@ def load_settings():
         ui_settings = toml_dict.get("UI", {})
         meta = toml_dict.get("meta")
 
-        if not meta or meta.get("generated_by") <= "0.3.0":
+        if not meta or not meta.get("generated_by") or meta.get("generated_by") <= "0.3.0":
             raise ValueError(
                 f"Your config file '{config_file}' is outdated. Please delete it and restart the app to regenerate it."
             )


### PR DESCRIPTION
## Problem

When `config.toml` has a `[meta]` section but lacks a `generated_by` key, the server crashes with:

```
TypeError: '<=' not supported between instances of 'NoneType' and 'str'
```

This happens because `meta.get("generated_by")` returns `None`, and `None <= "0.3.0"` is invalid.

## Fix

Added a guard to check for the key before comparison:

```python
# Before
if not meta or meta.get("generated_by") <= "0.3.0":

# After
if not meta or not meta.get("generated_by") or meta.get("generated_by") <= "0.3.0"::
```

When `generated_by` is missing, the short-circuit now raises the intended `ValueError` with a helpful message instead of crashing with `TypeError`.

**File:** `backend/chainlit/config.py`

Fixes #2942

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent server crash when `config.toml` has a `[meta]` section without `generated_by` by guarding the version check in `backend/chainlit/config.py`. If the key is missing, a clear ValueError is raised instructing users to regenerate the config instead of crashing with a TypeError.

<sup>Written for commit 37f74d1bc81806cae63a1b6986bf8c58d4977edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

