### PR TITLE
Show chat profile description when no icon is set

### DIFF
--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -63,7 +63,7 @@ export default function WelcomeScreen(props: Props) {
         }
       />
     ) : (
-      <Logo className="w-[200px] mb-2" />
+      <Logo className="w-[200px]" />
     );
 
     return (

--- a/frontend/src/components/chat/WelcomeScreen.tsx
+++ b/frontend/src/components/chat/WelcomeScreen.tsx
@@ -45,37 +45,38 @@ export default function WelcomeScreen(props: Props) {
   }, []);
 
   const logo = useMemo(() => {
-    if (chatProfile && chatProfiles) {
-      const currentChatProfile = chatProfiles.find(
-        (cp) => cp.name === chatProfile
-      );
-      if (currentChatProfile?.icon) {
-        return (
-          <div className="flex flex-col gap-2 mb-2 items-center">
-            <img
-              className="h-16 w-16 rounded-full"
-              src={
-                currentChatProfile?.icon.startsWith('/public')
-                  ? apiClient.buildEndpoint(currentChatProfile?.icon)
-                  : currentChatProfile?.icon
-              }
-            />
-            {currentChatProfile?.markdown_description ? (
-              <Markdown
-                allowHtml={allowHtml}
-                latex={latex}
-                renderMarkdown={true}
-              >
-                {currentChatProfile.markdown_description}
-              </Markdown>
-            ) : null}
-          </div>
-        );
-      }
+    const currentChatProfile = chatProfiles?.find(
+      (cp) => cp.name === chatProfile
+    );
+
+    if (!currentChatProfile) {
+      return <Logo className="w-[200px] mb-2" />;
     }
 
-    return <Logo className="w-[200px] mb-2" />;
-  }, [chatProfiles, chatProfile]);
+    const icon = currentChatProfile.icon ? (
+      <img
+        className="h-16 w-16 rounded-full"
+        src={
+          currentChatProfile.icon.startsWith('/public')
+            ? apiClient.buildEndpoint(currentChatProfile.icon)
+            : currentChatProfile.icon
+        }
+      />
+    ) : (
+      <Logo className="w-[200px] mb-2" />
+    );
+
+    return (
+      <div className="flex flex-col gap-2 mb-2 items-center">
+        {icon}
+        {currentChatProfile.markdown_description ? (
+          <Markdown allowHtml={allowHtml} latex={latex} renderMarkdown={true}>
+            {currentChatProfile.markdown_description}
+          </Markdown>
+        ) : null}
+      </div>
+    );
+  }, [allowHtml, apiClient, chatProfile, chatProfiles, latex]);
 
   if (hasMessage(messages)) return null;
 


### PR DESCRIPTION
The welcome screen only rendered `markdown_description` inside the `icon` branch, so a profile with a description and no icon just showed the default logo.

Pull the description out so it always shows when it's set. Logo fallback is unchanged.

Fixes #2935
