### PR TITLE
fix(ui): prevent double vertical scrollbars in latex math rendering

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -96,6 +96,15 @@ code {
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Prevent KaTeX/MathJax rendered math from creating its own vertical scrollbars */
+  .katex,
+  .katex-display,
+  .MathJax,
+  mjx-container {
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+  }
 }
 
 @keyframes loading-shimmer {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Fix duplicate vertical scrollbar when LaTeX rendering is enabled</h1><h2>Summary</h2><p>This PR fixes an issue where enabling <code inline="">latex=true</code> in <code inline="">config.toml</code> could cause two vertical scrollbars to appear in the chat UI when rendering LaTeX content.</p><h2>Root Cause</h2><p>The chat interface already provides a scrollable container for messages. When LaTeX content is rendered, the math wrapper may introduce additional overflow behavior, creating a nested scroll container and resulting in duplicate vertical scrollbars.</p><h2>Changes</h2><ul><li><p>Removed unnecessary vertical overflow handling from LaTeX rendering containers.</p></li><li><p>Restricted LaTeX elements to horizontal scrolling only when needed.</p></li><li><p>Ensured the main chat container remains the sole vertical scroll region.</p></li><li><p>Preserved existing LaTeX rendering behavior and layout.</p></li></ul><h2>Before</h2><ul><li><p><code inline="">latex=true</code> enabled.</p></li><li><p>Sending multiple messages containing LaTeX equations eventually displays <strong>two vertical scrollbars</strong>.</p></li></ul><h2>After</h2><ul><li><p>Only <strong>one vertical scrollbar</strong> is displayed.</p></li><li><p>LaTeX equations render correctly.</p></li><li><p>Normal chat scrolling behavior remains unchanged.</p></li></ul><h2>Testing</h2><h3>Reproduction Steps</h3><ol><li><p>Enable <code inline="">latex=true</code> in <code inline="">config.toml</code>.</p></li><li><p>Run the following application:</p></li></ol><pre><code class="language-python">import chainlit as cl

@cl.on_message
async def main(message: cl.Message):
    await cl.Message(
        content="Here is the quadratic formula:\n$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$"
    ).send()
</code></pre><ol start="3"><li><p>Start Chainlit.</p></li><li><p>Send messages multiple times until the chat becomes scrollable.</p></li></ol><h3>Results</h3>
Scenario | Result
-- | --
Before Fix | Two vertical scrollbars appear
After Fix | Only one vertical scrollbar appears

<img width="1600" height="900" alt="WhatsApp Image 2026-06-19 at 7 42 58 AM" src="https://github.com/user-attachments/assets/af581b61-256b-453d-9d32-39a138748634" />


<h2>References</h2><ul><li><p>Fixes #2949</p></li><li><p>Related to #2003</p></li></ul></body></html><!--EndFragment-->
</body>
</html>