### PR TITLE
fix(mcp): follow tools/list pagination so later pages are not dropped

### DIFF
--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -1,8 +1,10 @@
-from typing import Callable, Dict, Literal, Optional, Union
+from typing import Callable, Dict, List, Literal, Optional, Union
 from urllib.parse import unquote, urlparse
 
 import httpx
 from pydantic import BaseModel
+
+from chainlit.logger import logger
 
 
 class StdioMcpConnection(BaseModel):
@@ -241,6 +243,73 @@ McpHttpClientFactory = Callable[..., httpx.AsyncClient]
 # too low a value breaks `npx -y` cold starts — in a security release.
 _MCP_CONNECT_TIMEOUT_STDIO = 120.0  # npx -y can cold-download on first run
 _MCP_CONNECT_TIMEOUT_HTTP = 30.0
+
+# tools/list is cursor-paginated. A single list_tools() call is only the
+# first page, so the connect payload (and the composer MCP list) would
+# silently drop tools on servers that page. Cap the walk so a server that
+# never omits nextCursor cannot hang the connect handler.
+_MCP_LIST_TOOLS_MAX_PAGES = 100
+
+
+def _mcp_next_cursor(page) -> Optional[str]:
+    """Return the pagination cursor from a tools/list result, if any.
+
+    The MCP Python SDK exposes the spec field as ``nextCursor``; some
+    mocks/results use the snake_case alias. Treat empty strings as absent.
+    """
+    cursor = getattr(page, "nextCursor", None)
+    if cursor is None:
+        cursor = getattr(page, "next_cursor", None)
+    if not cursor:
+        return None
+    return str(cursor)
+
+
+async def list_all_mcp_tools(
+    mcp_client_session,
+    *,
+    max_pages: int = _MCP_LIST_TOOLS_MAX_PAGES,
+) -> List:
+    """Return every tool from an MCP session, following ``nextCursor``.
+
+    ``ClientSession.list_tools`` does not walk pages itself; callers must
+    pass the previous page's cursor until the server omits it.
+    """
+    tools: List = []
+    cursor: Optional[str] = None
+    seen_cursors: set[str] = set()
+
+    for page_index in range(max_pages):
+        if cursor is None:
+            page = await mcp_client_session.list_tools()
+        else:
+            page = await mcp_client_session.list_tools(cursor=cursor)
+
+        page_tools = getattr(page, "tools", None) or []
+        tools.extend(page_tools)
+
+        next_cursor = _mcp_next_cursor(page)
+        if not next_cursor:
+            return tools
+        if next_cursor in seen_cursors:
+            logger.warning(
+                "MCP tools/list repeated nextCursor %r after %s page(s); "
+                "stopping pagination with %s tool(s) collected",
+                next_cursor,
+                page_index + 1,
+                len(tools),
+            )
+            return tools
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    logger.warning(
+        "MCP tools/list still offered nextCursor after %s pages; "
+        "returning %s tool(s) collected so far",
+        max_pages,
+        len(tools),
+    )
+    return tools
 
 
 def make_mcp_http_client_factory(

--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Callable, Dict, List, Literal, Optional, Union
 from urllib.parse import unquote, urlparse
 
@@ -247,7 +248,8 @@ _MCP_CONNECT_TIMEOUT_HTTP = 30.0
 # tools/list is cursor-paginated. A single list_tools() call is only the
 # first page, so the connect payload (and the composer MCP list) would
 # silently drop tools on servers that page. Cap the walk so a server that
-# never omits nextCursor cannot hang the connect handler.
+# never omits nextCursor cannot hang the connect handler. Per-page and
+# total timeouts bound awaits: max_pages only limits *completed* calls.
 _MCP_LIST_TOOLS_MAX_PAGES = 100
 
 
@@ -269,47 +271,57 @@ async def list_all_mcp_tools(
     mcp_client_session,
     *,
     max_pages: int = _MCP_LIST_TOOLS_MAX_PAGES,
+    page_timeout: float = _MCP_CONNECT_TIMEOUT_HTTP,
+    total_timeout: float = _MCP_CONNECT_TIMEOUT_HTTP,
 ) -> List:
     """Return every tool from an MCP session, following ``nextCursor``.
 
     ``ClientSession.list_tools`` does not walk pages itself; callers must
     pass the previous page's cursor until the server omits it.
+
+    Each page is bounded by ``page_timeout``; the whole walk is bounded by
+    ``total_timeout``. Either timeout raises ``asyncio.TimeoutError``.
     """
-    tools: List = []
-    cursor: Optional[str] = None
-    seen_cursors: set[str] = set()
 
-    for page_index in range(max_pages):
-        if cursor is None:
-            page = await mcp_client_session.list_tools()
-        else:
-            page = await mcp_client_session.list_tools(cursor=cursor)
+    async def _walk() -> List:
+        tools: List = []
+        cursor: Optional[str] = None
+        seen_cursors: set[str] = set()
 
-        page_tools = getattr(page, "tools", None) or []
-        tools.extend(page_tools)
+        for page_index in range(max_pages):
+            if cursor is None:
+                page_coro = mcp_client_session.list_tools()
+            else:
+                page_coro = mcp_client_session.list_tools(cursor=cursor)
+            page = await asyncio.wait_for(page_coro, timeout=page_timeout)
 
-        next_cursor = _mcp_next_cursor(page)
-        if not next_cursor:
-            return tools
-        if next_cursor in seen_cursors:
-            logger.warning(
-                "MCP tools/list repeated nextCursor %r after %s page(s); "
-                "stopping pagination with %s tool(s) collected",
-                next_cursor,
-                page_index + 1,
-                len(tools),
-            )
-            return tools
-        seen_cursors.add(next_cursor)
-        cursor = next_cursor
+            page_tools = getattr(page, "tools", None) or []
+            tools.extend(page_tools)
 
-    logger.warning(
-        "MCP tools/list still offered nextCursor after %s pages; "
-        "returning %s tool(s) collected so far",
-        max_pages,
-        len(tools),
-    )
-    return tools
+            next_cursor = _mcp_next_cursor(page)
+            if not next_cursor:
+                return tools
+            if next_cursor in seen_cursors:
+                logger.warning(
+                    "MCP tools/list repeated nextCursor %r after %s page(s); "
+                    "stopping pagination with %s tool(s) collected",
+                    next_cursor,
+                    page_index + 1,
+                    len(tools),
+                )
+                return tools
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        logger.warning(
+            "MCP tools/list still offered nextCursor after %s pages; "
+            "returning %s tool(s) collected so far",
+            max_pages,
+            len(tools),
+        )
+        return tools
+
+    return await asyncio.wait_for(_walk(), timeout=total_timeout)
 
 
 def make_mcp_http_client_factory(

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1448,6 +1448,7 @@ async def connect_mcp(
         StdioMcpConnection,
         _destination_in_allowlist,
         _destination_on_origin,
+        list_all_mcp_tools,
         make_mcp_http_client_factory,
         validate_mcp_headers,
         validate_mcp_url,
@@ -1870,7 +1871,7 @@ async def connect_mcp(
                 "Error closing old MCP session %s", payload.name, exc_info=True
             )
 
-    tool_list = await mcp_client_session.list_tools()
+    tools = await list_all_mcp_tools(mcp_client_session)
 
     # `type` (named servers) vs `clientType` (user-provided) — IMcp in
     # libs/react-client/src/types/mcp.ts declares both as optional, not
@@ -1878,7 +1879,7 @@ async def connect_mcp(
     # as null.
     mcp_payload: Dict[str, object] = {
         "name": mcp_connection.name,
-        "tools": [{"name": t.name} for t in tool_list.tools],
+        "tools": [{"name": t.name} for t in tools],
         "isUserProvided": is_user_provided,
         # Only echo url/headers back for user-provided servers — the client
         # already sent those. For named servers they come from the

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1496,12 +1496,12 @@ async def connect_mcp(
     #
     # Runs before the eviction block below (moved further down, right
     # before "Store the session"): a reconnect that fails validation, fails
-    # to connect, times out, is blocked, or has its on_mcp_connect callback
-    # raise must not first kill the working session it was trying to
-    # replace. `session.mcp_sessions[name]` is written exactly once, after
-    # `on_mcp_connect` succeeds, so no two same-named sessions ever coexist
-    # under that key and no tool-name collision or emitter-ordering change
-    # results from this reordering.
+    # to connect, times out, is blocked, has its on_mcp_connect callback
+    # raise, or fails tools/list must not first kill the working session it
+    # was trying to replace. `session.mcp_sessions[name]` is written
+    # exactly once, after `on_mcp_connect` and tools/list succeed, so no
+    # two same-named sessions ever coexist under that key and no tool-name
+    # collision or emitter-ordering change results from this reordering.
     mcp_connection: McpConnection
     # Computed once and reused both by the destination-binding httpx factory
     # (below) and the connect-response / error-hygiene branches (below that).
@@ -1821,11 +1821,41 @@ async def connect_mcp(
                 content={"detail": detail},
             )
 
+    try:
+        tools = await list_all_mcp_tools(
+            mcp_client_session,
+            page_timeout=connect_timeout,
+            total_timeout=connect_timeout,
+        )
+    except Exception as e:
+        # Same teardown as a rejecting on_mcp_connect: tools/list is part of
+        # making the connection usable, and it runs *before* swap so a
+        # failed listing (timeout, later page error) does not evict a
+        # working session or leave a half-connected task in mcp_sessions.
+        await stop_mcp_task(task, stop_event, payload.name)
+        if is_user_provided:
+            detail = f"Could not connect to the MCP: {e!s}"
+        else:
+            logger.error(
+                "Listing MCP tools failed for MCP server %r",
+                payload.name,
+                exc_info=e,
+            )
+            detail = (
+                "Could not connect to the MCP server. Check the server "
+                "logs for details."
+            )
+        return JSONResponse(
+            status_code=400,
+            content={"detail": detail},
+        )
+
     # Disconnect previous session for this name (reconnection). Runs only
-    # now that on_mcp_connect has succeeded — a reconnect that failed for
-    # any reason above (bad creds, server down, blocked destination,
-    # timeout, a rejecting callback) leaves the old working session intact
-    # instead of evicting it before knowing the replacement would work.
+    # now that on_mcp_connect and tools/list have succeeded — a reconnect
+    # that failed for any reason above (bad creds, server down, blocked
+    # destination, timeout, a rejecting callback, a failed or hung
+    # tools/list) leaves the old working session intact instead of evicting
+    # it before knowing the replacement would work.
     # Trade-off: if the old session was already silently dead, it keeps
     # showing "connected" until this succeeds — pre-existing (McpSession has
     # no liveness probe), not made worse here.
@@ -1870,8 +1900,6 @@ async def connect_mcp(
             logger.debug(
                 "Error closing old MCP session %s", payload.name, exc_info=True
             )
-
-    tools = await list_all_mcp_tools(mcp_client_session)
 
     # `type` (named servers) vs `clientType` (user-provided) — IMcp in
     # libs/react-client/src/types/mcp.ts declares both as optional, not

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -20,6 +20,7 @@ from chainlit.mcp import (
     StdioMcpConnection,
     _destination_in_allowlist,
     _destination_on_origin,
+    list_all_mcp_tools,
     make_mcp_http_client_factory,
     validate_mcp_headers,
     validate_mcp_url,
@@ -785,6 +786,88 @@ class TestDestinationOnOriginHook:
             await client.aclose()
 
 
+class TestListAllMcpTools:
+    """ClientSession.list_tools() returns one page; connect_mcp must walk
+    nextCursor or the composer MCP list silently drops tools."""
+
+    async def test_single_page_without_cursor(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                assert cursor is None
+                return SimpleNamespace(tools=[SimpleNamespace(name="only")])
+
+        tools = await list_all_mcp_tools(Session())
+        assert [t.name for t in tools] == ["only"]
+
+    async def test_follows_nextCursor_across_pages(self):
+        calls: list = []
+
+        class Session:
+            async def list_tools(self, cursor=None):
+                calls.append(cursor)
+                if cursor is None:
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="a")],
+                        nextCursor="p2",
+                    )
+                if cursor == "p2":
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="b")],
+                        nextCursor="p3",
+                    )
+                if cursor == "p3":
+                    return SimpleNamespace(tools=[SimpleNamespace(name="c")])
+                raise AssertionError(cursor)
+
+        tools = await list_all_mcp_tools(Session())
+        assert [t.name for t in tools] == ["a", "b", "c"]
+        assert calls == [None, "p2", "p3"]
+
+    async def test_follows_snake_case_next_cursor(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                if cursor is None:
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="a")],
+                        next_cursor="p2",
+                    )
+                return SimpleNamespace(tools=[SimpleNamespace(name="b")])
+
+        tools = await list_all_mcp_tools(Session())
+        assert [t.name for t in tools] == ["a", "b"]
+
+    async def test_stops_on_repeated_cursor(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                return SimpleNamespace(
+                    tools=[SimpleNamespace(name="loop")],
+                    nextCursor="same",
+                )
+
+        tools = await list_all_mcp_tools(Session())
+        assert [t.name for t in tools] == ["loop", "loop"]
+
+    async def test_caps_pages(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                n = 0 if cursor is None else int(cursor)
+                return SimpleNamespace(
+                    tools=[SimpleNamespace(name=f"t{n}")],
+                    nextCursor=str(n + 1),
+                )
+
+        tools = await list_all_mcp_tools(Session(), max_pages=3)
+        assert [t.name for t in tools] == ["t0", "t1", "t2"]
+
+    async def test_empty_tools(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                return SimpleNamespace(tools=[])
+
+        tools = await list_all_mcp_tools(Session())
+        assert tools == []
+
+
 # ── /mcp (connect_mcp) endpoint tests ──────────────────────────────────────
 
 
@@ -944,6 +1027,50 @@ class TestConnectMcpEndpoint:
         assert data["mcp"]["isUserProvided"] is False
         assert data["mcp"]["url"] is None
         assert data["mcp"]["headers"] is None
+
+    def test_connect_follows_list_tools_pagination(
+        self,
+        test_client: TestClient,
+        test_config,
+        mcp_session_get_by_id_patched: Mock,
+        mock_get_current_user: Mock,
+        mock_mcp_transport,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from chainlit.config import SseMcpServer
+
+        mock_get_current_user.return_value = None
+        test_config.features.mcp.enabled = True
+        test_config.features.mcp.servers = [
+            SseMcpServer(type="sse", name="github", url="https://mcp.example.com/sse")
+        ]
+
+        class PagingClientSession(mock_mcp_transport):
+            async def list_tools(self, cursor=None, **kwargs):
+                if cursor is None:
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="tool_a")],
+                        nextCursor="page-2",
+                    )
+                if cursor == "page-2":
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="tool_b")],
+                    )
+                raise AssertionError(f"unexpected cursor {cursor!r}")
+
+        monkeypatch.setattr("mcp.ClientSession", PagingClientSession)
+
+        response = test_client.post(
+            "/mcp",
+            json={
+                "sessionId": mcp_session_get_by_id_patched.id,
+                "name": "github",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        names = [t["name"] for t in response.json()["mcp"]["tools"]]
+        assert names == ["tool_a", "tool_b"]
 
     def test_unknown_named_server_returns_400(
         self,

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -867,6 +867,28 @@ class TestListAllMcpTools:
         tools = await list_all_mcp_tools(Session())
         assert tools == []
 
+    async def test_page_timeout_raises(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                await asyncio.Event().wait()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await list_all_mcp_tools(Session(), page_timeout=0.05, total_timeout=1)
+
+    async def test_total_timeout_raises_across_slow_pages(self):
+        class Session:
+            async def list_tools(self, cursor=None):
+                await asyncio.sleep(0.08)
+                if cursor is None:
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="a")],
+                        nextCursor="p2",
+                    )
+                return SimpleNamespace(tools=[SimpleNamespace(name="b")])
+
+        with pytest.raises(asyncio.TimeoutError):
+            await list_all_mcp_tools(Session(), page_timeout=1, total_timeout=0.1)
+
 
 # ── /mcp (connect_mcp) endpoint tests ──────────────────────────────────────
 
@@ -1071,6 +1093,91 @@ class TestConnectMcpEndpoint:
         assert response.status_code == 200, response.text
         names = [t["name"] for t in response.json()["mcp"]["tools"]]
         assert names == ["tool_a", "tool_b"]
+
+    def test_list_tools_timeout_does_not_store_session(
+        self,
+        test_client: TestClient,
+        test_config,
+        mcp_session_get_by_id_patched: Mock,
+        mock_get_current_user: Mock,
+        mock_mcp_transport,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A hung tools/list must 400 and must not land a session in
+        mcp_sessions — the connect timeout does not cover listing."""
+        from chainlit.config import SseMcpServer
+
+        mock_get_current_user.return_value = None
+        test_config.features.mcp.enabled = True
+        test_config.features.mcp.servers = [
+            SseMcpServer(type="sse", name="github", url="https://mcp.example.com/sse")
+        ]
+        monkeypatch.setattr("chainlit.mcp._MCP_CONNECT_TIMEOUT_HTTP", 0.1)
+
+        class HangingClientSession(mock_mcp_transport):
+            async def list_tools(self, cursor=None, **kwargs):
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr("mcp.ClientSession", HangingClientSession)
+
+        response = test_client.post(
+            "/mcp",
+            json={
+                "sessionId": mcp_session_get_by_id_patched.id,
+                "name": "github",
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        assert "github" not in mcp_session_get_by_id_patched.mcp_sessions
+
+    def test_later_list_tools_page_failure_does_not_evict_existing_session(
+        self,
+        test_client: TestClient,
+        test_config,
+        mcp_session_get_by_id_patched: Mock,
+        mock_get_current_user: Mock,
+        mock_mcp_transport,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Page 2 raising must not swap in the new session or drop the old
+        one. Named-server errors stay generic (no exception text)."""
+        from chainlit.config import SseMcpServer
+
+        mock_get_current_user.return_value = None
+        test_config.features.mcp.enabled = True
+        test_config.features.mcp.servers = [
+            SseMcpServer(type="sse", name="github", url="https://mcp.example.com/sse")
+        ]
+        sentinel_existing_session = Mock(name="pre-existing-mcp-session")
+        mcp_session_get_by_id_patched.mcp_sessions["github"] = sentinel_existing_session
+
+        class PagingFailClientSession(mock_mcp_transport):
+            async def list_tools(self, cursor=None, **kwargs):
+                if cursor is None:
+                    return SimpleNamespace(
+                        tools=[SimpleNamespace(name="tool_a")],
+                        nextCursor="page-2",
+                    )
+                raise RuntimeError("page-2 failed")
+
+        monkeypatch.setattr("mcp.ClientSession", PagingFailClientSession)
+
+        response = test_client.post(
+            "/mcp",
+            json={
+                "sessionId": mcp_session_get_by_id_patched.id,
+                "name": "github",
+            },
+        )
+
+        assert response.status_code == 400, response.text
+        assert "page-2 failed" not in response.text
+        assert "check the server logs" in response.text.lower()
+        assert (
+            mcp_session_get_by_id_patched.mcp_sessions["github"]
+            is sentinel_existing_session
+        )
 
     def test_unknown_named_server_returns_400(
         self,


### PR DESCRIPTION
## Description

`POST /mcp` called `ClientSession.list_tools()` once. The MCP Python SDK returns a single page and leaves `nextCursor` to the caller, so servers that paginate `tools/list` silently dropped later tools from the connect payload and the composer MCP list.

This walks `nextCursor` (and the `next_cursor` alias), caps the walk at 100 pages, and stops if a cursor repeats.

## Why

MCP pagination is part of the spec; `list_tools()` does not auto-paginate. The UI only sees the tools returned here.

## Testing

- `uv run pytest backend/tests/test_mcp.py::TestListAllMcpTools`
- `uv run pytest backend/tests/test_mcp.py::TestConnectMcpEndpoint::test_connect_follows_list_tools_pagination` (needs frontend build)
- `uv run scripts/lint.py backend/chainlit/mcp.py backend/chainlit/server.py backend/tests/test_mcp.py`
- `uv run scripts/format.py --check` on the same files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `POST /mcp` so paginated MCP servers no longer silently drop later tools from the connect payload and composer MCP list, and ensures a failed or hung tools/list cannot evict a working session.

- Walks `nextCursor` (and the `next_cursor` alias) until the server omits it, capped at 100 pages and stopping on a repeated cursor.
- Bounds each page and the whole walk with the connect timeout, so a server that never finishes paginating cannot hang the connect handler.
- Lists tools before swapping in the replacement session, so a reconnect that fails during listing keeps the old session intact.
- Adds tests covering pagination, cursor aliases, repeated cursors, the page cap, timeouts, and session eviction.

<sup>Written for commit de819a682c2c684dfdb2ebb73e3ca62407c13909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

