### PR TITLE
fix(react-client): prefix configured asset URLs with the app base path

### DIFF
--- a/frontend/src/components/chat/Messages/Message/Avatar.tsx
+++ b/frontend/src/components/chat/Messages/Message/Avatar.tsx
@@ -35,11 +35,16 @@ const MessageAvatar = ({ author, hide, isError, iconName }: Props) => {
   }, [config, chatProfile]);
 
   const avatarUrl = useMemo(() => {
-    if (config?.ui?.default_avatar_file_url)
-      return config?.ui?.default_avatar_file_url;
+    if (config?.ui?.default_avatar_file_url) {
+      return config.ui.default_avatar_file_url.startsWith('/public')
+        ? apiClient?.buildEndpoint(config.ui.default_avatar_file_url)
+        : config.ui.default_avatar_file_url;
+    }
     const isAssistant = !author || author === config?.ui.name;
     if (isAssistant && selectedChatProfile?.icon) {
-      return selectedChatProfile.icon;
+      return selectedChatProfile.icon.startsWith('/public')
+        ? apiClient?.buildEndpoint(selectedChatProfile.icon)
+        : selectedChatProfile.icon;
     }
     return apiClient?.buildEndpoint(`/avatars/${author || 'default'}`);
   }, [apiClient, selectedChatProfile, config, author]);

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -107,8 +107,11 @@ export default function Login() {
         <div className="relative hidden bg-muted lg:block overflow-hidden">
           <img
             src={
-              config?.ui?.login_page_image ||
-              apiClient.buildEndpoint('/favicon')
+              config?.ui?.login_page_image
+                ? config.ui.login_page_image.startsWith('/public')
+                  ? apiClient.buildEndpoint(config.ui.login_page_image)
+                  : config.ui.login_page_image
+                : apiClient.buildEndpoint('/favicon')
             }
             alt="Image"
             className={`absolute inset-0 h-full w-full object-cover ${

--- a/libs/react-client/src/api/index.spec.ts
+++ b/libs/react-client/src/api/index.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChainlitAPI } from '../index';
+
+describe('getLogoEndpoint', () => {
+  const api = new ChainlitAPI('http://localhost:8000/my-app', 'webapp');
+
+  it('prefixes a configured logo served from the public directory with the base path', () => {
+    expect(api.getLogoEndpoint('light', '/public/logo.png')).toBe(
+      'http://localhost:8000/my-app/public/logo.png'
+    );
+  });
+
+  it('leaves a configured external logo URL untouched', () => {
+    expect(
+      api.getLogoEndpoint('light', 'https://cdn.example.com/logo.png')
+    ).toBe('https://cdn.example.com/logo.png');
+  });
+
+  it('falls back to the built-in /logo endpoint when unconfigured', () => {
+    expect(api.getLogoEndpoint('light')).toBe(
+      'http://localhost:8000/my-app/logo?theme=light'
+    );
+  });
+});

--- a/libs/react-client/src/api/index.tsx
+++ b/libs/react-client/src/api/index.tsx
@@ -349,7 +349,11 @@ export class ChainlitAPI extends APIBase {
   }
 
   getLogoEndpoint(theme: string, configuredLogoUrl?: string) {
-    if (configuredLogoUrl) return configuredLogoUrl;
+    if (configuredLogoUrl) {
+      return configuredLogoUrl.startsWith('/public')
+        ? this.buildEndpoint(configuredLogoUrl)
+        : configuredLogoUrl;
+    }
     return this.buildEndpoint(`/logo?theme=${theme}`);
   }
 


### PR DESCRIPTION
## Summary

`logo_file_url`, `default_avatar_file_url`, `ChatProfile.icon`, and `login_page_image` are returned verbatim by the frontend whenever they're configured as a `/public/...`-relative path, bypassing `apiClient.buildEndpoint()` entirely. This breaks under a reverse-proxy subpath deployment (e.g. `https://host/my-app/...`): the browser requests the unprefixed path against the domain root, which never reaches the app.

Several sibling call sites already guard against exactly this with the same pattern:

```ts
value.startsWith('/public') ? apiClient.buildEndpoint(value) : value
```

(see `WelcomeScreen.tsx`, `Starter.tsx`, `ChatProfiles.tsx`, `ModePicker.tsx`, `ButtonLink.tsx`) — `buildEndpoint()` is what correctly prepends `httpEndpoint` (`window.origin + basename`), so an already-absolute external URL is left untouched while a local `/public/...` path gets the app's base path prepended.

This PR applies the same, already-established guard to the three places that were missing it:

- `ChainlitAPI.getLogoEndpoint()` (`libs/react-client/src/api/index.tsx`) — returned `configuredLogoUrl` raw
- `Avatar.tsx` — returned `default_avatar_file_url` and `selectedChatProfile.icon` raw
- `Login.tsx` — returned `login_page_image` raw

No new abstraction, no behavior change for apps not deployed behind a subpath (an unprefixed `httpEndpoint` is a no-op prefix).

## Test plan

- Added `libs/react-client/src/api/index.spec.ts` covering `getLogoEndpoint`: prefixes a `/public/...` path, leaves an external URL untouched, and the unconfigured fallback still works. Matches the existing unit-test convention in this package (`state.spec.ts`) — the project otherwise relies on Cypress E2E rather than component unit tests, and adding an E2E fixture for this would have required changes to the shared test runner (no per-scenario env var support today), which felt like scope creep for a 3-site fix.
- `pnpm lint`, `pnpm format-check`, `pnpm type-check` (whole repo) all pass.
- `pnpm test` in `libs/react-client`: 19/19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes configured asset URLs being returned without the app base path when set to a `/public/...` path, which broke logo, avatar, and login page image loading under reverse-proxy subpath deployments. `logo_file_url`, `default_avatar_file_url`, `ChatProfile.icon`, and `login_page_image` now go through `apiClient.buildEndpoint()` when they start with `/public`; external URLs and unconfigured fallbacks behave as before, and apps not deployed behind a subpath see no change.

Adds unit tests for `getLogoEndpoint` covering base path prefixing, external URL passthrough, and the unconfigured fallback.

<sup>Written for commit d65fc9e7988a64be171937f660a5c4f806144d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

