### PR TITLE
ci(e2e): ensure Cypress binary is installed before running tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -52,6 +52,9 @@ jobs:
           key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - uses: ./.github/actions/pnpm-node-install
         name: Install Node, pnpm and dependencies.
+      - name: Ensure Cypress binary is installed
+        run: pnpm exec cypress install
+        shell: bash
       - uses: ./.github/actions/uv-python-install
         name: Install Python, uv and Python & pnpm (uv does it automatically) dependencies
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -45,6 +45,10 @@ jobs:
       CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress-cache
     steps:
       - uses: actions/checkout@v6
+      - name: Exclude Cypress cache from Windows Defender
+        if: runner.os == 'Windows'
+        run: Add-MpPreference -ExclusionPath "$env:CYPRESS_CACHE_FOLDER"
+        shell: pwsh
       - name: Cache Cypress binary
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary

- Adds an explicit `pnpm exec cypress install` step to the `e2e-tests` job, between `pnpm-node-install` and `uv-python-install`.
- Fixes the *"Cypress binary is missing"* failure seen on Windows shards (#2957) caused by the `windows-latest` → `windows-2025` runner migration.
- The step is idempotent: when the binary is already present in `CYPRESS_CACHE_FOLDER` it prints "Cypress … already installed" and exits 0; when it's missing it downloads and installs it.

## Root cause

`CYPRESS_CACHE_FOLDER` is backed by a separate `actions/cache` entry keyed on `pnpm-lock.yaml`. The pnpm store (restored by `setup-node`'s `cache: pnpm`) caches the package contents but pnpm skips re-running a dependency's postinstall script when it considers the package already built — so when the pnpm-store cache hits but the `.cypress-cache` misses, the Cypress binary is never downloaded. Ubuntu masked this through more-reliable cache hits; the new Windows runner exposed it reliably.

## Test plan

- [ ] Windows × shard matrix passes without "Cypress binary is missing" errors.
- [ ] Ubuntu shards remain green (no regression).
- [ ] Force a `.cypress-cache` miss (e.g. clear the Actions cache or bump `pnpm-lock.yaml`) and confirm the new step downloads the binary successfully.

Closes #2957

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Cypress binary is present in E2E CI and prevent Windows Defender from quarantining it. Fixes missing binary errors on Windows (`windows-2025`) by adding an explicit install and a Defender exclusion.

- **Bug Fixes**
  - Add `pnpm exec cypress install` after `pnpm-node-install`; idempotent and decouples binary presence from pnpm postinstall/cache mismatches.
  - On Windows, exclude `CYPRESS_CACHE_FOLDER` from Windows Defender before cache/installation to stop `Cypress.exe` from being quarantined.

<sup>Written for commit 787ed8f35004f5013fa85ba409be17c6cc308234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

