### PR TITLE
Fix: Resolve transparent UI issue in Copilot Light Mode

### DIFF
--- a/libs/copilot/src/index.css
+++ b/libs/copilot/src/index.css
@@ -16,7 +16,7 @@
 }
 
 @layer base {
-  #shadow-root-container {
+  #cl-shadow-root {
     --font-sans: 'Inter', sans-serif;
     --font-mono:
       source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
@@ -54,7 +54,9 @@
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-  .dark {
+  #cl-shadow-root.light {
+  }
+  #cl-shadow-root.dark {
     --background: 0 0% 13%;
     --foreground: 0 0% 93%;
     --card: 0 0% 18%;


### PR DESCRIPTION
### Summary

Fixes the transparent UI issue in Copilot **Light Mode**. This supersedes #2768, which was auto-closed by the stale bot after 7 days of inactivity and can no longer be reopened. Rebased on the latest `main`.

The bug is **still present in the current release (2.11.1)** and on `main`.

### Root cause

The light-mode CSS variables are defined under `#shadow-root-container`, but the shadow root element's actual id is `cl-shadow-root`:

```ts
// libs/copilot/index.tsx
shadowRootElement.id = 'cl-shadow-root';
```

So in `libs/copilot/src/index.css` the base/light variables never match, leaving the Copilot UI transparent in light mode. Dark mode happened to work because it was scoped with a bare `.dark` selector.

### Fix

- Change the base variable selector `#shadow-root-container` → `#cl-shadow-root` so light-mode variables actually apply.
- Scope theme variants to the shadow root element: `.dark` → `#cl-shadow-root.dark`, and add `#cl-shadow-root.light`.

This is correct because `ThemeProvider` adds the `light`/`dark` class directly onto the shadow root element:

```ts
// libs/copilot/src/ThemeProvider.tsx
shadowContainer.classList.remove('light', 'dark');
shadowContainer.classList.add(theme); // shadowContainer === #cl-shadow-root
```

### Notes

- Supersedes #2768 (same fix, rebased on latest `main`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the transparent Copilot UI in Light Mode by applying theme CSS variables to the correct shadow root. Updates selectors so light and dark themes render consistently.

- **Bug Fixes**
  - Changed base selector from `#shadow-root-container` to `#cl-shadow-root` so light-mode variables apply.
  - Scoped theme classes on the shadow root: added `#cl-shadow-root.light` and `#cl-shadow-root.dark`.

<sup>Written for commit 952645a0a679cf1eeeb9d58cd9b89483c6141866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

