### PR TITLE
ci(e2e): report Cypress retries in CI so flaky specs are visible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
     secrets: inherit
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml
+    permissions:
+      contents: read
+      pull-requests: write
     secrets: inherit
   ci:
     runs-on: ubuntu-slim

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -73,3 +73,112 @@ jobs:
         with:
           name: cypress-screenshots-${{ matrix.os }}-${{ matrix.containers }}
           path: cypress/screenshots
+      - name: Upload retry report
+        uses: actions/upload-artifact@v7
+        if: always() && hashFiles('cypress/reports/retries.json') != ''
+        with:
+          name: cypress-retries-${{ matrix.os }}-${{ matrix.containers }}
+          path: cypress/reports/retries.json
+
+  report-retries:
+    name: Report flaky test retries
+    needs: e2e-tests
+    if: always()
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download retry reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: cypress-retries-*
+          path: retry-reports
+        continue-on-error: true
+      - name: Summarize retried tests
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const root = 'retry-reports';
+            const retries = [];
+
+            if (fs.existsSync(root)) {
+              for (const shard of fs.readdirSync(root)) {
+                const reportFile = path.join(root, shard, 'retries.json');
+                if (!fs.existsSync(reportFile)) continue;
+                const entries = JSON.parse(fs.readFileSync(reportFile, 'utf8'));
+                for (const entry of entries) {
+                  retries.push({ shard, ...entry });
+                }
+              }
+            }
+
+            if (retries.length === 0) {
+              await core.summary
+                .addHeading('Cypress retries', 3)
+                .addRaw('No specs needed a retry in this run.')
+                .write();
+              return;
+            }
+
+            await core.summary
+              .addHeading('Cypress retries', 3)
+              .addTable([
+                [
+                  { data: 'Shard', header: true },
+                  { data: 'Spec', header: true },
+                  { data: 'Test', header: true },
+                  { data: 'Attempts', header: true }
+                ],
+                ...retries.map((retry) => [
+                  retry.shard,
+                  retry.spec,
+                  retry.title,
+                  String(retry.attempts)
+                ])
+              ])
+              .write();
+
+            // Best-effort PR comment: on forked PRs GITHUB_TOKEN is read-only,
+            // so a failure here must not fail the job. The step summary above
+            // is the primary, always-available output.
+            const pullRequest = context.payload.pull_request;
+            const isFork =
+              pullRequest &&
+              pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+            if (!pullRequest || isFork) return;
+
+            const marker = '<!-- cypress-retry-report -->';
+            const body = `${marker}\n**${retries.length} Cypress test attempt(s) were retried in this run.** See the job summary for details.`;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequest.number
+              });
+              const existingComment = comments.find((comment) =>
+                comment.body?.includes(marker)
+              );
+
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number,
+                  body
+                });
+              }
+            } catch (error) {
+              core.warning(`Could not post the retry-report comment: ${error.message}`);
+            }

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -121,26 +121,25 @@ jobs:
                 .addHeading('Cypress retries', 3)
                 .addRaw('No specs needed a retry in this run.')
                 .write();
-              return;
-            }
-
-            await core.summary
-              .addHeading('Cypress retries', 3)
-              .addTable([
-                [
-                  { data: 'Shard', header: true },
-                  { data: 'Spec', header: true },
-                  { data: 'Test', header: true },
-                  { data: 'Attempts', header: true }
-                ],
-                ...retries.map((retry) => [
-                  retry.shard,
-                  retry.spec,
-                  retry.title,
-                  String(retry.attempts)
+            } else {
+              await core.summary
+                .addHeading('Cypress retries', 3)
+                .addTable([
+                  [
+                    { data: 'Shard', header: true },
+                    { data: 'Spec', header: true },
+                    { data: 'Test', header: true },
+                    { data: 'Attempts', header: true }
+                  ],
+                  ...retries.map((retry) => [
+                    retry.shard,
+                    retry.spec,
+                    retry.title,
+                    String(retry.attempts)
+                  ])
                 ])
-              ])
-              .write();
+                .write();
+            }
 
             // Best-effort PR comment: on forked PRs GITHUB_TOKEN is read-only,
             // so a failure here must not fail the job. The step summary above
@@ -152,26 +151,34 @@ jobs:
             if (!pullRequest || isFork) return;
 
             const marker = '<!-- cypress-retry-report -->';
-            const body = `${marker}\n**${retries.length} Cypress test attempt(s) were retried in this run.** See the job summary for details.`;
+            const body =
+              retries.length === 0
+                ? `${marker}\n**No specs needed a retry in this run.**`
+                : `${marker}\n**${retries.length} Cypress test(s) were retried in this run.** See the job summary for details.`;
 
             try {
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequest.number
-              });
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullRequest.number
+                }
+              );
               const existingComment = comments.find((comment) =>
                 comment.body?.includes(marker)
               );
 
               if (existingComment) {
+                // Keep the marker comment in sync, including clearing it back
+                // to "no retries" so a fixed run doesn't leave a stale report.
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: existingComment.id,
                   body
                 });
-              } else {
+              } else if (retries.length > 0) {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,3 +26,6 @@ jobs:
         run: uv run --no-project pytest --cov=chainlit/
       - name: Run frontend tests
         run: pnpm run test
+      - name: Run cypress support unit tests
+        if: matrix.python-version == '3.13'
+        run: pnpm test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ chainlit.md
 cypress/screenshots
 cypress/videos
 cypress/downloads
+cypress/reports
 
 __pycache__
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -64,7 +64,13 @@ export default defineConfig({
       });
 
       on('after:spec', async (spec, results) => {
-        retriedTests.push(...collectRetriedTests(spec.relative, results.tests));
+        // `results` is undefined under `cypress open` (no run results are
+        // collected in interactive mode), so guard before reading it.
+        if (results) {
+          retriedTests.push(
+            ...collectRetriedTests(spec.relative, results.tests)
+          );
+        }
         await mkdir(dirname(RETRY_REPORT_PATH), { recursive: true });
         await writeFile(
           RETRY_REPORT_PATH,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,10 +1,25 @@
 import { defineConfig } from 'cypress';
 import cypressSplit from 'cypress-split';
 import fkill from 'fkill';
+import { mkdir, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 
+import {
+  RetriedTest,
+  collectRetriedTests
+} from './cypress/support/retryReport';
 import { runChainlit } from './cypress/support/run';
 
 export const CHAINLIT_APP_PORT = 8000;
+
+// Per-shard record of tests that failed at least once but passed on retry,
+// written after every spec so a killed job still leaves partial data behind.
+const RETRY_REPORT_PATH = join(
+  process.cwd(),
+  'cypress',
+  'reports',
+  'retries.json'
+);
 
 async function killChainlit() {
   await fkill(`:${CHAINLIT_APP_PORT}`, {
@@ -41,12 +56,21 @@ export default defineConfig({
       await killChainlit(); // Fallback to ensure no previous instance is running
       await runChainlit(); // Start Chainlit before running tests as Cypress require
 
+      const retriedTests: RetriedTest[] = [];
+
       on('before:spec', async (spec) => {
         await killChainlit();
         await runChainlit(spec);
       });
 
-      on('after:spec', async () => {
+      on('after:spec', async (spec, results) => {
+        retriedTests.push(...collectRetriedTests(spec.relative, results.tests));
+        await mkdir(dirname(RETRY_REPORT_PATH), { recursive: true });
+        await writeFile(
+          RETRY_REPORT_PATH,
+          JSON.stringify(retriedTests, null, 2)
+        );
+
         await killChainlit();
       });
 

--- a/cypress/support/retryReport.test.ts
+++ b/cypress/support/retryReport.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { collectRetriedTests } from './retryReport.ts';
+
+const asTests = (tests: unknown) =>
+  tests as CypressCommandLine.RunResult['tests'];
+
+test('ignores a test that passed on its first attempt', () => {
+  const tests = asTests([
+    {
+      title: ['suite', 'stable test'],
+      state: 'passed',
+      attempts: [{ state: 'passed' }]
+    }
+  ]);
+
+  assert.deepEqual(
+    collectRetriedTests('cypress/e2e/example/spec.cy.ts', tests),
+    []
+  );
+});
+
+test('reports a test that failed then passed as retried', () => {
+  const tests = asTests([
+    {
+      title: ['suite', 'flaky test'],
+      state: 'passed',
+      attempts: [{ state: 'failed' }, { state: 'passed' }]
+    }
+  ]);
+
+  assert.deepEqual(
+    collectRetriedTests('cypress/e2e/example/spec.cy.ts', tests),
+    [
+      {
+        spec: 'cypress/e2e/example/spec.cy.ts',
+        title: 'suite > flaky test',
+        attempts: 2
+      }
+    ]
+  );
+});
+
+test('excludes a test that failed every attempt', () => {
+  const tests = asTests([
+    {
+      title: ['suite', 'broken test'],
+      state: 'failed',
+      attempts: [
+        { state: 'failed' },
+        { state: 'failed' },
+        { state: 'failed' },
+        { state: 'failed' }
+      ]
+    }
+  ]);
+
+  assert.deepEqual(
+    collectRetriedTests('cypress/e2e/example/spec.cy.ts', tests),
+    []
+  );
+});

--- a/cypress/support/retryReport.ts
+++ b/cypress/support/retryReport.ts
@@ -1,0 +1,28 @@
+export interface RetriedTest {
+  spec: string;
+  title: string;
+  attempts: number;
+}
+
+/**
+ * A test counts as retried when at least one attempt failed but the overall
+ * test still passed - i.e. Cypress' `retries` config absorbed the failure.
+ * Tests that exhaust every retry and still fail are already visible via the
+ * job's exit status, so they are excluded here.
+ */
+export function collectRetriedTests(
+  specRelative: string,
+  tests: CypressCommandLine.RunResult['tests']
+): RetriedTest[] {
+  return tests
+    .filter(
+      (test) =>
+        test.state === 'passed' &&
+        test.attempts.some((attempt) => attempt.state === 'failed')
+    )
+    .map((test) => ({
+      spec: specRelative,
+      title: test.title.join(' > '),
+      attempts: test.attempts.length
+    }));
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "check-overrides": "node scripts/check-pnpm-overrides.mjs",
     "test": "pnpm run --recursive test",
     "test:e2e": "cypress run",
-    "test:e2e:interactive": "cypress open"
+    "test:e2e:interactive": "cypress open",
+    "test:unit": "node --test cypress/support/*.test.ts"
   },
   "pnpm": {
     "overrides": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
     "esModuleInterop": true
   },
   "include": ["cypress/**/*.ts", "cypress.config.ts"],
-  "exclude": ["cypress/**/*.test.ts"]
+  "exclude": ["cypress/support/retryReport.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,9 @@
     "lib": ["ESNext", "dom"],
     "types": ["cypress", "cypress-plugin-steps", "node"],
     "baseUrl": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
-  "include": ["cypress/**/*.ts", "cypress.config.ts"],
-  "exclude": ["cypress/support/retryReport.test.ts"]
+  "include": ["cypress/**/*.ts", "cypress.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,6 @@
     "baseUrl": ".",
     "esModuleInterop": true
   },
-  "include": ["cypress/**/*.ts", "cypress.config.ts"]
+  "include": ["cypress/**/*.ts", "cypress.config.ts"],
+  "exclude": ["cypress/**/*.test.ts"]
 }


### PR DESCRIPTION
Fixes #3024.

## Root cause

`cypress.config.ts` sets `retries: 3`, so a spec that fails and then passes on retry reports the job green with no trace anywhere a human will look. #3023 is a concrete example: a genuine `oauth_auth` failure on `windows-latest-3` was absorbed by a retry, and finding it required pulling and grepping job logs by hand. The existing `after:spec` handler discarded both of its arguments and only called `killChainlit()`, so this information was never captured.

## Fix

Implements Option B from the issue (self-contained, no Cypress Cloud dependency, works on forked PRs):

1. `cypress/support/retryReport.ts` adds `collectRetriedTests`, a pure function that flags a test as retried when its overall state is `passed` but at least one attempt has `state === 'failed'`. Tests that exhaust every retry and still fail are excluded, since those are already visible via the job's exit status.
2. `cypress.config.ts`'s `after:spec` handler now receives `(spec, results)`, accumulates retried tests for the shard, and writes them to `cypress/reports/retries.json` after every spec (so a killed job still leaves partial data).
3. `.github/workflows/e2e-tests.yaml` uploads that file as a per-shard artifact (`cypress-retries-<os>-<containers>`, same pattern as the existing screenshot upload), and a new `report-retries` job downloads every shard's artifact, merges them, and writes a table to `$GITHUB_STEP_SUMMARY`.
4. When retries are found on a same-repo PR, the job also posts (or updates) a single PR comment. Top-level `permissions: read-all` is unchanged; the `report-retries` job itself is granted `pull-requests: write`, and `.github/workflows/ci.yaml`'s `e2e-tests:` call site now also grants `contents: read` / `pull-requests: write` on the reusable-workflow job entry — a reusable workflow can only narrow permissions inherited from its caller, never widen them, so without this the grant inside `e2e-tests.yaml` would have had no effect even on same-repo PRs. On forked PRs `GITHUB_TOKEN` is read-only, so the comment step is skipped ahead of time based on `pull_request.head.repo.full_name` and additionally wrapped in try/catch as a fallback; it never uses `pull_request_target`. The step summary is always the primary, unconditional output.

The unrelated dead `read-only-banner` testid assertion in `cypress/e2e/thread_resume/spec.cy.ts` flagged in the issue as a separate item is left untouched, as the issue itself scopes it out.

## Testing

- `node --test cypress/support/retryReport.test.ts` -> 3/3 pass (a test passing on first attempt is ignored, a test that fails then passes is reported with its attempt count, a test that fails every attempt is ignored). Verified this is a genuine regression test: temporarily reverted `collectRetriedTests` to a no-op returning `[]` (matching the old discard-everything `after:spec` behavior) and reran — the retry-detection case failed with an `AssertionError` as expected — then restored the real implementation and confirmed 3/3 pass again.
- `npx prettier --check` on all touched files -> clean.
- `npx eslint` on `cypress.config.ts`, `cypress/support/retryReport.ts`, `cypress/support/retryReport.test.ts` -> clean.
- `npx tsc --noEmit -p tsconfig.json` -> no new errors from this change (only 4 pre-existing `TS2428` WeakMap errors from Cypress's vendored lodash types, confirmed present identically on a clean checkout via `git stash -u`, and unrelated to this change — this tsconfig is also not wired into any CI script; `pnpm type-check` only recurses into the `frontend`/`libs` workspace packages).
- `actionlint` on the modified workflow files -> clean, exit 0.
- The modified `e2e-tests.yaml` was parsed with `yaml.safe_load` to confirm it still parses correctly and the job list is `['prepare', 'e2e-tests', 'report-retries']` as intended.
- The `permissions:` fix in `ci.yaml` (a reusable-workflow call site can only narrow, never widen, the caller's inherited permissions) was verified by re-reading the affected files against GitHub's documented permission-inheritance semantics for `workflow_call`, since that runtime behavior cannot be exercised locally or with `actionlint` (which validates syntax, not inheritance semantics).
- Husky's pre-commit hook (`lint-staged`, which runs `format:files`, `lint:fix`, and `actionlint` on staged files) ran on every commit and made no further modifications, confirming the diff was already compliant.
- Not run: `pnpm test:e2e` (the full Cypress suite), since it requires the full Chainlit backend and a live browser; the pure retry-detection logic is covered by the `node:test` regression test instead, and the artifact-upload/aggregation job will be exercised directly by this repo's own `e2e-tests` CI workflow on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Cypress retries visible in CI so specs that fail once and pass on retry no longer produce a silently green run (#3024). The workflow now records and reports those tests without changing the pass/fail result; tests that still fail remain governed by the existing job failure.

- Writes per-shard `cypress/reports/retries.json`, uploads it, and merges available reports into `$GITHUB_STEP_SUMMARY`.
- Creates or updates one marker PR comment on same-repo PRs, including clearing it when a later run has no retries; forked PRs use the summary because their token is read-only.
- Grants `pull-requests: write` through the reusable workflow call and adds the retry-report unit tests to CI via `pnpm test:unit`.
- Guards the report hook when Cypress runs interactively, where results are unavailable.

<sup>Written for commit 209adbfcfc6527fc15ff6bd7834a3ff9b89eee5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

