### PR TITLE
fix(langchain): preserve tool calls in generation traces

### DIFF
--- a/backend/chainlit/langchain/callbacks.py
+++ b/backend/chainlit/langchain/callbacks.py
@@ -167,6 +167,8 @@ class GenerationHelper:
         )
         if name := kwargs.get("name"):
             msg["name"] = name
+        if tool_call_id := kwargs.get("tool_call_id"):
+            msg["tool_call_id"] = tool_call_id
         if function_call:
             msg["function_call"] = function_call
         else:
@@ -196,7 +198,24 @@ class GenerationHelper:
             else:
                 msg["content"] = content  # type: ignore
 
+        if normalized_tool_calls := kwargs.get("tool_calls"):
+            msg["tool_calls"] = self._convert_tool_calls(normalized_tool_calls)
+
         return msg
+
+    def _convert_tool_calls(self, tool_calls: List[Dict]) -> List[Dict]:
+        """Convert LangChain's normalized tool calls to the generation format."""
+        return [
+            {
+                "id": tool_call.get("id"),
+                "type": "function",
+                "function": {
+                    "name": tool_call["name"],
+                    "arguments": tool_call["args"],
+                },
+            }
+            for tool_call in tool_calls
+        ]
 
     def _convert_message(
         self,
@@ -220,6 +239,8 @@ class GenerationHelper:
 
         if name := getattr(message, "name", None):
             msg["name"] = name
+        if tool_call_id := getattr(message, "tool_call_id", None):
+            msg["tool_call_id"] = tool_call_id
 
         if function_call:
             msg["function_call"] = function_call
@@ -250,6 +271,9 @@ class GenerationHelper:
                     msg["content"] = content_parts  # type: ignore
             else:
                 msg["content"] = message.content  # type: ignore
+
+        if normalized_tool_calls := getattr(message, "tool_calls", None):
+            msg["tool_calls"] = self._convert_tool_calls(normalized_tool_calls)
 
         return msg
 

--- a/backend/tests/langchain/test_async_callback.py
+++ b/backend/tests/langchain/test_async_callback.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
-from langchain_core.outputs import GenerationChunk
+from langchain_core.callbacks import AsyncCallbackManager
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, GenerationChunk, LLMResult
 
 from chainlit.langchain.callbacks import LangchainTracer
 from chainlit.step import Step
@@ -166,3 +168,34 @@ async def test_error_handling(mock_chainlit_context):
 
         assert step.is_error is True
         assert step.output == "Test error"
+
+
+async def test_generation_trace_preserves_tool_exchange(mock_chainlit_context):
+    """Tool calls and results stay correlated in the persisted generation payload."""
+    call = AIMessage(
+        content="",
+        tool_calls=[{"name": "weather", "args": {"city": "Paris"}, "id": "call_1"}],
+    )
+    result = ToolMessage(content="Sunny", tool_call_id="call_1")
+    async with mock_chainlit_context:
+        tracer = LangchainTracer()
+        manager = AsyncCallbackManager([tracer])
+        runs = await manager.on_chat_model_start(
+            serialized={"name": "test_llm"},
+            messages=[[HumanMessage(content="Weather?"), call, result]],
+            invocation_params={"_type": "test", "model": "test-model"},
+        )
+        step = tracer.steps[str(runs[0].run_id)]
+
+        with patch.object(step, "update", new_callable=AsyncMock):
+            await runs[0].on_llm_end(
+                LLMResult(generations=[[ChatGeneration(message=call)]])
+            )
+
+        generation = step.generation
+        assert generation.messages[1]["tool_calls"][0]["id"] == "call_1"
+        assert generation.messages[2]["tool_call_id"] == "call_1"
+        assert generation.message_completion["tool_calls"][0]["function"] == {
+            "name": "weather",
+            "arguments": {"city": "Paris"},
+        }

--- a/backend/tests/langchain/test_sync_callback.py
+++ b/backend/tests/langchain/test_sync_callback.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from unittest.mock import Mock
 from uuid import uuid4
 
-from langchain_core.messages import AIMessage, HumanMessage
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from chainlit.langchain.callbacks import (
     FinalStreamHelper,
@@ -110,6 +111,102 @@ class TestGenerationHelper:
         assert provider == "openai"
         assert model == "gpt-4"
         assert settings["temperature"] == 0.7
+
+    @pytest.mark.parametrize("serialized", [False, True])
+    @pytest.mark.parametrize("content", ["Checking the weather.", []])
+    def test_convert_standard_tool_calls(self, serialized, content):
+        message = AIMessage(
+            content=content,
+            tool_calls=[
+                {"name": "weather", "args": {"city": "上海"}, "id": "call_weather"},
+                {"name": "clock", "args": {}, "id": "call_clock"},
+            ],
+        )
+        original = message.model_dump()
+        result = GenerationHelper()._convert_message(
+            message.to_json() if serialized else message
+        )
+
+        assert result["tool_calls"] == [
+            {
+                "id": "call_weather",
+                "type": "function",
+                "function": {"name": "weather", "arguments": {"city": "上海"}},
+            },
+            {
+                "id": "call_clock",
+                "type": "function",
+                "function": {"name": "clock", "arguments": {}},
+            },
+        ]
+        assert result["content"] == (content or "")
+        assert message.model_dump() == original
+
+    @pytest.mark.parametrize("serialized", [False, True])
+    def test_convert_tool_result_preserves_call_id(self, serialized):
+        message = ToolMessage(
+            content="Sunny", tool_call_id="call_weather", name="weather"
+        )
+        result = GenerationHelper()._convert_message(
+            message.to_json() if serialized else message
+        )
+
+        assert result == {
+            "role": "tool",
+            "content": "Sunny",
+            "name": "weather",
+            "tool_call_id": "call_weather",
+        }
+
+    @pytest.mark.parametrize("serialized", [False, True])
+    @pytest.mark.parametrize("normalized", [False, True])
+    def test_convert_anthropic_tool_calls_without_duplicates(
+        self, serialized, normalized
+    ):
+        message = AIMessage(
+            content=[
+                {"type": "text", "text": "Checking."},
+                {
+                    "type": "tool_use",
+                    "id": "call_weather",
+                    "name": "weather",
+                    "input": {"city": "Paris"},
+                },
+            ],
+            tool_calls=(
+                [{"name": "weather", "args": {"city": "Paris"}, "id": "call_weather"}]
+                if normalized
+                else []
+            ),
+        )
+        result = GenerationHelper()._convert_message(
+            message.to_json() if serialized else message
+        )
+
+        assert result["tool_calls"] == [
+            {
+                "id": "call_weather",
+                "type": "function",
+                "function": {"name": "weather", "arguments": {"city": "Paris"}},
+            }
+        ]
+        assert result["content"] == [{"type": "text", "text": "Checking."}]
+
+    @pytest.mark.parametrize("serialized", [False, True])
+    def test_convert_legacy_function_call(self, serialized):
+        function_call = {"name": "weather", "arguments": '{"city":"Paris"}'}
+        message = AIMessage(
+            content="", additional_kwargs={"function_call": function_call}
+        )
+        result = GenerationHelper()._convert_message(
+            message.to_json() if serialized else message
+        )
+
+        assert result == {
+            "role": "assistant",
+            "content": "",
+            "function_call": function_call,
+        }
 
 
 async def test_should_ignore_run(mock_chainlit_context):


### PR DESCRIPTION
## Problem and change

LangChain exposes provider-independent tool calls in `AIMessage.tool_calls` and correlates results through `ToolMessage.tool_call_id`. Chainlit's generation converter drops both: a message such as `AIMessage(content="", tool_calls=[{"name": "weather", "args": {"city": "Paris"}, "id": "call_1"}])` is recorded as an empty assistant message, and its tool result loses `call_1`.

Preserve normalized call IDs, names and arguments, and the tool-result ID, for both live messages and LangChain's serialized constructor dictionaries. Prefer normalized calls when a provider also puts the same calls in content blocks, so Anthropic calls are not duplicated. Existing text content, legacy `function_call`, and content-only Anthropic `tool_use` handling are retained. This repairs generation tracing; it does not change agent tool execution.

## Validation

- Before the fix: six new conversion cases and the real async callback-manager regression fail on missing tool calls or result correlation.
- After the fix: **76 tests pass** with `PYTHONPATH=backend uv run --no-sync pytest backend/tests/langchain backend/tests/test_step.py -q` (Python 3.13.14, LangChain Core 1.2.27, LiteralAI 0.1.201).
- Added compatibility controls for legacy function calls and Anthropic content with/without normalized calls. The async test drives `AsyncCallbackManager` through start/end events and inspects the resulting generation payload, without a model API request.
- Project Python lint/format wrappers pass for the three changed files; scoped source mypy passes.
- Full backend mypy was attempted. Optional integration dependencies/stubs are missing in the local environment, so it is not reported as passing. Full-extra installation is blocked by the lock's NumPy 1.26.4 build on Python 3.13. Frontend/E2E and live-provider suites were not run.

Found through source inspection; searches for LangChain/tool-call PRs did not identify an overlapping open fix. No existing issue is claimed as resolved.

No manual browser verification was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LangChain generation tracing so tool calls and tool-result IDs are preserved in the persisted step.

- Records normalized tool calls (`name`, `args`, `id`) from `AIMessage.tool_calls` in both live and serialized message conversion.
- Records `tool_call_id` on tool result messages so calls and results stay correlated.
- Prefers normalized tool calls over provider-specific content blocks, preventing duplicate Anthropic `tool_use` entries.
- Retains existing text content, legacy `function_call`, and content-only Anthropic handling.

<sup>Written for commit 45bae9d0af5c1ab28baecbda31dcfc22cda4c644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->