### PR TITLE
fix(auth): read login error param synchronously to close a render race

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -16,7 +16,12 @@ export const LoginError = new Error(
 export default function Login() {
   const query = useQuery();
   const { data: config, user, setUserFromAPI } = useAuth();
-  const [error, setError] = useState('');
+  // Read the error param synchronously on mount instead of via effect, so the
+  // first render already carries it. Otherwise `error` starts empty, flows
+  // into `LoginForm`'s own `useState(error)` initial value, and only catches
+  // up once both components' effects have flushed -- a two-hop async chain
+  // that a slow test runner can lose a race against (chainlit#3023).
+  const [error, setError] = useState(() => query.get('error') || '');
   const apiClient = useContext(ChainlitContext);
   const navigate = useNavigate();
   const { variant } = useTheme();

--- a/frontend/tests/Login.spec.tsx
+++ b/frontend/tests/Login.spec.tsx
@@ -50,8 +50,13 @@ window.matchMedia =
 
 describe('Login', () => {
   let container: HTMLDivElement | null = null;
+  let root: ReturnType<typeof createRoot> | null = null;
 
   afterEach(() => {
+    if (root) {
+      root.unmount();
+      root = null;
+    }
     if (container) {
       document.body.removeChild(container);
       container = null;
@@ -67,7 +72,7 @@ describe('Login', () => {
   it('renders the [role="alert"] error message on the first synchronous commit', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
-    const root = createRoot(container);
+    root = createRoot(container);
 
     flushSync(() => {
       root.render(
@@ -83,7 +88,7 @@ describe('Login', () => {
   it('renders no [role="alert"] on the first synchronous commit when there is no error param', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
-    const root = createRoot(container);
+    root = createRoot(container);
 
     flushSync(() => {
       root.render(

--- a/frontend/tests/Login.spec.tsx
+++ b/frontend/tests/Login.spec.tsx
@@ -1,0 +1,98 @@
+import { i18nSetupLocalization } from '@/i18n';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Login from '@/pages/Login';
+
+// Real i18next init (no backend plugin, so it resolves synchronously) --
+// LoginForm's <Translator> calls i18n.exists() at render time and throws
+// if no instance was ever initialized.
+i18nSetupLocalization();
+
+vi.mock('client-types/*', async () => {
+  const { createContext } = await import('react');
+  const mockApiClient = {
+    buildEndpoint: (path: string) => `http://localhost:8000${path}`,
+    getOAuthEndpoint: (provider: string) =>
+      `http://localhost:8000/auth/oauth/${provider}`
+  };
+  return {
+    ChainlitContext: createContext(mockApiClient),
+    useAuth: () => ({
+      data: { requireLogin: true, oauthProviders: [] },
+      user: null,
+      setUserFromAPI: vi.fn()
+    })
+  };
+});
+
+// Logo pulls useConfig() from @chainlit/react-client, which needs a
+// RecoilRoot ancestor. It is unrelated to the error-render race under test,
+// so stub it out rather than wiring up Recoil for this test.
+vi.mock('@/components/Logo', () => ({
+  Logo: () => null
+}));
+
+// jsdom does not implement matchMedia, and Login -> useTheme() calls it
+// synchronously during render (not from an effect), so stub it the same way
+// FavoriteButton.spec.tsx stubs ResizeObserver.
+window.matchMedia =
+  window.matchMedia ||
+  vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }));
+
+describe('Login', () => {
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    if (container) {
+      document.body.removeChild(container);
+      container = null;
+    }
+  });
+
+  // Regression test for the render race fixed by reading the ?error= query
+  // param via a lazy useState initializer instead of an effect. Uses
+  // createRoot + flushSync directly instead of Testing Library's render(),
+  // because render() wraps in act(), which flushes passive effects
+  // synchronously and hides the gap this test is pinning: what is in the DOM
+  // on the very first commit, before any useEffect has run.
+  it('renders the [role="alert"] error message on the first synchronous commit', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/login?error=some-error']}>
+          <Login />
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+  });
+
+  it('renders no [role="alert"] on the first synchronous commit when there is no error param', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/login']}>
+          <Login />
+        </MemoryRouter>
+      );
+    });
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Refs #3023.

## Root cause

`Login` read the `?error=` query param via a `useEffect`, so `error` always started as `''` on the first render. That empty value flowed into `LoginForm`'s own `useState(error)` initial value. `LoginForm` only picked up the real error message once *both* components' effects had flushed:

1. `Login` mounts with `error=''`.
2. `Login`'s `useEffect` fires, calling `setError(query.get('error') || '')`, re-rendering `Login` and passing the correct `error` prop to `LoginForm`.
3. `LoginForm`'s own `useEffect` (which syncs `errorState` from the `error` prop) fires and finally updates `errorState`, causing the `[role="alert"]` element to appear.

That is a two-hop async chain between two components' effects before the error message exists in the DOM at all -- the same class of stale-DOM-vs-async-render bug already diagnosed and fixed for `thread_resume` in #3021, just at the login page instead of the chat composer.

#3023 reports a single `windows-latest` CI occurrence where the `oauth_auth` spec's `shows a specific message for oauthSignin error` test hit Cypress's 30s `defaultCommandTimeout` on attempt 1 and passed on retry. This render gap resolves within a single synchronous commit -- orders of magnitude smaller than a 30s command timeout -- so this PR does not claim to be a confirmed diagnosis of #3023. It fixes a genuine render-timing bug in the exact code path that test exercises; I could not reproduce the CI flake locally to confirm it is the same mechanism (a single occurrence, unknown rate, Windows-only real-browser timing).

## Fix

Initialize `error` from the query param synchronously with a lazy `useState` initializer, instead of via `useEffect`. The first render now already carries the correct value, so `LoginForm`'s initial `errorState` is correct from its very first render too -- no async hop is needed for the initial-load case. The existing `useEffect` is kept so `error` still re-syncs if the query string changes while the component stays mounted.

## Testing

- `pnpm lint frontend/src/pages/Login.tsx` -- clean.
- `pnpm format-check:files frontend/src/pages/Login.tsx` -- "Checking formatting... All matched files use Prettier code style!"
- `pnpm --filter @chainlit/app type-check` (after building `libs/react-client`, a pre-existing workspace build-order requirement) -- 0 errors; on unmodified HEAD via `git stash` the same command produced 262 pre-existing `error TS...` lines from the unbuilt `@chainlit/react-client`/`client-types` workspace package, confirming those are pre-existing and unrelated to this change.
- Added `frontend/tests/Login.spec.tsx`: mounts `<Login>` with `createRoot` + `flushSync` (bypassing React Testing Library's `act()`-wrapped `render()`, which flushes effects synchronously and would hide the bug) and asserts `[role="alert"]` is present on the very first commit when mounted with `?error=...`, plus a negative-control assertion for the no-error-param case. Confirmed this fails on pre-fix `Login.tsx` (`AssertionError: expected null not to be null`) and passes post-fix.
- `pnpm --filter @chainlit/app test` -- `Test Files  1 failed | 5 passed (6)`, `Tests  3 failed | 31 passed (34)`. The one failing file (`displayModePrecedence.spec.ts`, a jsdom/localStorage environment issue) is identical before and after this change -- re-verified on both `HEAD` and `HEAD~1`'s `Login.tsx` -- and unrelated to `Login.tsx`.
- The repo's husky pre-commit hook (lint-staged: prettier + eslint --fix + `pnpm --filter @chainlit/app type-check` on staged files) ran automatically on `git commit` and passed without `--no-verify`.

Not run: Cypress e2e (`cypress/e2e/oauth_auth`). It requires spinning up a full Chainlit backend via `uv run chainlit run ...` per `cypress.config.ts`'s `before:spec` hook, and more importantly the flake this fix targets is a Windows-only, real-browser timing race with a single observed occurrence that I have no way to force or deterministically re-verify locally either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a login render race that could delay the OAuth error message until after two effects; it now appears on the first commit. This covers the code path in #3023, though the reported CI flake remains unconfirmed.

- Initializes the error from `?error=` synchronously and still re-syncs when the query changes.
- Adds first-commit tests for error and no-error cases using `createRoot` and `flushSync`.
- Unmounts manually created roots after each test to prevent leaked effects.

<sup>Written for commit 10428c5732e7936a217d4f0fccebc0c371248e7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

