### PR TITLE
fix(settings): validate DatePicker mode and bounds

### DIFF
--- a/backend/chainlit/input_widget.py
+++ b/backend/chainlit/input_widget.py
@@ -340,12 +340,11 @@ class DatePicker(InputWidget):
         if self.mode not in ("single", "range"):
             raise ValueError("mode must be 'single' or 'range'")
 
-        if (
-            self.mode == "range"
-            and self.initial is not None
-            and not isinstance(self.initial, tuple)
-        ):
-            raise ValueError("'initial' must be a tuple for range mode")
+        if self.initial is not None:
+            if self.mode == "range" and not isinstance(self.initial, tuple):
+                raise ValueError("'initial' must be a tuple for range mode")
+            if self.mode == "single" and isinstance(self.initial, tuple):
+                raise ValueError("'initial' must be a single date for single mode")
 
         (initial_start, initial_end), min_date, max_date = (
             [
@@ -362,7 +361,8 @@ class DatePicker(InputWidget):
 
         if self.mode == "range":
             self._validate_range(initial_start, initial_end, "initial")
-            self._validate_range(min_date, max_date, "[min_date, max_date]")
+
+        self._validate_range(min_date, max_date, "[min_date, max_date]")
 
         # Validate that initial value(s) are within min_date and max_date bounds
         for d in [initial_start, initial_end]:

--- a/backend/tests/test_input_widget.py
+++ b/backend/tests/test_input_widget.py
@@ -2,6 +2,7 @@ import pytest
 
 from chainlit.input_widget import (
     Checkbox,
+    DatePicker,
     MultiSelect,
     NumberInput,
     RadioGroup,
@@ -627,6 +628,29 @@ class TestTabWidget:
         assert result["id"] == "test_tab"
         assert result["label"] == "Empty Tab"
         assert result["inputs"] == []
+
+
+class TestDatePickerWidget:
+    def test_single_mode_rejects_range_initial_value(self):
+        with pytest.raises(
+            ValueError, match="'initial' must be a single date for single mode"
+        ):
+            DatePicker(
+                id="date",
+                label="Date",
+                mode="single",
+                initial=("2026-01-01", "2026-01-02"),
+            )
+
+    def test_single_mode_rejects_inverted_bounds(self):
+        with pytest.raises(ValueError, match="start must be before end"):
+            DatePicker(
+                id="date",
+                label="Date",
+                mode="single",
+                min_date="2026-02-01",
+                max_date="2026-01-01",
+            )
 
 
 class TestInputWidgetEdgeCases:


### PR DESCRIPTION
## Summary

- reject range tuples when `DatePicker` is configured in single mode
- validate `min_date <= max_date` for both single and range pickers
- add regression coverage for both invalid configurations

## Testing

- `uv run --project backend --extra tests pytest tests/test_input_widget.py -q` (55 passed)
- scoped Python lint and format checks
- full backend mypy (109 source files, no issues)

Fixes #2986

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `DatePicker` mode and bounds to prevent invalid configs: enforce tuple `initial` in range mode, reject tuple `initial` in single mode, and always enforce `min_date <= max_date`. Adds tests for single-mode tuple `initial` and inverted bounds. Fixes #2986.

<sup>Written for commit 01407389027474f46bfcfa922d652bd5dc58b9e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

