### PR TITLE
fix(cli): make lint-translations exit non-zero when translations differ

### DIFF
--- a/backend/chainlit/cli/__init__.py
+++ b/backend/chainlit/cli/__init__.py
@@ -26,6 +26,7 @@ from chainlit.config import (
 from chainlit.logger import logger
 from chainlit.markdown import init_markdown
 from chainlit.secret import random_secret
+from chainlit.translations import _safe_print
 from chainlit.utils import check_file
 
 logging.basicConfig(
@@ -241,4 +242,10 @@ def chainlit_create_secret(args=None, **kwargs):
 @cli.command("lint-translations")
 @click.argument("args", nargs=-1)
 def chainlit_lint_translations(args=None, **kwargs):
-    lint_translations()
+    error_count = lint_translations()
+    if error_count:
+        _safe_print(
+            f"\n❌ Found {error_count} translation "
+            f"{'difference' if error_count == 1 else 'differences'}."
+        )
+        raise SystemExit(1)

--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -860,22 +860,31 @@ def load_config():
     return ChainlitConfig(**settings)
 
 
-def lint_translations():
+def lint_translations() -> int:
+    """Lint the app's translation files against the packaged ``en-US.json``.
+
+    Returns the total number of structural differences found, so callers can
+    fail instead of reporting success on a broken translation.
+    """
     # Load the ground truth (en-US.json file from chainlit source code)
     src = os.path.join(TRANSLATIONS_DIR, "en-US.json")
     with open(src, encoding="utf-8") as f:
         truth = json.load(f)
 
-        # Find the local app translations
-        for file in os.listdir(config_translation_dir):
-            if file.endswith(".json"):
-                # Load the translation file
-                to_lint = os.path.join(config_translation_dir, file)
-                with open(to_lint, encoding="utf-8") as f2:
-                    translation = json.load(f2)
+    error_count = 0
 
-                    # Lint the translation file
-                    lint_translation_json(file, truth, translation)
+    # Find the local app translations. Sorted so the report is deterministic.
+    for file in sorted(os.listdir(config_translation_dir)):
+        if file.endswith(".json"):
+            # Load the translation file
+            to_lint = os.path.join(config_translation_dir, file)
+            with open(to_lint, encoding="utf-8") as f2:
+                translation = json.load(f2)
+
+            # Lint the translation file
+            error_count += len(lint_translation_json(file, truth, translation))
+
+    return error_count
 
 
 config = load_config()

--- a/backend/chainlit/translations.py
+++ b/backend/chainlit/translations.py
@@ -60,6 +60,11 @@ def compare_json_structures(truth, to_compare, path=""):
 
 
 def lint_translation_json(file, truth, to_compare):
+    """Print the structural differences between a translation and the truth.
+
+    Returns the list of differences so callers can distinguish a clean
+    translation from a broken one instead of relying on the printed output.
+    """
     _safe_print(f"\nLinting {file}...")
 
     errors = compare_json_structures(truth, to_compare)
@@ -69,3 +74,5 @@ def lint_translation_json(file, truth, to_compare):
             _safe_print(f"{error}")
     else:
         _safe_print(f"✅ No errors found in {file}")
+
+    return errors

--- a/backend/tests/test_translations.py
+++ b/backend/tests/test_translations.py
@@ -1,8 +1,11 @@
+import json
 from io import BytesIO, StringIO, TextIOWrapper
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from chainlit import config as config_module
 from chainlit.translations import compare_json_structures, lint_translation_json
 
 
@@ -421,3 +424,80 @@ class TestTranslationsEdgeCases:
         missing_errors = [e for e in errors if "Missing" in e]
         assert len(extra_errors) == 2
         assert len(missing_errors) == 3
+
+
+class TestLintTranslationJsonReturnValue:
+    """``lint_translation_json`` must report differences to its caller.
+
+    It previously only printed them and returned ``None``, so every caller -
+    including the ``lint-translations`` CLI command - had no way to tell a
+    clean translation from a broken one.
+    """
+
+    def test_returns_the_errors_it_printed(self):
+        """A broken translation returns its differences."""
+        truth = {"key1": "value1", "key2": "value2"}
+        to_compare = {"key1": "value1"}
+
+        with patch("sys.stdout", new=StringIO()):
+            errors = lint_translation_json("broken.json", truth, to_compare)
+
+        assert errors == ["❌ Missing key: 'key2'"]
+
+    def test_returns_empty_list_for_a_clean_translation(self):
+        """A matching translation returns no differences."""
+        truth = {"key1": "value1"}
+
+        with patch("sys.stdout", new=StringIO()):
+            errors = lint_translation_json("clean.json", truth, {"key1": "value1"})
+
+        assert errors == []
+
+
+class TestLintTranslationsExitCode:
+    """``chainlit lint-translations`` must fail on a broken translation.
+
+    ``lint_translations()`` returned ``None`` and the CLI command ignored it,
+    so the command exited 0 even when keys were missing and could not be used
+    as a CI gate.
+    """
+
+    def _seed_translation_dir(self, tmp_path, mutate=None):
+        """Copy the packaged ground truth into a temp dir, optionally broken."""
+        truth_path = Path(config_module.TRANSLATIONS_DIR) / "en-US.json"
+        payload = json.loads(truth_path.read_text(encoding="utf-8"))
+        if mutate is not None:
+            mutate(payload)
+        (tmp_path / "en-US.json").write_text(
+            json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_returns_zero_when_translations_match(self, tmp_path):
+        """An untouched copy of the ground truth reports no differences."""
+        self._seed_translation_dir(tmp_path)
+
+        with patch("chainlit.config.config_translation_dir", str(tmp_path)):
+            with patch("sys.stdout", new=StringIO()):
+                assert config_module.lint_translations() == 0
+
+    def test_counts_differences_when_a_key_is_missing(self, tmp_path):
+        """Dropping a top-level key is reported as one difference."""
+
+        def drop_chat(payload):
+            payload.pop("chat", None)
+
+        self._seed_translation_dir(tmp_path, drop_chat)
+
+        with patch("chainlit.config.config_translation_dir", str(tmp_path)):
+            with patch("sys.stdout", new=StringIO()):
+                assert config_module.lint_translations() == 1
+
+    def test_ignores_non_json_files(self, tmp_path):
+        """Stray files in the translations directory are not linted."""
+        self._seed_translation_dir(tmp_path)
+        (tmp_path / "notes.txt").write_text("not a translation", encoding="utf-8")
+
+        with patch("chainlit.config.config_translation_dir", str(tmp_path)):
+            with patch("sys.stdout", new=StringIO()):
+                assert config_module.lint_translations() == 0


### PR DESCRIPTION
## Problem

`chainlit lint-translations` reports differences and then exits 0, so it cannot gate anything. Issue #2993 identified this as the reason locale keys drift unnoticed, and it is true even for the app translations the command is actually pointed at.

The chain is silent end to end:

- `lint_translation_json` prints the differences and returns `None`
- `lint_translations` returns `None`
- `chainlit_lint_translations` calls it and ignores the result, so Click exits 0

## Change

- `lint_translation_json` returns the differences it printed. Additive - existing callers that ignore the return value are unaffected, and the printed output is unchanged.
- `lint_translations` returns the total count across all linted files.
- The CLI command prints a summary and raises `SystemExit(1)` when the count is non-zero.

Two incidental cleanups in the same function: the per-file loop was nested inside the ground-truth `with open(...)` block, holding that handle open for the entire run, so it is dedented; and `os.listdir` is now sorted so the report order is deterministic. Happy to drop either if you would rather keep the diff to the exit code alone.

## Verification

Ran on Windows against a directory containing all 23 packaged locales, comparing a clean `main` worktree with the patched tree:

| | files linted | differences reported | exit code |
| --- | ---: | ---: | ---: |
| `main` | 23 | 6 | **0** |
| patched | 23 | 6 | **1** |

Same six differences either way - only the exit code changes. A directory whose translations match the ground truth still exits 0.

The six it finds are the real gaps from #2993, which is a useful independent cross-check: this is the CLI path rather than the test suite, and it reports exactly `chat.favorites.remove` (ar-SA, da-DK), `components.DatePickerInput` (de-DE, it, ko) and `chat.fileUpload.browse` (ja).

`pytest backend/tests/test_translations.py` - 41 passed. That is the 39 from this PR plus the two cp1252 regression tests added by #3006, both preserved through the rebase. New tests here cover the returned error list, the aggregate count for both clean and broken input, and that non-JSON files in the directory are ignored.

`ruff format --check` clean on all four files. `ruff check` reports two RUF036 findings at `config.py:477-478` (`on_app_startup` / `on_app_shutdown`), which are pre-existing on `main` and untouched by this change.

## Note

The `UnicodeEncodeError` I originally flagged in this section - a stock Windows console cannot encode the `✅` / `❌` markers - was filed as #2997 and fixed upstream by #3006 while this PR was open. So that note is resolved, and #3006 touching the same two files is what produced the merge conflicts.

Now rebased onto current `main`. The conflicts were both mechanical:

- `translations.py` - kept #3006's `_safe_print` calls, re-applied this PR's docstring and `return errors`.
- `test_translations.py` - union of the two import sets; the test bodies did not overlap, so both sets are intact.

One follow-through worth calling out: the summary line this PR adds also carries a `❌`, so it now goes through #3006's `_safe_print` rather than a bare `print`. Otherwise the CLI layer would reintroduce in the command exactly the crash #3006 just fixed in the library. Verified against a cp1252 stdout - the command still exits 1 and the marker degrades to `?` instead of raising. Happy to add a regression test for that CLI path, or to drop the change, whichever you prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `chainlit lint-translations` fail fast when translations differ. Previously it printed differences and exited 0; now it exits 1 so CI can gate locale changes.

- `lint_translation_json` returns the list of differences (printed output unchanged).
- `lint_translations` returns the total difference count and sorts the directory listing for deterministic reports.
- The CLI prints a summary and exits 1 when the count is non-zero.
- Moved the per-file loop out of the ground-truth `with open(...)` block to avoid holding the handle open.
- Tests cover returned errors, aggregate counts for clean/broken inputs, and ignoring non-JSON files.

<sup>Written for commit af2f7ad24e267a858d88384308b2776abfabbdc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/2996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
