### PR TITLE
Fix chat profile welcome description without icon

### DIFF
--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -49,29 +49,36 @@ export default function WelcomeScreen(props: Props) {
       const currentChatProfile = chatProfiles.find(
         (cp) => cp.name === chatProfile
       );
-      if (currentChatProfile?.icon) {
-        return (
-          <div className="flex flex-col gap-2 mb-2 items-center">
+      if (!currentChatProfile) return null;
+
+      const profileIcon = currentChatProfile.icon
+        ? currentChatProfile.icon.startsWith('/public')
+          ? apiClient.buildEndpoint(currentChatProfile.icon)
+          : currentChatProfile.icon
+        : null;
+
+      return (
+        <div className="flex flex-col gap-2 mb-2 items-center">
+          {profileIcon ? (
             <img
               className="h-16 w-16 rounded-full"
-              src={
-                currentChatProfile?.icon.startsWith('/public')
-                  ? apiClient.buildEndpoint(currentChatProfile?.icon)
-                  : currentChatProfile?.icon
-              }
+              src={profileIcon}
+              alt={currentChatProfile.display_name || currentChatProfile.name}
             />
-            {currentChatProfile?.markdown_description ? (
-              <Markdown
-                allowHtml={allowHtml}
-                latex={latex}
-                renderMarkdown={true}
-              >
-                {currentChatProfile.markdown_description}
-              </Markdown>
-            ) : null}
-          </div>
-        );
-      }
+          ) : (
+            <Logo className="w-[200px] mb-2" />
+          )}
+          {currentChatProfile?.markdown_description ? (
+            <Markdown
+              allowHtml={allowHtml}
+              latex={latex}
+              renderMarkdown={true}
+            >
+              {currentChatProfile.markdown_description}
+            </Markdown>
+          ) : null}
+        </div>
+      );
     }
 
     return <Logo className="w-[200px] mb-2" />;

--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -49,7 +49,9 @@ export default function WelcomeScreen(props: Props) {
       const currentChatProfile = chatProfiles.find(
         (cp) => cp.name === chatProfile
       );
-      if (!currentChatProfile) return null;
+      if (!currentChatProfile) {
+        return <Logo className="w-[200px] mb-2" />;
+      }
 
       const profileIcon = currentChatProfile.icon
         ? currentChatProfile.icon.startsWith('/public')


### PR DESCRIPTION
## Summary
- Decouple chat profile welcome description rendering from icon presence so markdown_description always renders when provided.
- Keep existing logo fallback behavior when icon is missing.

Closes issue #2935.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the welcome screen so a chat profile’s `markdown_description` shows even without an icon. Fixes #2935.

- **Bug Fixes**
  - Always render `markdown_description` independent of icon presence.
  - Normalize icon URLs via `apiClient.buildEndpoint`; add descriptive `alt` text; show `Logo` when no icon or the selected profile is missing/unmatched.

<sup>Written for commit 70b3cc79f56cb6afe47aaa2875676ea960515cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

