### PR TITLE
ci: install Cypress binary before e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -52,6 +52,9 @@ jobs:
           key: cypress-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - uses: ./.github/actions/pnpm-node-install
         name: Install Node, pnpm and dependencies.
+      - name: Ensure Cypress binary is installed
+        run: pnpm exec cypress install
+        shell: bash
       - uses: ./.github/actions/uv-python-install
         name: Install Python, uv and Python & pnpm (uv does it automatically) dependencies
         with:


### PR DESCRIPTION
## Summary

- explicitly run `pnpm exec cypress install` after dependency installation
- restore the Cypress binary on cache misses before any e2e shard starts
- keep the existing cache, matrix, and fail-fast behavior unchanged

This matches the e2e setup documented in `CONTRIBUTING.md` and prevents Windows runners from failing before executing a spec when the binary cache is cold.

Closes #2957

## Validation

- parsed `.github/workflows/e2e-tests.yaml` with Ruby YAML
- checked the workflow with the repository Prettier configuration
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly install the `cypress` binary in CI after dependencies to prevent e2e shards from failing on Windows when the cache is cold. Added `pnpm exec cypress install` to `.github/workflows/e2e-tests.yaml`; caching, matrix, and fail-fast settings are unchanged.

<sup>Written for commit b40cdf307ef41ba9b862c7849d29af177200f3b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

