### PR TITLE
chore(deps): drop unused `audioop-lts` core dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "packaging>=23.1",
     "python-multipart>=0.0.18,<1.0.0",
     "pyjwt>=2.8.0,<3.0.0",
-    "audioop-lts>=0.2.1,<0.3.0; python_version>='3.13'",
     "pydantic-settings>=2.10.1"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -692,7 +692,6 @@ source = { editable = "backend" }
 dependencies = [
     { name = "aiofiles" },
     { name = "asyncer" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "click" },
     { name = "dataclasses-json" },
     { name = "fastapi" },
@@ -766,7 +765,6 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'tests'", specifier = ">=0.20.0,<1.0.0" },
     { name = "asyncer", specifier = ">=0.0.8,<0.1.0" },
     { name = "asyncpg", marker = "extra == 'custom-data'", specifier = ">=0.30.0,<1.0.0" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'", specifier = ">=0.2.1,<0.3.0" },
     { name = "azure-identity", marker = "extra == 'custom-data'", specifier = ">=1.14.1,<2.0.0" },
     { name = "azure-storage-blob", marker = "extra == 'custom-data'", specifier = ">=12.24.0,<13.0.0" },
     { name = "azure-storage-file-datalake", marker = "extra == 'custom-data'", specifier = ">=12.14.0,<13.0.0" },


### PR DESCRIPTION
`audioop-lts` was promoted to a core backend dependency in #2342,
yet nothing in chainlit imports `audioop`. It only ever mattered as a
transitive dependency of `discord.py`, a tests-extra dependency that
has declared `audioop-lts` itself since 2.5.0, so dropping the direct
pin leaves test resolution unchanged.

Discovered using `pyproject-udeps` [[1]].

[1]: https://github.com/lukehsiao/pyproject-udeps


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `audioop-lts` from backend core dependencies to reduce install surface. Runtime and tests are unchanged; `discord.py` already declares `audioop-lts` since 2.5.0, and `uv.lock` was updated accordingly.

<sup>Written for commit 3ace2844ec62a52eeff1fce16bf5ba5937005873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



