### PR TITLE
chore(deps): bump fastapi and starlette lock

### DIFF
--- a/cypress/e2e/auth/main.py
+++ b/cypress/e2e/auth/main.py
@@ -32,14 +32,17 @@ async def custom_token_auth() -> Response:
     return response
 
 
-catch_all_route = None
-for route in app.routes:
-    if route.path == "/{full_path:path}":
-        catch_all_route = route
-
-if catch_all_route:
-    app.routes.remove(catch_all_route)
-    app.routes.append(catch_all_route)
+# Chainlit's catch-all SPA route (`/{full_path:path}`) matches every path
+# and Starlette dispatch is first-match-wins, so without reordering it would
+# shadow the custom routes above. Move the custom routes to the very front
+# of app.routes instead of trying to relocate the catch-all itself — this
+# works whether the catch-all is a top-level route or (fastapi >= 0.141)
+# nested inside an internal router-include wrapper.
+_custom_paths = {"/auth/custom", "/auth/token"}
+_custom_routes = [r for r in app.routes if getattr(r, "path", None) in _custom_paths]
+for _route in _custom_routes:
+    app.routes.remove(_route)
+app.routes[:0] = _custom_routes
 
 
 @cl.on_chat_start

--- a/uv.lock
+++ b/uv.lock
@@ -1347,17 +1347,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.123.5"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b8/c6e916565af8a8e1c8f5a4736b31a6995adb51dbd4cbefc8b022e753ecb9/fastapi-0.123.5.tar.gz", hash = "sha256:54bbb660ca231d3985474498b51c621ddcf8888d9a4c1ecb10aa40ec217e4965", size = 352030, upload-time = "2025-12-02T21:08:38.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/dc/faa52fe784892bb057934248ded02705d26ca3aca562876e61c239947036/fastapi-0.123.5-py3-none-any.whl", hash = "sha256:a9c708e47c0fa424139cddb8601d0f92d3111b77843c22e9c8d0164d65fe3c97", size = 111316, upload-time = "2025-12-02T21:08:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -5441,15 +5442,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.50.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Refreshes `uv.lock` to pull in the latest fastapi (0.123.5 -> 0.141.1) and starlette (0.50.0 -> 1.6.0) releases via `uv lock -P fastapi -P starlette`
- No `pyproject.toml` constraint changes needed (both deps use unbounded `>=` lower pins)

## Test plan
- [x] `uv run pytest --cov=chainlit/` — 932 passed
- [x] `uv run scripts/type_check.py` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113KUXq5rCWWo6wWeMCKPi1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `uv.lock` for `fastapi` (0.123.5 → 0.141.1) and `starlette` (0.50.0 → 1.6.0), and fixes the e2e auth test for the new FastAPI routing behavior.

- Both deps use unbounded `>=` pins, so `pyproject.toml` is unchanged; verified with 932 passing tests and the type checker.
- FastAPI ≥ 0.141 no longer flattens `include_router` into `app.routes`, so the old catch-all relocation crashed; the e2e test now moves the custom auth routes to the front of `app.routes` instead.

<sup>Written for commit d09191c54584d5b25a355408663d2867eac45d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Chainlit/chainlit/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

