### PR TITLE
fix: handle null/undefined mime in Attachment component

### DIFF
--- a/frontend/src/components/Elements/File.tsx
+++ b/frontend/src/components/Elements/File.tsx
@@ -14,7 +14,7 @@ const FileElement = ({ element }: { element: IFileElement }) => {
       href={element.url}
       target="_blank"
     >
-      <Attachment name={element.name} mime={element.mime!} />
+      <Attachment name={element.name} mime={element.mime} />
     </a>
   );
 };

--- a/frontend/src/components/chat/MessageComposer/Attachment.tsx
+++ b/frontend/src/components/chat/MessageComposer/Attachment.tsx
@@ -11,7 +11,7 @@ import {
 
 interface AttachmentProps {
   name: string;
-  mime: string;
+  mime?: string | null;
   children?: React.ReactNode;
   file?: File;
 }
@@ -22,7 +22,7 @@ const Attachment: React.FC<AttachmentProps> = ({
   children,
   file
 }) => {
-  const isImage = useMemo(() => mime.startsWith('image/'), [mime]);
+  const isImage = useMemo(() => mime?.startsWith('image/') ?? false, [mime]);
   const imageUrl = useMemo(() => {
     if (isImage && file) {
       return URL.createObjectURL(file);


### PR DESCRIPTION
## Problem

When a file element has a null or undefined `mime` property, the Attachment component crashes with:

```
TypeError: Cannot read properties of null (reading 'startsWith')
```

This happens at line 25 where `mime.startsWith('image/')` is called without null checking.

## Fix

**File:** `frontend/src/components/chat/MessageComposer/Attachment.tsx`

1. Changed `mime: string` → `mime?: string | null` in the `AttachmentProps` interface to properly reflect that mime can be null/undefined
2. Changed `mime.startsWith('image/')` → `mime?.startsWith('image/') ?? false` to safely handle null/undefined

Also cleaned up `frontend/src/components/Elements/File.tsx` — removed incorrect non-null assertion `element.mime!` since `IFileElement` already defines `mime` as optional.

Fixes #2938

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash in the `Attachment` component when `mime` is null or undefined by making the prop optional and guarding the image check. Threads now render safely for files without a `mime`.

- **Bug Fixes**
  - `Attachment`: change prop to `mime?: string | null` and use `mime?.startsWith('image/') ?? false`.
  - `File.tsx`: remove non-null assertion and pass `element.mime` directly.

<sup>Written for commit 739051cf94f7ae767876f614ee31de1282c01196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

