### PR TITLE
fix(elements): reconstruct uploaded PDFs as Pdf elements in Element.from_dict

### DIFF
--- a/backend/chainlit/element.py
+++ b/backend/chainlit/element.py
@@ -181,6 +181,9 @@ class Element:
 
         elif type == "custom":
             return CustomElement(props=e_dict.get("props", {}), **common_params)  # type: ignore[arg-type]
+
+        elif type == "pdf":
+            return Pdf(page=e_dict.get("page"), **common_params)  # type: ignore[arg-type]
         else:
             # Default to File for any other type
             return File(**common_params)  # type: ignore[arg-type]

--- a/backend/tests/test_element.py
+++ b/backend/tests/test_element.py
@@ -582,3 +582,25 @@ class TestDataframeElement:
             assert len(parsed["data"]) == 2
             assert parsed["data"][0][0] == "2026-01-01"
             assert parsed["data"][1][0] == "2025-12-31"
+
+
+@pytest.mark.asyncio
+async def test_from_dict_pdf_reconstructs_pdf(mock_chainlit_context):
+    """A PDF upload (infer_type_from_mime -> 'pdf') must reconstruct as a Pdf element."""
+    async with mock_chainlit_context:
+        mime = "application/pdf"
+        e_dict = {
+            "id": "abc",
+            "name": "report.pdf",
+            "path": "/tmp/report.pdf",
+            "chainlitKey": "abc",
+            "display": "inline",
+            "type": Element.infer_type_from_mime(mime),
+            "mime": mime,
+            "page": 3,
+        }
+        assert e_dict["type"] == "pdf"
+        el = Element.from_dict(e_dict)
+        assert isinstance(el, Pdf)
+        assert el.type == "pdf"
+        assert el.page == 3


### PR DESCRIPTION
### What's broken

`Element.infer_type_from_mime("application/pdf")` returns `"pdf"`, and that value is fed straight into `Element.from_dict` for every user file upload (`emitter.py`, `slack/app.py`, `discord/app.py`, `teams/app.py` all build `{"type": Element.infer_type_from_mime(file["type"]), ...}`). But `from_dict` only special-cases `image/audio/video/plotly/custom` and sends everything else — **including `"pdf"`** — to the `File` default:

```python
el = Element.from_dict({..., "type": "pdf", "mime": "application/pdf"})
# el is a File with type == "file", not a Pdf
```

So an uploaded PDF is reconstructed as a generic `File` and **never renders in the PDF viewer**. The two methods on the same class contradict each other — the distinct `"pdf"` value from `infer_type_from_mime` is silently discarded.

### Fix

Add the missing `"pdf"` branch to `from_dict` so PDFs reconstruct as `Pdf` elements (preserving `page`), mirroring how `plotly` preserves its type-specific field.

### Tests

Adds `test_from_dict_pdf_reconstructs_pdf` to `backend/tests/test_element.py`. The `test_element` PDF/element tests pass (the only failures in the file are pre-existing `pandas`/`polars` dataframe tests that need those optional deps, unrelated to this change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uploaded PDFs being reconstructed as generic files. `Element.from_dict` now rebuilds them as `Pdf` elements so they render in the PDF viewer, preserving the `page` field.

- **Bug Fixes**
  - Added a `"pdf"` branch in `Element.from_dict` that returns `Pdf(page=...)` instead of falling back to `File`.
  - Added `test_from_dict_pdf_reconstructs_pdf` to prevent regression.

<sup>Written for commit 78d6d8df8a5506ebc4d466ff5243a3b5204bcd4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

