### PR TITLE
Handle UnicodeEncodeError in lint-translations on Windows consoles

### DIFF
--- a/backend/chainlit/translations.py
+++ b/backend/chainlit/translations.py
@@ -1,6 +1,17 @@
+import sys
+
 # TODO:
 # - Support linting plural
 # - Support interpolation
+
+
+def _safe_print(message: str) -> None:
+    """Print, degrading when the stream cannot encode the text."""
+    try:
+        print(message)
+    except UnicodeEncodeError:
+        encoding = sys.stdout.encoding or "ascii"
+        print(message.encode(encoding, "replace").decode(encoding, "replace"))
 
 
 def compare_json_structures(truth, to_compare, path=""):
@@ -49,12 +60,12 @@ def compare_json_structures(truth, to_compare, path=""):
 
 
 def lint_translation_json(file, truth, to_compare):
-    print(f"\nLinting {file}...")
+    _safe_print(f"\nLinting {file}...")
 
     errors = compare_json_structures(truth, to_compare)
 
     if errors:
         for error in errors:
-            print(f"{error}")
+            _safe_print(error)
     else:
-        print(f"✅ No errors found in {file}")
+        _safe_print(f"✅ No errors found in {file}")

--- a/backend/tests/test_translations.py
+++ b/backend/tests/test_translations.py
@@ -1,3 +1,5 @@
+import io
+import sys
 from io import StringIO
 from unittest.mock import patch
 
@@ -235,6 +237,25 @@ class TestLintTranslationJson:
 
             assert "Linting test.json..." in output
             assert "✅ No errors found in test.json" in output
+
+    def test_lint_with_cp1252_stdout(self):
+        """Regression test for Windows cp1252 consoles."""
+
+        truth = {"key": "value"}
+        to_compare = {}
+
+        buffer = io.BytesIO()
+        stdout = io.TextIOWrapper(buffer, encoding="cp1252")
+
+        with patch.object(sys, "stdout", stdout):
+            lint_translation_json("test.json", truth, to_compare)
+
+        stdout.flush()
+        buffer.seek(0)
+        output = buffer.read().decode("cp1252")
+
+        assert "Linting test.json..." in output
+        assert "Missing key: 'key'" in output
 
     def test_lint_with_errors(self):
         """Test linting when there are errors."""


### PR DESCRIPTION
## Summary

Fixes #2997.

This change adds a small `_safe_print()` helper to gracefully handle `UnicodeEncodeError` when `lint-translations` is run on Windows consoles using legacy code pages (for example, cp1252).

Instead of crashing when printing Unicode status markers (✅, ❌, ⚠️), the output is encoded using the current stdout encoding with replacement characters when the console cannot represent those symbols.

## Changes

- Add `_safe_print()` helper.
- Route all output in `lint_translation_json()` through `_safe_print()`.
- Add a regression test that simulates a `cp1252` stdout stream.

## Testing

```bash
python -m pytest backend/tests/test_translations.py -v
python -m ruff check backend/chainlit/translations.py backend/tests/test_translations.py