### PR TITLE
fix(e2e): de-flake thread_resume by waiting on the resume replay

### DIFF
--- a/cypress/e2e/thread_resume/main.py
+++ b/cypress/e2e/thread_resume/main.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 
 import chainlit as cl
 import chainlit.data as cl_data
+from chainlit.data.utils import queue_until_user_message
 from chainlit.element import Element, ElementDict
 from chainlit.step import StepDict
 from chainlit.types import (
@@ -21,6 +22,42 @@ now = utc_now()
 
 # Simple in-memory persistence for threads per user
 THREADS: Dict[str, List[ThreadDict]] = {}
+
+
+def find_thread(thread_id: str) -> Optional[ThreadDict]:
+    """Return the stored thread with this id, whichever user bucket holds it."""
+    for threads in THREADS.values():
+        for thread in threads:
+            if thread["id"] == thread_id:
+                return thread
+    return None
+
+
+def ensure_thread(thread_id: str, user_id: Optional[str] = None) -> ThreadDict:
+    """Return the stored thread with this id, creating the row if needed.
+
+    Steps can be persisted before the first `update_thread` call, so a row may
+    have to be created without an owner. Re-home it when the owner shows up
+    instead of appending a second, empty row under the user.
+    """
+    thread = find_thread(thread_id)
+    if thread is None:
+        thread = {
+            "id": thread_id,
+            "createdAt": utc_now(),
+            "userId": user_id,
+            "userIdentifier": user_id,
+            "name": thread_id,
+            "steps": [],
+        }
+        THREADS.setdefault(user_id or "", []).append(thread)
+    elif user_id and thread.get("userIdentifier") != user_id:
+        for uid, threads in THREADS.items():
+            THREADS[uid] = [t for t in threads if t is not thread]
+        thread["userId"] = user_id
+        thread["userIdentifier"] = user_id
+        THREADS.setdefault(user_id, []).append(thread)
+    return thread
 
 
 class MemoryDataLayer(cl_data.BaseDataLayer):
@@ -55,14 +92,26 @@ class MemoryDataLayer(cl_data.BaseDataLayer):
     async def delete_element(self, element_id: str, thread_id: Optional[str] = None):
         pass
 
+    @queue_until_user_message()
     async def create_step(self, step_dict: "StepDict"):
-        pass
+        thread_id = step_dict.get("threadId")
+        if not thread_id:
+            return
+        steps = ensure_thread(thread_id)["steps"]
+        for index, existing in enumerate(steps):
+            if existing["id"] == step_dict["id"]:
+                steps[index] = step_dict
+                return
+        steps.append(step_dict)
 
+    @queue_until_user_message()
     async def update_step(self, step_dict: "StepDict"):
-        pass
+        await self.create_step(step_dict)
 
+    @queue_until_user_message()
     async def delete_step(self, step_id: str):
-        pass
+        for thread in (t for threads in THREADS.values() for t in threads):
+            thread["steps"] = [s for s in thread["steps"] if s["id"] != step_id]
 
     async def get_thread_author(self, thread_id: str) -> str:
         return (await self.get_thread(thread_id))["userIdentifier"]
@@ -96,18 +145,7 @@ class MemoryDataLayer(cl_data.BaseDataLayer):
         metadata: Optional[Dict] = None,
         tags: Optional[List[str]] = None,
     ):
-        user_threads = THREADS.setdefault(user_id or "", [])
-        thr = next((t for t in user_threads if t["id"] == thread_id), None)
-        if not thr:
-            thr = {
-                "id": thread_id,
-                "createdAt": utc_now(),
-                "userId": user_id,
-                "userIdentifier": user_id,
-                "name": name or thread_id,
-                "steps": [],
-            }
-            user_threads.append(thr)
+        thr = ensure_thread(thread_id, user_id)
         if name:
             thr["name"] = name
         if metadata is not None:

--- a/cypress/e2e/thread_resume/spec.cy.ts
+++ b/cypress/e2e/thread_resume/spec.cy.ts
@@ -21,7 +21,18 @@ describe('Thread resume (author)', () => {
   it('resumes own thread, composer visible, can continue chatting', () => {
     login('alice');
 
-    // Start a thread and let the first turn finish before reloading
+    // `on_chat_start` sends its welcome message asynchronously. While the
+    // message list is empty `WelcomeScreen` renders the composer and `Footer`
+    // renders nothing; the first message flips `hasMessage()` and swaps which
+    // of the two owns it, remounting the input. Wait for that swap before
+    // typing, or the typed value is dropped mid-`type()`.
+    cy.get("[data-step-type='assistant_message']").should(
+      'contain',
+      'Welcome, say hi to start!'
+    );
+
+    // Start a thread and let the first turn finish, so the data layer has
+    // persisted it and there is a history for resume to replay.
     submitMessage('hi');
     cy.location('pathname').should('match', /\/thread\//);
     cy.get("[data-step-type='assistant_message']").should(
@@ -36,15 +47,17 @@ describe('Thread resume (author)', () => {
     cy.get('#message-composer').should('be.visible');
     cy.get('[data-testid="read-only-banner"]').should('not.exist');
 
-    // `#message-composer` turns visible before the thread has finished
-    // hydrating. Wait for the `@cl.on_chat_resume` message to land and for the
-    // task to end (the composer shows a stop button while one is running),
-    // otherwise the send button re-renders under the click.
+    // `#message-composer` is visible well before the thread has hydrated. The
+    // backend's resume path emits, in order: the `@cl.on_chat_resume` message,
+    // then `resume_thread` with the persisted history -- and the client's
+    // `resume_thread` handler *replaces* the whole message list with it. So
+    // `Echo: hi` can only come from that replay, which is the last write to
+    // the list; once it is on screen every resume event has landed and the
+    // composer has stopped remounting.
     cy.get("[data-step-type='assistant_message']").should(
       'contain',
-      'Resumed:'
+      'Echo: hi'
     );
-    cy.get('#stop-button').should('not.exist');
 
     // Continue chatting
     submitMessage('still here');

--- a/cypress/e2e/thread_resume/spec.cy.ts
+++ b/cypress/e2e/thread_resume/spec.cy.ts
@@ -21,9 +21,13 @@ describe('Thread resume (author)', () => {
   it('resumes own thread, composer visible, can continue chatting', () => {
     login('alice');
 
-    // Start a thread
+    // Start a thread and let the first turn finish before reloading
     submitMessage('hi');
     cy.location('pathname').should('match', /\/thread\//);
+    cy.get("[data-step-type='assistant_message']").should(
+      'contain',
+      'Echo: hi'
+    );
 
     // Reload to trigger resume
     cy.reload();
@@ -31,6 +35,16 @@ describe('Thread resume (author)', () => {
     // Composer present and no read-only banner
     cy.get('#message-composer').should('be.visible');
     cy.get('[data-testid="read-only-banner"]').should('not.exist');
+
+    // `#message-composer` turns visible before the thread has finished
+    // hydrating. Wait for the `@cl.on_chat_resume` message to land and for the
+    // task to end (the composer shows a stop button while one is running),
+    // otherwise the send button re-renders under the click.
+    cy.get("[data-step-type='assistant_message']").should(
+      'contain',
+      'Resumed:'
+    );
+    cy.get('#stop-button').should('not.exist');
 
     // Continue chatting
     submitMessage('still here');

--- a/cypress/support/testUtils.ts
+++ b/cypress/support/testUtils.ts
@@ -8,13 +8,15 @@ Cypress.on('uncaught:exception', (err) => {
   }
 });
 
-// An assertion terminates a query chain: `.should()` freezes the element it
-// resolved, so a following action command acts on that stale node instead of
-// re-querying it. When React re-renders in between (the composer swaps its send
-// button for a stop button while a task is running), the node is detached and
-// the action fails. Assert first, then re-query for the action so Cypress keeps
-// retrying the query itself.
-// https://docs.cypress.io/app/core-concepts/retry-ability
+// The composer is re-rendered by React while a message round-trip is in flight,
+// so the input and the send button can be replaced between the two actions
+// below. Cypress retries queries but never re-runs an action command, so the
+// docs recommend a separate `cy.get()` per action rather than one chain:
+// "Call cy.get() separately for each action if the DOM node might be replaced
+// between steps." -- https://docs.cypress.io/app/core-concepts/retry-ability
+// ("Use separate queries for re-rendering elements"); see also
+// https://docs.cypress.io/app/core-concepts/interacting-with-elements
+// ("Detached").
 export function submitMessage(message: string) {
   cy.get('#chat-input').should('be.visible').should('not.be.disabled');
   cy.get('#chat-input').type(message);

--- a/cypress/support/testUtils.ts
+++ b/cypress/support/testUtils.ts
@@ -8,16 +8,23 @@ Cypress.on('uncaught:exception', (err) => {
   }
 });
 
+// An assertion terminates a query chain: `.should()` freezes the element it
+// resolved, so a following action command acts on that stale node instead of
+// re-querying it. When React re-renders in between (the composer swaps its send
+// button for a stop button while a task is running), the node is detached and
+// the action fails. Assert first, then re-query for the action so Cypress keeps
+// retrying the query itself.
+// https://docs.cypress.io/app/core-concepts/retry-ability
 export function submitMessage(message: string) {
-  cy.get('#chat-input')
-    .should('be.visible')
-    .should('not.be.disabled')
-    .type(message);
-  cy.get('#chat-submit').should('not.be.disabled').click();
+  cy.get('#chat-input').should('be.visible').should('not.be.disabled');
+  cy.get('#chat-input').type(message);
+  cy.get('#chat-submit').should('not.be.disabled');
+  cy.get('#chat-submit').click();
 }
 
 export function openHistory() {
-  cy.get(`#chat-input`).should('not.be.disabled').type(`{upArrow}`);
+  cy.get(`#chat-input`).should('not.be.disabled');
+  cy.get(`#chat-input`).type(`{upArrow}`);
 }
 
 export function closeHistory() {


### PR DESCRIPTION
Fixes #3019.

## What the flake actually is

The issue diagnosed a stale-subject bug in `submitMessage` — `cy.get('#chat-submit').should('not.be.disabled').click()` acting on an already-resolved node. That's a real smell and is fixed here, but it isn't the mechanism.

Composer ownership moves between two different components as the message list changes:

- `frontend/src/components/chat/Footer.tsx:20` returns `null` while `!hasMessage(messages)`
- `frontend/src/components/chat/WelcomeScreen.tsx:80,91` returns `null` once `hasMessage(messages)`, and otherwise renders its **own** `MessageComposer`

So every flip of `hasMessage()` unmounts one composer and mounts another. Two points in this spec crossed that boundary mid-interaction:

1. **First turn.** `on_chat_start` sends its welcome message asynchronously. Landing during `type()` remounts the input, loses the typed value, and leaves `#chat-submit` disabled.
2. **Resume.** `connection_successful` (`backend/chainlit/socket.py:208-240`) emits `first_interaction` → the `@cl.on_chat_resume` message → `resume_thread`. The client handler (`libs/react-client/src/useChatSession.ts:258+`) rebuilds the list from `thread.steps` and **replaces** it wholesale. Because this fixture's `MemoryDataLayer.create_step` was a no-op and `steps` was always `[]`, that replay drove the list back to empty — swapping the composer a *second* time, exactly where the test clicks.

`cy.get('#message-composer').should('be.visible')` is satisfied early in that sequence, well before hydration finishes, so it never gated anything.

The underlying app behaviour is filed separately as #3022 — this PR makes the test honest about the churn, it does not remove the churn.

## Changes

**`cypress/e2e/thread_resume/main.py`** — implement `create_step` / `update_step` / `delete_step` on the fixture's `MemoryDataLayer` so steps are actually persisted, with `@queue_until_user_message()` matching `data/sql_alchemy.py:383-421`. `ensure_thread` backfills a row when a step is persisted before the first `update_thread`, and re-homes it when the owner arrives rather than duplicating it.

This is the crux, not incidental cleanup. With `steps: []` the resume ends in a state indistinguishable from a fresh chat, so there was **no observable signal that hydration had finished** to wait on. Persisting steps gives the replay a stable end state — `hasMessage()` now stays true across it, so the composer no longer remounts — and means the spec finally exercises thread resume instead of resuming an empty thread.

**`cypress/e2e/thread_resume/spec.cy.ts`** — wait for the welcome message before the first submit, and after reload wait on `Echo: hi`, which only the replay can produce and which is the last write to the message list. No `cy.wait(<ms>)`.

**`cypress/support/testUtils.ts`** — split the query chains in `submitMessage` / `openHistory` so each action re-queries. Signatures unchanged; all 34 call sites unaffected.

## Verification

Local: `pnpm lint cypress/`, Prettier, and `ruff check` / `ruff format --check` all clean. Note `pnpm type-check` does **not** cover `cypress/`.

CI: three attempts of run [32954779496](https://github.com/Chainlit/chainlit/actions/runs/32954779496), all on this commit, all green. Because `retries: 3` would mask a surviving flake behind a green badge, I pulled all 30 shard logs and checked `(Attempt N of 4)` annotations directly:

| Attempt | `thread_resume` (ubuntu-5) | `thread_resume` (windows-5) | Retries in run |
|---|---|---|---|
| 1 | ✓ first attempt, 3664ms | ✓ first attempt, 4143ms | none |
| 2 | ✓ first attempt, 4150ms | ✓ first attempt, 3399ms | none |
| 3 | ✓ first attempt, 3032ms | ✓ first attempt, 4594ms | one, unrelated (see below) |

Six first-attempt passes, no retry annotations on this spec anywhere. All 30 shard-runs ended `Failing: 0`.

Being straight about the strength of this: at the 20–33% rate reported in #3019, three clean runs would happen by luck roughly 30–50% of the time, so the runs alone aren't proof. The mechanism argument is the stronger half — `hasMessage()` no longer flips during the resume, so the remount that detached the button cannot occur — and the retry data rules out the specific way a survivor would have hidden.

Attempt 3 did contain one genuine retry, in `oauth_auth` on `windows-latest-3`, unrelated to this spec and pre-existing. Filed as #3023, with the general "retries are invisible in CI" problem as #3024.

## Review notes

- `2099804` is wrong and `c13ae25` corrects it; left in history rather than force-pushed so the reasoning is visible. Happy to squash on merge.
- Known-remaining, deliberately out of scope: `submitMessage` is still exposed to the same remount race in other specs that call it against an empty message list (#3022 is the real fix); `[data-testid="read-only-banner"]` at `spec.cy.ts:48` asserts a testid that exists nowhere in the frontend and is therefore vacuous (noted in #3024); ~27 other `.should(...).<action>()` sites remain across `cypress/e2e/`.