### PR TITLE
fix(cli): avoid lint-translations UnicodeEncodeError on legacy consoles

### DIFF
--- a/backend/chainlit/translations.py
+++ b/backend/chainlit/translations.py
@@ -1,6 +1,17 @@
+import sys
+
 # TODO:
 # - Support linting plural
 # - Support interpolation
+
+
+def _safe_print(message: str) -> None:
+    """Print without crashing on streams that cannot encode emoji markers."""
+    try:
+        print(message)
+    except UnicodeEncodeError:
+        encoding = sys.stdout.encoding or "ascii"
+        print(message.encode(encoding, "replace").decode(encoding, "replace"))
 
 
 def compare_json_structures(truth, to_compare, path=""):
@@ -49,12 +60,12 @@ def compare_json_structures(truth, to_compare, path=""):
 
 
 def lint_translation_json(file, truth, to_compare):
-    print(f"\nLinting {file}...")
+    _safe_print(f"\nLinting {file}...")
 
     errors = compare_json_structures(truth, to_compare)
 
     if errors:
         for error in errors:
-            print(f"{error}")
+            _safe_print(f"{error}")
     else:
-        print(f"✅ No errors found in {file}")
+        _safe_print(f"✅ No errors found in {file}")

--- a/backend/tests/test_translations.py
+++ b/backend/tests/test_translations.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from unittest.mock import patch
 
 import pytest
@@ -224,6 +224,12 @@ class TestCompareJsonStructures:
 class TestLintTranslationJson:
     """Test suite for lint_translation_json function."""
 
+    @staticmethod
+    def _cp1252_stdout():
+        raw = BytesIO()
+        stream = TextIOWrapper(raw, encoding="cp1252")
+        return raw, stream
+
     def test_lint_with_no_errors(self):
         """Test linting when there are no errors."""
         truth = {"key1": "value1", "key2": "value2"}
@@ -309,6 +315,37 @@ class TestLintTranslationJson:
             lines = output.strip().split("\n")
             assert "Linting format.json..." in lines[0]
             assert len(lines) >= 2  # At least linting message + errors
+
+    def test_lint_with_errors_on_legacy_stdout_encoding(self):
+        """Test linting degrades markers when stdout cannot encode them."""
+        truth = {"key1": "value1"}
+        to_compare = {"key2": "value2"}
+        raw, stream = self._cp1252_stdout()
+
+        with patch("sys.stdout", new=stream):
+            lint_translation_json("test.json", truth, to_compare)
+            stream.flush()
+
+        output = raw.getvalue().decode("cp1252")
+
+        assert "Linting test.json..." in output
+        assert "Missing key: 'key1'" in output
+        assert "Extra key: 'key2'" in output
+
+    def test_lint_success_on_legacy_stdout_encoding(self):
+        """Test success output does not crash on legacy stdout encodings."""
+        truth = {"key1": "value1"}
+        to_compare = {"key1": "value1"}
+        raw, stream = self._cp1252_stdout()
+
+        with patch("sys.stdout", new=stream):
+            lint_translation_json("test.json", truth, to_compare)
+            stream.flush()
+
+        output = raw.getvalue().decode("cp1252")
+
+        assert "Linting test.json..." in output
+        assert "No errors found in test.json" in output
 
 
 class TestTranslationsEdgeCases:


### PR DESCRIPTION
Fixes #2997

## Summary
- add a safe print helper for translation lint output
- degrade emoji markers when stdout cannot encode them instead of crashing
- cover both error and success paths with legacy cp1252 stdout regression tests

## Verification
- manual reproduction with cp1252-wrapped stdout no longer crashes
- `uv run --no-project pytest backend/tests/test_translations.py`
- `uv run --no-project ruff check backend/chainlit/translations.py backend/tests/test_translations.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CLI translation linter from crashing on consoles that can’t encode emojis (e.g., cp1252). Output now degrades safely instead of raising UnicodeEncodeError.

- **Bug Fixes**
  - Added `_safe_print` to handle unencodable characters based on `sys.stdout.encoding`.
  - Replaced direct `print` calls with `_safe_print` in lint output.
  - Added regression tests using a cp1252-wrapped stdout for both error and success paths.

<sup>Written for commit 76b4752f314a85fe65e63e3667c8887b3010ea12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

