### PR TITLE
docs(mcp): add anonymous Parallel Search config example

### DIFF
--- a/backend/chainlit/config.py
+++ b/backend/chainlit/config.py
@@ -173,6 +173,18 @@ reaction_on_message_received = false
     # type = "streamable-http"
     # url = "https://mcp.example.com/mcp"
 
+    # Parallel Search: web_search and web_fetch without an account or API key.
+    # Free anonymous access is rate limited. Setup: set enabled = true above,
+    # uncomment the four lines below, restart the app, and connect parallel-search
+    # in the MCP menu. Disconnect it there to stop using its tools.
+    # Once connected, your app/agent can call the tools, sending queries, URLs,
+    # and any supplied objectives, context, or metadata to Parallel.
+    # https://docs.parallel.ai/integrations/mcp/search-mcp
+    # [[features.mcp.servers]]
+    # name = "parallel-search"
+    # type = "streamable-http"
+    # url = "https://search.parallel.ai/mcp"
+
     [features.mcp.user_servers]
         # Opt-in: allow end-users to connect their own SSE or streamable-http MCP servers.
         # stdio is never user-provided (server-side config only).


### PR DESCRIPTION
This adds a commented config example so Chainlit developers can try Parallel web search and page extraction without creating an account or adding an API key.

Chainlit has no automatic search default or bundled web-search MCP provider. Its [existing examples](https://github.com/Chainlit/chainlit/blob/190ea74239d9e84b26e7c91bc2882dd038942564/backend/chainlit/config.py#L148-L182) are GitHub and generic SSE/HTTP servers, with MCP disabled. This gives developers a working search endpoint to try through that same setup.

I checked all 19 products on [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api#details), using its August 31, 2026 data. Parallel Fast has the lowest time per task at **19.2 seconds**, compared with 28.6 for Perplexity Medium, 45.9 for Tavily Basic and 63.0 for Firecrawl. That's about **70% less time than Firecrawl** in this benchmark.

The research scores are a good reason to try it too. On DeepSearchQA, Parallel Fast scores **80 F1**, ahead of Exa Auto and Brave LLM Context at 78, You.com Highlights at 77, Firecrawl and Tavily Basic at 74, both Keenable modes at 70, and TinyFish Web at 67. Perplexity Medium still leads the overall Search Index, 80 to Parallel Fast's 73. [Source: Artificial Analysis](https://artificialanalysis.ai/agents/search-api#details).

These are Search API results in [AA's fixed harness](https://artificialanalysis.ai/methodology/search-api), where time per task combines derived model time and measured search time. The [anonymous MCP uses Fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp), but AA did not test this Chainlit integration.

The comments cover setup, disconnecting, the inputs sent to Parallel, and anonymous rate limits. MCP stays disabled by default, no server is preconfigured, and user-server permissions stay unchanged.

Validation:

- Repository lint and format wrappers pass for `backend/chainlit/config.py` with the locked Ruff 0.14.7; `git diff --check` passes.
- Verified default config generation and `load_settings()` with the exact uncommented example.
- Exercised the source `connect_mcp` and `disconnect_mcp` handlers with a real websocket session and MCP client: disabled gate, named-server connection, anonymous tool discovery, `web_search`, `web_fetch`, and cleanup passed.

The focused handler check isolated UI emitter initialization and loaded the handler definitions without the full server module. HTTP routing, browser behavior, full app startup, and the full test suite were not tested. No repository build ran.

I work at Parallel, which operates this service. This contribution was prepared with coding-agent assistance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a commented Parallel Search MCP server example to the generated config, showing developers how to enable web search and page extraction without an account or API key. MCP stays disabled by default, no server is preconfigured, and user-server permission settings are unchanged.

<sup>Written for commit 7d4c4a04fda52895fe1f2b87419f034b0c38e7aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

