### PR TITLE
fix(cache): scope entries by function identity

### DIFF
--- a/backend/chainlit/cache.py
+++ b/backend/chainlit/cache.py
@@ -46,10 +46,8 @@ _cache_lock = threading.Lock()
 
 def cache(func):
     def wrapper(*args, **kwargs):
-        # Create a cache key based on the function name, arguments, and keyword arguments
-        cache_key = (
-            (func.__name__,) + args + tuple((k, v) for k, v in sorted(kwargs.items()))
-        )
+        # Include the function object so same-named callables cannot share entries.
+        cache_key = (func,) + args + tuple((k, v) for k, v in sorted(kwargs.items()))
 
         with _cache_lock:
             # Check if the result is already in the cache

--- a/backend/tests/test_cache.py
+++ b/backend/tests/test_cache.py
@@ -228,6 +228,22 @@ class TestCacheDecorator:
         assert call_count_1 == 1
         assert call_count_2 == 1
 
+    def test_cache_distinguishes_different_functions_with_same_name(self):
+        """Test that function identity, not only its name, scopes cache entries."""
+
+        def make_loader(value):
+            @cache
+            def load(key):
+                return value
+
+            return load
+
+        first = make_loader("first")
+        second = make_loader("second")
+
+        assert first("same") == "first"
+        assert second("same") == "second"
+
     def test_cache_with_none_arguments(self):
         """Test cache with None as argument."""
         call_count = 0


### PR DESCRIPTION
## Summary

The global cache key now includes the decorated function object instead of only `func.__name__`. Distinct same-named callables can no longer return each other's cached values, while argument and thread-safety behavior remains unchanged.

## Testing

- `uv run --project backend --extra tests pytest tests/test_cache.py -q` (24 passed)
- scoped Python lint and format checks
- full backend mypy (109 source files, no issues)

Fixes #2985

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache keys now include the function object, not just the name, so same-named functions (including closures) no longer share cached results. Argument handling and thread-safety remain unchanged.

- **Bug Fixes**
  - Scope entries by function identity to prevent cache collisions (fixes #2985).
  - Added a test to ensure two `load` closures with the same name cache independently.

<sup>Written for commit 8bee94440e597671b57b12f80d88079806006d25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

