### PR TITLE
fix(frontend): preserve composer draft across remounts

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -26,6 +26,7 @@ interface Props {
   className?: string;
   autoFocus?: boolean;
   placeholder?: string;
+  value: string;
   selectedCommand?: ICommand;
   setSelectedCommand: (command: ICommand | undefined) => void;
   onChange: (value: string) => void;
@@ -45,6 +46,7 @@ const Input = forwardRef<InputMethods, Props>(
       id,
       className,
       autoFocus,
+      value,
       selectedCommand,
       setSelectedCommand,
       onChange,
@@ -57,7 +59,6 @@ const Input = forwardRef<InputMethods, Props>(
     const [isComposing, setIsComposing] = useState(false);
     const [showCommands, setShowCommands] = useState(false);
     const [commandInput, setCommandInput] = useState('');
-    const [value, setValue] = useState('');
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const normalizedInput = commandInput.toLowerCase().slice(1);
@@ -88,7 +89,6 @@ const Input = forwardRef<InputMethods, Props>(
     });
 
     const reset = () => {
-      setValue('');
       if (!selectedCommand?.persistent) {
         setSelectedCommand(undefined);
       }
@@ -100,7 +100,6 @@ const Input = forwardRef<InputMethods, Props>(
     useImperativeHandle(ref, () => ({
       reset,
       setValueExtern: (value: string) => {
-        setValue(value);
         onChange(value);
       }
     }));
@@ -113,7 +112,6 @@ const Input = forwardRef<InputMethods, Props>(
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
-      setValue(newValue);
       onChange(newValue);
 
       // Command detection for dropdown
@@ -133,7 +131,6 @@ const Input = forwardRef<InputMethods, Props>(
 
       // Remove the command text from the input
       const newValue = value.replace(commandInput, '').trimStart();
-      setValue(newValue);
       onChange(newValue);
 
       setCommandInput('');

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -12,6 +12,7 @@ import {
   FileSpec,
   IStep,
   commandsState,
+  sessionIdState,
   useAuth,
   useChatData,
   useChatInteract,
@@ -37,6 +38,7 @@ import { chatSettingsOpenState } from '@/state/project';
 import {
   IAttachment,
   attachmentsState,
+  composerDraftState,
   persistentCommandState
 } from 'state/chat';
 
@@ -65,7 +67,8 @@ export default function MessageComposer({
   autoScrollRef
 }: Props) {
   const inputRef = useRef<InputMethods>(null);
-  const [value, setValue] = useState('');
+  const sessionId = useRecoilValue(sessionIdState);
+  const [value, setValue] = useRecoilState(composerDraftState(sessionId));
   const [selectedCommand, setSelectedCommand] = useRecoilState(
     persistentCommandState
   );
@@ -246,18 +249,17 @@ export default function MessageComposer({
   ]);
 
   useEffect(() => {
-    if (inputRef.current && promptValue && !promptUsed) {
-      const prompt = promptValue;
-      if (prompt) {
-        if (prompt.length > 1000) {
-          inputRef.current?.setValueExtern(prompt.slice(0, 1000));
-        } else {
-          inputRef.current?.setValueExtern(prompt);
-        }
-        setPromptUsed(true);
+    if (!promptValue || promptUsed) return;
+
+    setPromptUsed(true);
+    if (inputRef.current && !value) {
+      if (promptValue.length > 1000) {
+        inputRef.current.setValueExtern(promptValue.slice(0, 1000));
+      } else {
+        inputRef.current.setValueExtern(promptValue);
       }
     }
-  }, [promptValue, promptUsed]);
+  }, [promptValue, promptUsed, value]);
 
   return (
     <div
@@ -273,6 +275,7 @@ export default function MessageComposer({
         ref={inputRef}
         id="chat-input"
         autoFocus={!isMobile}
+        value={value}
         selectedCommand={selectedCommand}
         setSelectedCommand={setSelectedCommand}
         onChange={setValue}

--- a/frontend/src/state/chat.ts
+++ b/frontend/src/state/chat.ts
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, atomFamily } from 'recoil';
 
 import { ICommand } from 'client-types/*';
 
@@ -18,6 +18,11 @@ export interface IAttachment {
 export const attachmentsState = atom<IAttachment[]>({
   key: 'Attachments',
   default: []
+});
+
+export const composerDraftState = atomFamily<string, string>({
+  key: 'ComposerDraft',
+  default: ''
 });
 
 export const persistentCommandState = atom<ICommand | undefined>({

--- a/frontend/tests/MessageComposer.spec.tsx
+++ b/frontend/tests/MessageComposer.spec.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRef, useState } from 'react';
+import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionIdState } from '@chainlit/react-client';
+
+import MessageComposer from '@/components/chat/MessageComposer';
+
+const { queryParams } = vi.hoisted(() => ({
+  queryParams: new URLSearchParams()
+}));
+
+vi.mock('@chainlit/react-client', async () => {
+  const { atom } = await import('recoil');
+
+  return {
+    commandsState: atom({ key: 'ComposerTestCommands', default: [] }),
+    modesState: atom({ key: 'ComposerTestModes', default: [] }),
+    sessionIdState: atom({
+      key: 'ComposerTestSessionId',
+      default: 'session-1'
+    }),
+    useAuth: () => ({ user: { identifier: 'tester' } }),
+    useChatData: () => ({
+      askUser: undefined,
+      chatSettingsInputs: [],
+      disabled: false
+    }),
+    useChatInteract: () => ({
+      replyMessage: vi.fn(),
+      sendMessage: vi.fn()
+    }),
+    useConfig: () => ({ config: {} })
+  };
+});
+
+vi.mock('components/i18n/Translator', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('@/hooks/query', () => ({
+  useQuery: () => queryParams
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false
+}));
+
+vi.mock('@/components/chat/MessageComposer/Attachments', () => ({
+  Attachments: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/CommandButtons', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/CommandPopoverButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/FavoriteButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/Mcp', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/ModePicker', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/SubmitButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/UploadButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/VoiceButton', () => ({
+  default: () => null
+}));
+
+function ComposerOwnerSwap() {
+  const [owner, setOwner] = useState<'welcome' | 'footer'>('welcome');
+  const setSessionId = useSetRecoilState(sessionIdState);
+  const autoScrollRef = useRef(true);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          setOwner((current) => (current === 'welcome' ? 'footer' : 'welcome'))
+        }
+      >
+        Swap composer owner
+      </button>
+      <button type="button" onClick={() => setSessionId('session-2')}>
+        Start new session
+      </button>
+      <MessageComposer
+        key={owner}
+        fileSpec={{ max_size_mb: 1, max_files: 1, accept: {} }}
+        onFileUpload={vi.fn()}
+        onFileUploadError={vi.fn()}
+        autoScrollRef={autoScrollRef}
+      />
+    </>
+  );
+}
+
+describe('MessageComposer', () => {
+  beforeEach(() => {
+    queryParams.delete('prompt');
+  });
+
+  it('preserves an in-progress draft when the composer owner changes', () => {
+    render(
+      <RecoilRoot>
+        <ComposerOwnerSwap />
+      </RecoilRoot>
+    );
+
+    const originalInput = screen.getByRole('textbox');
+    fireEvent.change(originalInput, { target: { value: 'unfinished draft' } });
+    expect(originalInput).toHaveValue('unfinished draft');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Swap composer owner' })
+    );
+
+    const remountedInput = screen.getByRole('textbox');
+    expect(remountedInput).not.toBe(originalInput);
+    expect(remountedInput).toHaveValue('unfinished draft');
+  });
+
+  it('starts with an empty draft when the chat session changes', () => {
+    render(
+      <RecoilRoot>
+        <ComposerOwnerSwap />
+      </RecoilRoot>
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'previous chat draft' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Start new session' }));
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+
+  it('does not restore a URL prompt over an edited draft after remounting', () => {
+    queryParams.set('prompt', 'initial prompt');
+
+    render(
+      <RecoilRoot>
+        <ComposerOwnerSwap />
+      </RecoilRoot>
+    );
+
+    const originalInput = screen.getByRole('textbox');
+    expect(originalInput).toHaveValue('initial prompt');
+    fireEvent.change(originalInput, { target: { value: 'edited draft' } });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Swap composer owner' })
+    );
+
+    const remountedInput = screen.getByRole('textbox');
+    expect(remountedInput).toHaveValue('edited draft');
+
+    fireEvent.change(remountedInput, { target: { value: '' } });
+    expect(remountedInput).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #3022.
- Fixes: When the message list changes between empty and non-empty, the welcome composer is replaced by the footer composer and text the user is still typing disappears.
- Root cause: WelcomeScreen and Footer own separate MessageComposer instances, while both MessageComposer and Input stored the draft only in component-local state; switching owners therefore unmounted the only copy of the draft.

## Regression evidence

- Before: `npx --yes pnpm@9.15.9 --dir frontend exec vitest run tests/MessageComposer.spec.tsx` exited `1`

- After: `npx --yes pnpm@9.15.9 --dir frontend exec vitest run tests/MessageComposer.spec.tsx` exited `0`

## Verification

- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm test`
- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm lint`
- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm format-check`
- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm type-check`
- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm build`
- `npx --yes -p node@24 -p pnpm@9.15.9 pnpm check-overrides`

## Scope

- 4 files changed, +192 / -17 lines


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the composer draft when the message list switches between empty and non-empty states, so user-typed text no longer disappears when the welcome composer is replaced by the footer composer. The draft now lives in shared state per session instead of only in component-local state. New sessions start empty, and a URL prompt no longer overwrites an edited draft after a remount. Fixes #3022.

<sup>Written for commit 9d06696b95de555ce944317ffdfc8858ab4f3d71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

