### PR TITLE
fix(frontend): preserve composer drafts across remounts

### DIFF
--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -36,7 +36,6 @@ interface Props {
 
 export interface InputMethods {
   reset: () => void;
-  setValueExtern: (value: string) => void;
 }
 
 const Input = forwardRef<InputMethods, Props>(
@@ -97,10 +96,7 @@ const Input = forwardRef<InputMethods, Props>(
       onChange('');
     };
 
-    useImperativeHandle(ref, () => ({
-      reset,
-      setValueExtern: onChange
-    }));
+    useImperativeHandle(ref, () => ({ reset }));
 
     useEffect(() => {
       if (textareaRef.current && autoFocus) {

--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -26,6 +26,7 @@ interface Props {
   className?: string;
   autoFocus?: boolean;
   placeholder?: string;
+  value: string;
   selectedCommand?: ICommand;
   setSelectedCommand: (command: ICommand | undefined) => void;
   onChange: (value: string) => void;
@@ -47,6 +48,7 @@ const Input = forwardRef<InputMethods, Props>(
       autoFocus,
       selectedCommand,
       setSelectedCommand,
+      value,
       onChange,
       onEnter,
       onPaste
@@ -57,7 +59,6 @@ const Input = forwardRef<InputMethods, Props>(
     const [isComposing, setIsComposing] = useState(false);
     const [showCommands, setShowCommands] = useState(false);
     const [commandInput, setCommandInput] = useState('');
-    const [value, setValue] = useState('');
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const normalizedInput = commandInput.toLowerCase().slice(1);
@@ -88,7 +89,6 @@ const Input = forwardRef<InputMethods, Props>(
     });
 
     const reset = () => {
-      setValue('');
       if (!selectedCommand?.persistent) {
         setSelectedCommand(undefined);
       }
@@ -99,10 +99,7 @@ const Input = forwardRef<InputMethods, Props>(
 
     useImperativeHandle(ref, () => ({
       reset,
-      setValueExtern: (value: string) => {
-        setValue(value);
-        onChange(value);
-      }
+      setValueExtern: onChange
     }));
 
     useEffect(() => {
@@ -113,7 +110,6 @@ const Input = forwardRef<InputMethods, Props>(
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value;
-      setValue(newValue);
       onChange(newValue);
 
       // Command detection for dropdown
@@ -133,7 +129,6 @@ const Input = forwardRef<InputMethods, Props>(
 
       // Remove the command text from the input
       const newValue = value.replace(commandInput, '').trimStart();
-      setValue(newValue);
       onChange(newValue);
 
       setCommandInput('');

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -1,10 +1,4 @@
-import {
-  MutableRefObject,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -68,7 +62,29 @@ export default function MessageComposer({
 }: Props) {
   const inputRef = useRef<InputMethods>(null);
   const sessionId = useRecoilValue(sessionIdState);
-  const [value, setValue] = useRecoilState(messageDraftState(sessionId));
+  const [messageDraft, setMessageDraft] = useRecoilState(messageDraftState);
+  const isCurrentDraft = messageDraft.sessionId === sessionId;
+  const value = isCurrentDraft ? messageDraft.value : '';
+  const promptUsed = isCurrentDraft && messageDraft.promptUsed;
+  const setValue = useCallback(
+    (value: string) => {
+      setMessageDraft((current) => ({
+        sessionId,
+        value,
+        promptUsed: current.sessionId === sessionId ? current.promptUsed : false
+      }));
+    },
+    [sessionId, setMessageDraft]
+  );
+
+  useEffect(() => {
+    setMessageDraft((current) =>
+      current.sessionId === sessionId
+        ? current
+        : { sessionId, value: '', promptUsed: false }
+    );
+  }, [sessionId, setMessageDraft]);
+
   const [selectedCommand, setSelectedCommand] = useRecoilState(
     persistentCommandState
   );
@@ -133,14 +149,9 @@ export default function MessageComposer({
     console.warn('Could not parse query parameters');
   }
 
-  const [promptUsed, setPromptUsed] = useState(false);
-
   const onFavoriteSelect = useCallback(
     (content: string) => {
       setValue(content);
-      if (inputRef.current) {
-        inputRef.current.setValueExtern(content);
-      }
     },
     [setValue]
   );
@@ -255,15 +266,15 @@ export default function MessageComposer({
   useEffect(() => {
     if (!promptValue || promptUsed) return;
 
-    setPromptUsed(true);
-    if (inputRef.current && !value) {
-      if (promptValue.length > 1000) {
-        inputRef.current.setValueExtern(promptValue.slice(0, 1000));
-      } else {
-        inputRef.current.setValueExtern(promptValue);
-      }
-    }
-  }, [promptValue, promptUsed, value]);
+    setMessageDraft((current) => {
+      const currentValue = current.sessionId === sessionId ? current.value : '';
+      return {
+        sessionId,
+        value: currentValue || promptValue.slice(0, 1000),
+        promptUsed: true
+      };
+    });
+  }, [promptValue, promptUsed, sessionId, setMessageDraft]);
 
   return (
     <div

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -12,6 +12,7 @@ import {
   FileSpec,
   IStep,
   commandsState,
+  sessionIdState,
   useAuth,
   useChatData,
   useChatInteract,
@@ -37,6 +38,7 @@ import { chatSettingsOpenState } from '@/state/project';
 import {
   IAttachment,
   attachmentsState,
+  messageDraftState,
   persistentCommandState
 } from 'state/chat';
 
@@ -65,7 +67,8 @@ export default function MessageComposer({
   autoScrollRef
 }: Props) {
   const inputRef = useRef<InputMethods>(null);
-  const [value, setValue] = useState('');
+  const sessionId = useRecoilValue(sessionIdState);
+  const [value, setValue] = useRecoilState(messageDraftState(sessionId));
   const [selectedCommand, setSelectedCommand] = useRecoilState(
     persistentCommandState
   );
@@ -132,12 +135,15 @@ export default function MessageComposer({
 
   const [promptUsed, setPromptUsed] = useState(false);
 
-  const onFavoriteSelect = useCallback((content: string) => {
-    setValue(content);
-    if (inputRef.current) {
-      inputRef.current.setValueExtern(content);
-    }
-  }, []);
+  const onFavoriteSelect = useCallback(
+    (content: string) => {
+      setValue(content);
+      if (inputRef.current) {
+        inputRef.current.setValueExtern(content);
+      }
+    },
+    [setValue]
+  );
 
   const onPaste = useCallback(
     (event: ClipboardEvent) => {
@@ -241,23 +247,23 @@ export default function MessageComposer({
     attachments,
     selectedCommand,
     setAttachments,
+    setValue,
     onSubmit,
     onReply
   ]);
 
   useEffect(() => {
-    if (inputRef.current && promptValue && !promptUsed) {
-      const prompt = promptValue;
-      if (prompt) {
-        if (prompt.length > 1000) {
-          inputRef.current?.setValueExtern(prompt.slice(0, 1000));
-        } else {
-          inputRef.current?.setValueExtern(prompt);
-        }
-        setPromptUsed(true);
+    if (!promptValue || promptUsed) return;
+
+    setPromptUsed(true);
+    if (inputRef.current && !value) {
+      if (promptValue.length > 1000) {
+        inputRef.current.setValueExtern(promptValue.slice(0, 1000));
+      } else {
+        inputRef.current.setValueExtern(promptValue);
       }
     }
-  }, [promptValue, promptUsed]);
+  }, [promptValue, promptUsed, value]);
 
   return (
     <div
@@ -273,6 +279,7 @@ export default function MessageComposer({
         ref={inputRef}
         id="chat-input"
         autoFocus={!isMobile}
+        value={value}
         selectedCommand={selectedCommand}
         setSelectedCommand={setSelectedCommand}
         onChange={setValue}

--- a/frontend/src/state/chat.ts
+++ b/frontend/src/state/chat.ts
@@ -1,4 +1,4 @@
-import { atom, atomFamily } from 'recoil';
+import { atom } from 'recoil';
 
 import { ICommand } from 'client-types/*';
 
@@ -20,9 +20,15 @@ export const attachmentsState = atom<IAttachment[]>({
   default: []
 });
 
-export const messageDraftState = atomFamily<string, string>({
+interface MessageDraft {
+  sessionId?: string;
+  value: string;
+  promptUsed: boolean;
+}
+
+export const messageDraftState = atom<MessageDraft>({
   key: 'MessageDraft',
-  default: ''
+  default: { value: '', promptUsed: false }
 });
 
 export const persistentCommandState = atom<ICommand | undefined>({

--- a/frontend/src/state/chat.ts
+++ b/frontend/src/state/chat.ts
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, atomFamily } from 'recoil';
 
 import { ICommand } from 'client-types/*';
 
@@ -18,6 +18,11 @@ export interface IAttachment {
 export const attachmentsState = atom<IAttachment[]>({
   key: 'Attachments',
   default: []
+});
+
+export const messageDraftState = atomFamily<string, string>({
+  key: 'MessageDraft',
+  default: ''
 });
 
 export const persistentCommandState = atom<ICommand | undefined>({

--- a/frontend/tests/MessageComposer.spec.tsx
+++ b/frontend/tests/MessageComposer.spec.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { RecoilRoot, useSetRecoilState } from 'recoil';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FileSpec, IStep } from '@chainlit/react-client';
+import { sessionIdState } from '@chainlit/react-client';
+
+import ChatFooter from '@/components/chat/Footer';
+import WelcomeScreen from '@/components/chat/WelcomeScreen';
+
+let messages: IStep[] = [];
+const { queryParams } = vi.hoisted(() => ({
+  queryParams: new URLSearchParams()
+}));
+
+vi.mock('@chainlit/react-client', async () => {
+  const { atom } = await import('recoil');
+  const { createContext } = await import('react');
+
+  return {
+    ChainlitContext: createContext({ buildEndpoint: (path: string) => path }),
+    commandsState: atom({ key: 'messageComposerCommands', default: [] }),
+    modesState: atom({ key: 'messageComposerModes', default: [] }),
+    sessionIdState: atom({ key: 'messageComposerSessionId', default: 'a' }),
+    useAuth: () => ({ user: undefined }),
+    useChatData: () => ({
+      askUser: undefined,
+      chatSettingsInputs: [],
+      disabled: false
+    }),
+    useChatInteract: () => ({ sendMessage: vi.fn(), replyMessage: vi.fn() }),
+    useChatMessages: () => ({ messages }),
+    useChatSession: () => ({ chatProfile: undefined }),
+    useConfig: () => ({ config: {} })
+  };
+});
+
+vi.mock('@/components/Logo', () => ({ Logo: () => null }));
+vi.mock('@/components/Markdown', () => ({
+  Markdown: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}));
+vi.mock('@/components/WaterMark', () => ({ default: () => null }));
+vi.mock('@/components/chat/Starters', () => ({ default: () => null }));
+vi.mock('@/components/chat/MessageComposer/Attachments', () => ({
+  Attachments: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/CommandButtons', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/CommandPopoverButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/FavoriteButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/Mcp', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/ModePicker', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/SubmitButton', () => ({
+  default: ({ disabled }: { disabled?: boolean }) => (
+    <button id="chat-submit" disabled={disabled} />
+  )
+}));
+vi.mock('@/components/chat/MessageComposer/UploadButton', () => ({
+  default: () => null
+}));
+vi.mock('@/components/chat/MessageComposer/VoiceButton', () => ({
+  default: () => null
+}));
+vi.mock('@/hooks/query', () => ({ useQuery: () => queryParams }));
+vi.mock('@/hooks/use-mobile', () => ({ useIsMobile: () => false }));
+vi.mock('components/i18n/Translator', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+const composerProps = {
+  fileSpec: {} as FileSpec,
+  onFileUpload: vi.fn(),
+  onFileUploadError: vi.fn(),
+  autoScrollRef: { current: true }
+};
+
+function SessionScope({ sessionId }: { sessionId: string }) {
+  const setSessionId = useSetRecoilState(sessionIdState);
+
+  useEffect(() => {
+    setSessionId(sessionId);
+  }, [sessionId, setSessionId]);
+
+  return null;
+}
+
+function ComposerOwners({ sessionId = 'a' }: { sessionId?: string }) {
+  return (
+    <RecoilRoot>
+      <SessionScope sessionId={sessionId} />
+      <WelcomeScreen {...composerProps} />
+      <ChatFooter {...composerProps} />
+    </RecoilRoot>
+  );
+}
+
+describe('MessageComposer', () => {
+  beforeEach(() => {
+    messages = [];
+    queryParams.delete('prompt');
+  });
+
+  it('preserves a draft when ownership moves from the welcome screen to the footer', () => {
+    const view = render(<ComposerOwners />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'draft message' }
+    });
+
+    messages = [
+      {
+        id: 'message-1',
+        name: 'Assistant',
+        type: 'assistant_message',
+        output: 'Hello',
+        createdAt: 0
+      }
+    ];
+    view.rerender(<ComposerOwners />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('draft message');
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('does not retain a draft after the session changes', async () => {
+    const view = render(<ComposerOwners />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'draft message' }
+    });
+    view.rerender(<ComposerOwners sessionId="b" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('');
+    });
+  });
+
+  it('does not replace an edited draft with the URL prompt after an owner change', async () => {
+    queryParams.set('prompt', 'initial prompt');
+    const view = render(<ComposerOwners />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('initial prompt');
+    });
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'edited draft' }
+    });
+
+    messages = [
+      {
+        id: 'message-1',
+        name: 'Assistant',
+        type: 'assistant_message',
+        output: 'Hello',
+        createdAt: 0
+      }
+    ];
+    view.rerender(<ComposerOwners />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('edited draft');
+  });
+});

--- a/frontend/tests/MessageComposer.spec.tsx
+++ b/frontend/tests/MessageComposer.spec.tsx
@@ -132,7 +132,7 @@ describe('MessageComposer', () => {
     expect(screen.getByRole('button')).not.toBeDisabled();
   });
 
-  it('does not retain a draft after the session changes', async () => {
+  it('discards a draft when the session changes', async () => {
     const view = render(<ComposerOwners />);
 
     fireEvent.change(screen.getByRole('textbox'), {
@@ -140,6 +140,11 @@ describe('MessageComposer', () => {
     });
     view.rerender(<ComposerOwners sessionId="b" />);
 
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('');
+    });
+
+    view.rerender(<ComposerOwners sessionId="a" />);
     await waitFor(() => {
       expect(screen.getByRole('textbox')).toHaveValue('');
     });
@@ -168,5 +173,30 @@ describe('MessageComposer', () => {
     view.rerender(<ComposerOwners />);
 
     expect(screen.getByRole('textbox')).toHaveValue('edited draft');
+  });
+
+  it('does not restore a URL prompt that the user deleted', async () => {
+    queryParams.set('prompt', 'initial prompt');
+    const view = render(<ComposerOwners />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveValue('initial prompt');
+    });
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '' }
+    });
+
+    messages = [
+      {
+        id: 'message-1',
+        name: 'Assistant',
+        type: 'assistant_message',
+        output: 'Hello',
+        createdAt: 0
+      }
+    ];
+    view.rerender(<ComposerOwners />);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 });


### PR DESCRIPTION
## Summary

- keep the composer draft in one bounded Recoil record so the WelcomeScreen → Footer owner swap cannot discard in-progress input
- make `Input` controlled by that single source of truth while preserving reset, command, favorite, and URL-prompt behavior
- discard the old draft at session boundaries and track URL-prompt initialization so a remount cannot restore a prompt the user edited or deleted
- fixes #3022

## Regression evidence

With the new owner-swap test kept in place and the composer temporarily restored to local state, the test failed as expected:

```text
Expected the element to have value: draft message
Received:
```

The URL-prompt boundary also failed before its guard was added:

```text
Expected: edited draft
Received: initial prompt
```

The first bounded-state revision also proved that merely hiding a stale session record was insufficient: switching `a → b → a` restored `draft message`. The final implementation clears that single record when the session changes.

## Verification

- `pnpm --filter @chainlit/app test -- tests/MessageComposer.spec.tsx` — 4 passed
- `pnpm --filter @chainlit/app test` — 6 files, 36 tests passed
- `pnpm type-check` — frontend and react-client passed; copilot reports its repository-configured skip
- `pnpm lint` and `pnpm lint:fix` — passed
- `pnpm format-check` and `pnpm format` — passed
- `pnpm build` — react-client, frontend, and copilot production builds passed
- `git diff --check` — passed

## Prior work and AI assistance

PR #3028 previously explored the same session-scoped state direction and was closed by its author before maintainer review. Thank you to @Iams4kura for that public investigation. This PR independently re-ran the baseline, adds explicit owner-level, session-lifecycle, and URL-prompt regressions, and follows this repository's required AI attribution. OpenAI Codex assisted with implementation and review; both commits include the required `Co-Authored-By` trailer.
